### PR TITLE
7 geobench needs its own config file for customizations

### DIFF
--- a/desktop/main.asm
+++ b/desktop/main.asm
@@ -35,6 +35,7 @@ geobench
                 include "../lib/fs.asm"
                 include "../lib/fs_ide_fat.asm"
                 include "../lib/fs_amsdos.asm"
+                include "../lib/config.asm"
 
 ; --- Palette (firmware ink numbers 0..26) --------------------------------
 INK_DESKTOP     equ   1           ; blue        -> pen 0 (paper / backdrop)
@@ -104,6 +105,7 @@ desktop_start
                 call  fmt_mem                 ; -> mem_str "<KB>K"
                 call  clock_init             ; RTC? else software clock -> time_str
                 call  fs_init                ; pick default backend (IDE? else floppy)
+                call  cfg_load               ; read GEOBENCH.CFG -> cfg_* settings
                 call  build_desktop_icons    ; probe drives -> live icon table
                 call  TXT_CUR_DISABLE        ; no blinking text cursor blob
                 call  TXT_CUR_OFF

--- a/lib/config.asm
+++ b/lib/config.asm
@@ -1,0 +1,137 @@
+; ---------------------------------------------------------------------------
+; lib/config.asm - GEOBENCH configuration file.
+;
+; Reads GEOBENCH.CFG (KEY=VALUE, one per line, '#' comments, CR/LF endings) off
+; the active storage via fs_load_file, and parses known keys into cfg_* vars.
+; Missing file or missing key -> the built-in default is kept.
+;
+; Settings:
+;   cfg_icons   icon-set name (default "DEFAULT")   <- key ICONS
+;
+; Requires lib/fs.asm (fs_load_file, fs_req_name, fs_load_dst, fs_ent_size).
+; ---------------------------------------------------------------------------
+
+CFG_BUF_SZ      equ   512
+
+; cfg_load: apply defaults, then load + parse GEOBENCH.CFG if it exists.
+cfg_load
+                ld    hl,cfg_def_icons       ; default ICONS = "DEFAULT"
+                ld    de,cfg_icons
+                ld    bc,9
+                ldir
+
+                ld    hl,cfg_fname           ; fs_req_name = "GEOBENCH.CFG"
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    hl,cfg_buf
+                ld    (fs_load_dst),hl
+                call  fs_load_file
+                ret   nc                      ; no config file -> keep defaults
+
+                ld    hl,cfg_buf             ; parse fs_ent_size bytes
+                ld    bc,(fs_ent_size)
+                ; fall through
+
+; cfg_parse: HL = text, BC = byte count. Walk lines; apply known KEY=VALUE.
+cfg_parse
+cfgp_line
+                ld    a,b
+                or    c
+                ret   z                       ; consumed everything
+                ld    a,(hl)
+                cp    13
+                jr    z,cfgp_eateol
+                cp    10
+                jr    z,cfgp_eateol
+                cp    '#'
+                jr    z,cfgp_skipline         ; comment
+
+                push  hl                       ; try the known keys at this line
+                push  bc
+                ld    de,key_icons
+                call  cfg_keymatch
+                jr    nc,cfgp_nomatch
+                ld    de,cfg_icons            ; ICONS= matched
+                ld    a,8                      ; filename stem, max 8 chars
+                call  cfg_copyval
+cfgp_nomatch
+                pop   bc
+                pop   hl
+cfgp_skipline                                  ; advance to the line's CR/LF
+                ld    a,b
+                or    c
+                ret   z
+                ld    a,(hl)
+                cp    13
+                jr    z,cfgp_eateol
+                cp    10
+                jr    z,cfgp_eateol
+                inc   hl
+                dec   bc
+                jr    cfgp_skipline
+cfgp_eateol                                    ; eat one or more CR/LF
+                ld    a,b
+                or    c
+                ret   z
+                ld    a,(hl)
+                cp    13
+                jr    z,cfgp_eat1
+                cp    10
+                jr    z,cfgp_eat1
+                jr    cfgp_line
+cfgp_eat1
+                inc   hl
+                dec   bc
+                jr    cfgp_eateol
+
+; cfg_keymatch: HL = line, DE = key template (e.g. "ICONS=",0). If the line
+; starts with the template, CF set and HL points at the value; else NC.
+cfg_keymatch
+                ld    a,(de)
+                or    a
+                jr    z,ckm_yes               ; template exhausted -> match
+                ld    a,(de)
+                cp    (hl)
+                jr    nz,ckm_no
+                inc   hl
+                inc   de
+                jr    cfg_keymatch
+ckm_yes
+                scf
+                ret
+ckm_no
+                or    a
+                ret
+
+; cfg_copyval: copy the value at (HL) to (DE), up to A chars, stopping at
+; CR/LF/NUL; NUL-terminates the destination.
+cfg_copyval
+                ld    b,a
+ccv_loop
+                ld    a,b
+                or    a
+                jr    z,ccv_end
+                ld    a,(hl)
+                or    a
+                jr    z,ccv_end
+                cp    13
+                jr    z,ccv_end
+                cp    10
+                jr    z,ccv_end
+                ld    (de),a
+                inc   hl
+                inc   de
+                dec   b
+                jr    ccv_loop
+ccv_end
+                xor   a
+                ld    (de),a
+                ret
+
+; --- data ----------------------------------------------------------------
+cfg_fname       db    "GEOBENCHCFG"      ; "GEOBENCH.CFG" (8.3)
+key_icons       db    "ICONS=",0
+cfg_def_icons   db    "DEFAULT",0,0      ; 9 bytes
+cfg_icons       defs  9                  ; parsed icon-set name (NUL-terminated)
+cfg_buf         defs  CFG_BUF_SZ

--- a/lib/fs.asm
+++ b/lib/fs.asm
@@ -24,21 +24,32 @@ fs_init
                 ld    (fs_p_first),hl
                 ld    hl,fside_dir_next
                 ld    (fs_p_next),hl
+                ld    hl,fside_load_file
+                ld    (fs_p_load),hl
                 ret
 fsi_floppy
                 ld    hl,fsam_dir_first
                 ld    (fs_p_first),hl
                 ld    hl,fsam_dir_next
                 ld    (fs_p_next),hl
+                ld    hl,fs_load_none         ; floppy file-read: TODO
+                ld    (fs_p_load),hl
                 ret
 
-; fs_dir_first / fs_dir_next: route to the selected backend.
+; fs_dir_first / fs_dir_next / fs_load_file: route to the selected backend.
 fs_dir_first
                 ld    hl,(fs_p_first)
                 jp    (hl)
 fs_dir_next
                 ld    hl,(fs_p_next)
                 jp    (hl)
+; fs_load_file: load file (fs_req_name) into (fs_load_dst). CF set = loaded.
+fs_load_file
+                ld    hl,(fs_p_load)
+                jp    (hl)
+fs_load_none
+                or    a                        ; not implemented -> NC
+                ret
 
 ; fs_ide_present: ATA register read-back test on the IDE LBA-low port. A real
 ; controller latches the value; an unconnected expansion bus does not. CF set =
@@ -65,6 +76,9 @@ fsip_absent
 ; --- state / shared per-entry output -------------------------------------
 fs_p_first      defw  fside_dir_first   ; default IDE; fs_init rewrites on detect
 fs_p_next       defw  fside_dir_next
+fs_p_load       defw  fside_load_file
 fs_ent_name     defs  11
 fs_ent_attr     defb  0
 fs_ent_size     defs  4
+fs_req_name     defs  11           ; fs_load_file: 8.3 name to load
+fs_load_dst     defw  0            ; fs_load_file: destination buffer

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -57,6 +57,17 @@ ffr_mul
 ffr_secok
                 ld    (fs_root_secs),a
 
+                ld    a,(fs_secbuf+#0D)       ; geometry for file reads (BPB still
+                ld    (fs_spc),a               ; in secbuf): sectors per cluster,
+                ld    hl,(fs_secbuf+#0E)      ; FAT start (= reserved),
+                ld    (fs_fat_lba),hl
+                ld    hl,(fs_root_lba)        ; data start = root_lba + root_secs
+                ld    a,(fs_root_secs)
+                ld    e,a
+                ld    d,0
+                add   hl,de
+                ld    (fs_data_lba),hl
+
                 xor   a
                 ld    (fs_cur_sec),a
                 ld    (fs_ent_idx),a
@@ -132,6 +143,15 @@ fdn_have
                 ld    bc,4
                 ldir
                 pop   hl
+                push  hl                       ; start cluster (word @ 0x1A)
+                ld    de,#1A
+                add   hl,de
+                ld    a,(hl)
+                ld    (fs_ent_clus),a
+                inc   hl
+                ld    a,(hl)
+                ld    (fs_ent_clus+1),a
+                pop   hl
 
                 ld    a,(fs_ent_idx)
                 inc   a
@@ -145,6 +165,125 @@ fdn_skip
                 jp    fdn_loop
 fdn_end
                 or    a                         ; CF clear = end of directory
+                ret
+
+; ---------------------------------------------------------------------------
+; fside_load_file: load the file named in fs_req_name (11-byte 8.3) into the
+; buffer at (fs_load_dst). CF set = loaded (fs_ent_size = byte size), NC = not
+; found. Follows the FAT16 cluster chain. 16-bit LBA (files in the first 32MB).
+fside_load_file
+                call  fside_dir_first         ; also sets fs_spc/fat_lba/data_lba
+flf_find
+                jr    nc,flf_notfound         ; end of directory
+                call  flf_cmpname             ; fs_ent_name == fs_req_name?
+                jr    z,flf_found
+                call  fside_dir_next
+                jr    flf_find
+flf_notfound
+                or    a
+                ret
+flf_found                                      ; fs_ent_clus + fs_ent_size set
+                ld    hl,(fs_ent_size)        ; sectors = ceil(size/512)
+                ld    de,511
+                add   hl,de
+                ld    b,9
+flf_sh          srl   h
+                rr    l
+                djnz  flf_sh
+                ld    (flf_secs),hl
+                ld    hl,(fs_ent_clus)
+                ld    (flf_clus),hl
+                xor   a
+                ld    (flf_sic),a
+flf_loop
+                ld    hl,(flf_secs)
+                ld    a,h
+                or    l
+                jr    z,flf_done
+                ld    hl,(flf_clus)           ; LBA = data_lba+(clus-2)*spc+sic
+                dec   hl
+                dec   hl
+                call  flf_mul_spc
+                ld    de,(fs_data_lba)
+                add   hl,de
+                ld    a,(flf_sic)
+                ld    e,a
+                ld    d,0
+                add   hl,de
+                call  fs_read_sector
+                ld    hl,fs_secbuf            ; copy sector to dst
+                ld    de,(fs_load_dst)
+                ld    bc,512
+                ldir
+                ld    (fs_load_dst),de
+                ld    hl,(flf_secs)
+                dec   hl
+                ld    (flf_secs),hl
+                ld    a,(flf_sic)             ; advance sector-in-cluster
+                inc   a
+                ld    b,a
+                ld    a,(fs_spc)
+                cp    b
+                jr    nz,flf_keepsic
+                call  flf_fat_next            ; cluster boundary -> next cluster
+                xor   a
+                ld    (flf_sic),a
+                jr    flf_loop
+flf_keepsic
+                ld    a,b
+                ld    (flf_sic),a
+                jr    flf_loop
+flf_done
+                scf
+                ret
+
+flf_cmpname                                    ; fs_ent_name == fs_req_name? Z if so
+                ld    hl,fs_ent_name
+                ld    de,fs_req_name
+                ld    b,11
+flf_cn
+                ld    a,(de)
+                cp    (hl)
+                ret   nz
+                inc   hl
+                inc   de
+                djnz  flf_cn
+                xor   a
+                ret
+
+flf_mul_spc                                    ; HL *= fs_spc (power of 2)
+                ld    a,(fs_spc)
+                ld    b,0
+flf_log         srl   a
+                jr    z,flf_doshift
+                inc   b
+                jr    flf_log
+flf_doshift     inc   b
+flf_dec         dec   b
+                ret   z
+                add   hl,hl
+                jr    flf_dec
+
+flf_fat_next                                   ; flf_clus -> next cluster (FAT16)
+                ld    hl,(flf_clus)
+                ld    a,h                       ; fat_sector = fat_lba + clus/256
+                ld    l,a
+                ld    h,0
+                ld    de,(fs_fat_lba)
+                add   hl,de
+                call  fs_read_sector
+                ld    a,(flf_clus)             ; within = (clus & 255) * 2
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                ld    de,fs_secbuf
+                add   hl,de
+                ld    a,(hl)
+                ld    e,a
+                inc   hl
+                ld    a,(hl)
+                ld    d,a
+                ld    (flf_clus),de
                 ret
 
 ; ---------------------------------------------------------------------------
@@ -193,4 +332,11 @@ fs_root_lba     defw  0
 fs_root_secs    defb  0
 fs_cur_sec      defb  0
 fs_ent_idx      defb  0
+fs_ent_clus     defw  0            ; current entry's start cluster
+fs_spc          defb  0            ; sectors per cluster (file-read geometry)
+fs_fat_lba      defw  0            ; FAT start LBA
+fs_data_lba     defw  0            ; data region start LBA
+flf_secs        defw  0            ; load: sectors remaining
+flf_clus        defw  0            ; load: current cluster
+flf_sic         defb  0            ; load: sector within the cluster
 fs_secbuf       defs  512

--- a/tests/cfgtest.asm
+++ b/tests/cfgtest.asm
@@ -1,0 +1,38 @@
+; cfgtest - load and parse GEOBENCH.CFG via the real lib/config.asm + fs stack,
+; then print the parsed ICONS value (should be "NEON" from the test config, not
+; the built-in default "DEFAULT").
+
+SCR_SET_MODE    equ   #BC0E
+TXT_OUTPUT      equ   #BB5A
+
+                org   #4000
+start
+                ld    a,1
+                call  SCR_SET_MODE
+                call  fs_init                 ; select storage backend (IDE present)
+                call  cfg_load                ; load + parse GEOBENCH.CFG
+
+                ld    hl,msg
+                call  puts
+                ld    hl,cfg_icons
+                call  puts
+done            jr    done
+
+puts            ld    a,(hl)
+                or    a
+                ret   z
+                push  hl
+                call  TXT_OUTPUT
+                pop   hl
+                inc   hl
+                jr    puts
+
+msg             db    "ICONS=",0
+
+                include "../lib/fs.asm"
+                include "../lib/fs_ide_fat.asm"
+                include "../lib/fs_amsdos.asm"
+                include "../lib/config.asm"
+prog_end
+                save  "CFGTEST",start,prog_end-start,DSK,"build/cfgtest.dsk"
+                save  "build/CFGTEST.RAW",start,prog_end-start

--- a/tests/libloadtest.asm
+++ b/tests/libloadtest.asm
@@ -1,0 +1,72 @@
+; libloadtest - exercise the real lib/fs_ide_fat.asm fside_load_file (loads a
+; named file's contents off the FAT16/IDE volume). Confirms the library port,
+; including the find-via-fside_dir_first/next path.
+
+SCR_SET_MODE    equ   #BC0E
+TXT_OUTPUT      equ   #BB5A
+
+                org   #4000
+start
+                ld    a,1
+                call  SCR_SET_MODE
+
+                ld    hl,want                 ; fs_req_name = "BIG     TXT"
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    hl,buf
+                ld    (fs_load_dst),hl
+                call  fside_load_file
+                jr    nc,nf
+
+                ld    hl,(fs_ent_size)        ; print last 40 bytes (cluster 2)
+                ld    de,40
+                or    a
+                sbc   hl,de
+                ld    de,buf
+                add   hl,de
+                ex    de,hl
+                ld    hl,40
+ploop           ld    a,h
+                or    l
+                jr    z,done
+                ld    a,(de)
+                push  hl
+                push  de
+                call  putc
+                pop   de
+                pop   hl
+                inc   de
+                dec   hl
+                jr    ploop
+nf              ld    hl,txtnf
+nfl             ld    a,(hl)
+                or    a
+                jr    z,done
+                push  hl
+                call  TXT_OUTPUT
+                pop   hl
+                inc   hl
+                jr    nfl
+done            jr    done
+
+putc            cp    32
+                jr    nc,putc1
+                ld    a,'.'
+putc1           jp    TXT_OUTPUT
+
+want            db    "BIG     TXT"
+txtnf           db    "NOT FOUND",0
+
+; --- symbols the library expects from lib/fs.asm ------------------------
+fs_ent_name     defs  11
+fs_ent_attr     defb  0
+fs_ent_size     defs  4
+fs_req_name     defs  11
+fs_load_dst     defw  0
+buf             defs  6144
+
+                include "../lib/fs_ide_fat.asm"
+prog_end
+                save  "LIBLOAD",start,prog_end-start,DSK,"build/libload.dsk"
+                save  "build/LIBLOAD.RAW",start,prog_end-start

--- a/tests/loadtest.asm
+++ b/tests/loadtest.asm
@@ -1,0 +1,342 @@
+; loadtest - read a named file's CONTENTS off the FAT16/IDE volume and print it.
+; Validates the cluster-chain file read that lib/fs_ide_fat.asm will expose as
+; fside_load_file (the foundation for GEOBENCH.CFG and disk-loaded icon sets).
+;
+; FAT16: BPB at LBA0 gives sec/clus (0x0D), reserved=FAT start (0x0E),
+; num_fats (0x10), sec/fat (0x16), root_entries (0x11). root_lba = reserved +
+; num_fats*spf; data_lba = root_lba + root_entries/16. A file's dir entry gives
+; the start cluster (0x1A) and size (0x1C). cluster C -> LBA data_lba+(C-2)*spc;
+; FAT16 next cluster = word at FAT[C]. 16-bit LBA (files live in the first 32MB).
+
+SCR_SET_MODE    equ   #BC0E
+TXT_OUTPUT      equ   #BB5A
+
+IDE_SCNT        equ   #FD0A
+IDE_LBAL        equ   #FD0B
+IDE_LBAM        equ   #FD0C
+IDE_LBAH        equ   #FD0D
+IDE_DEV         equ   #FD0E
+IDE_CMD         equ   #FD0F
+IDE_STAT        equ   #FD0F
+IDE_DATA        equ   #FD08
+
+                org   #4000
+start
+                ld    a,1
+                call  SCR_SET_MODE
+
+                call  fat_geometry           ; BPB -> spc, fat_lba, root_lba, data_lba
+                ld    hl,want_name
+                call  find_file              ; -> CF set, file_clus + file_size
+                jr    nc,notfound
+                ld    hl,filebuf
+                ld    (load_dst),hl
+                call  read_file              ; chain -> filebuf
+
+                ld    hl,(file_size)         ; print the last 40 bytes (in cluster 2)
+                ld    de,40
+                or    a
+                sbc   hl,de
+                ld    de,filebuf
+                add   hl,de
+                ex    de,hl                   ; DE = filebuf + size - 40
+                ld    hl,40                   ; HL = byte count
+print_loop
+                ld    a,h
+                or    l
+                jr    z,done
+                ld    a,(de)
+                push  hl
+                push  de
+                call  putc
+                pop   de
+                pop   hl
+                inc   de
+                dec   hl
+                jr    print_loop
+notfound
+                ld    hl,txt_nf
+nf_loop         ld    a,(hl)
+                or    a
+                jr    z,done
+                push  hl
+                call  TXT_OUTPUT
+                pop   hl
+                inc   hl
+                jr    nf_loop
+done            jr    done
+
+putc                                          ; print A (control -> '.')
+                cp    32
+                jr    nc,putc1
+                cp    13
+                jr    z,putc1
+                cp    10
+                jr    z,putc1
+                ld    a,'.'
+putc1           jp    TXT_OUTPUT
+
+; ---------------------------------------------------------------------------
+; fat_geometry: parse the BPB at LBA0 into spc / fat_lba / root_lba / data_lba.
+fat_geometry
+                ld    hl,0
+                call  read_sector
+                ld    a,(secbuf+#0D)
+                ld    (spc),a
+                ld    hl,(secbuf+#0E)         ; reserved = FAT start
+                ld    (fat_lba),hl
+                ld    a,(secbuf+#10)          ; root_lba = reserved + fats*spf
+                ld    b,a
+                ld    de,(secbuf+#16)
+                ld    hl,(secbuf+#0E)
+fg_mul          add   hl,de
+                djnz  fg_mul
+                ld    (root_lba),hl
+                ld    hl,(secbuf+#11)         ; root_secs = root_entries/16
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                ld    a,l
+                ld    (root_secs),a
+                ld    e,a                      ; data_lba = root_lba + root_secs
+                ld    d,0
+                ld    hl,(root_lba)
+                add   hl,de
+                ld    (data_lba),hl
+                ret
+
+; ---------------------------------------------------------------------------
+; find_file: HL -> 11-byte name. Scans the root dir; on match sets file_clus +
+; file_size and returns CF set, else NC.
+find_file
+                ld    (want_ptr),hl
+                ld    a,(root_secs)
+                ld    (ff_secsleft),a
+                ld    hl,(root_lba)
+                ld    (ff_lba),hl
+ff_nextsec
+                ld    a,(ff_secsleft)
+                or    a
+                jr    z,ff_none
+                ld    hl,(ff_lba)
+                call  read_sector
+                ld    ix,secbuf
+                ld    b,16                     ; 16 entries / sector
+ff_ent
+                ld    a,(ix+0)
+                or    a
+                jr    z,ff_none               ; 0x00 = end of directory
+                cp    #E5
+                jr    z,ff_skip
+                ld    a,(ix+#0B)
+                and   #0F
+                cp    #0F
+                jr    z,ff_skip               ; LFN
+                ld    a,(ix+#0B)
+                and   #08
+                jr    nz,ff_skip              ; volume label
+                call  ff_match                ; compare 11 bytes
+                jr    z,ff_found
+ff_skip
+                push  bc
+                ld    de,32
+                add   ix,de
+                pop   bc
+                djnz  ff_ent
+                ld    hl,(ff_lba)             ; next sector
+                inc   hl
+                ld    (ff_lba),hl
+                ld    a,(ff_secsleft)
+                dec   a
+                ld    (ff_secsleft),a
+                jr    ff_nextsec
+ff_found
+                ld    a,(ix+#1A)             ; start cluster
+                ld    (file_clus),a
+                ld    a,(ix+#1B)
+                ld    (file_clus+1),a
+                ld    a,(ix+#1C)             ; size (low 16 used)
+                ld    (file_size),a
+                ld    a,(ix+#1D)
+                ld    (file_size+1),a
+                scf
+                ret
+ff_none
+                or    a
+                ret
+
+ff_match                                      ; IX entry vs (want_ptr); Z if equal
+                ld    hl,(want_ptr)
+                push  ix
+                pop   de                       ; DE = entry
+                ld    b,11
+ffm_loop
+                ld    a,(de)
+                cp    (hl)
+                jr    nz,ffm_no
+                inc   hl
+                inc   de
+                djnz  ffm_loop
+                xor   a                        ; Z
+                ret
+ffm_no
+                or    1                        ; NZ
+                ret
+
+; ---------------------------------------------------------------------------
+; read_file: follow file_clus's chain, copying file_size bytes' worth of
+; sectors to (load_dst).
+read_file
+                ld    hl,(file_size)         ; sectors = ceil(size/512)
+                ld    de,511
+                add   hl,de
+                ld    b,9
+rf_sh           srl   h
+                rr    l
+                djnz  rf_sh
+                ld    (rf_secs),hl
+                ld    hl,(file_clus)
+                ld    (rf_clus),hl
+                xor   a
+                ld    (rf_sic),a
+rf_loop
+                ld    hl,(rf_secs)
+                ld    a,h
+                or    l
+                ret   z                         ; all sectors read
+                ld    hl,(rf_clus)            ; LBA = data_lba+(clus-2)*spc+sic
+                dec   hl
+                dec   hl
+                call  mul_spc
+                ld    de,(data_lba)
+                add   hl,de
+                ld    a,(rf_sic)
+                ld    e,a
+                ld    d,0
+                add   hl,de
+                call  read_sector
+                ld    hl,secbuf              ; copy sector to dst
+                ld    de,(load_dst)
+                ld    bc,512
+                ldir
+                ld    (load_dst),de
+                ld    hl,(rf_secs)
+                dec   hl
+                ld    (rf_secs),hl
+                ld    a,(rf_sic)             ; advance sector-in-cluster
+                inc   a
+                ld    b,a                      ; B = new sector-in-cluster
+                ld    a,(spc)
+                cp    b
+                jr    nz,rf_keepsic
+                call  fat_next                ; cluster boundary -> next cluster
+                xor   a                        ; sic back to 0
+                ld    (rf_sic),a
+                jr    rf_loop
+rf_keepsic
+                ld    a,b                      ; still inside the cluster
+                ld    (rf_sic),a
+                jr    rf_loop
+
+mul_spc                                       ; HL *= spc (power of 2)
+                ld    a,(spc)
+                ld    b,0
+ms_log          srl   a
+                jr    z,ms_shift
+                inc   b
+                jr    ms_log
+ms_shift
+                inc   b
+ms_dec          dec   b
+                ret   z
+                add   hl,hl
+                jr    ms_dec
+
+fat_next                                      ; rf_clus -> next cluster (FAT16)
+                ld    hl,(rf_clus)
+                ld    a,h                       ; fat_sector = fat_lba + clus/256
+                ld    l,a
+                ld    h,0
+                ld    de,(fat_lba)
+                add   hl,de
+                call  read_sector
+                ld    a,(rf_clus)             ; within = (clus & 255)*2
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                ld    de,secbuf
+                add   hl,de
+                ld    a,(hl)
+                ld    e,a
+                inc   hl
+                ld    a,(hl)
+                ld    d,a
+                ld    (rf_clus),de
+                ret
+
+; ---------------------------------------------------------------------------
+; read_sector: read one 512-byte sector, LBA in HL (16-bit), into secbuf.
+read_sector
+                push  hl
+                ld    a,#E0
+                ld    bc,IDE_DEV
+                out   (c),a
+                ld    a,1
+                ld    bc,IDE_SCNT
+                out   (c),a
+                pop   hl
+                ld    a,l
+                ld    bc,IDE_LBAL
+                out   (c),a
+                ld    a,h
+                ld    bc,IDE_LBAM
+                out   (c),a
+                xor   a
+                ld    bc,IDE_LBAH
+                out   (c),a
+                ld    a,#20
+                ld    bc,IDE_CMD
+                out   (c),a
+rs_poll         ld    bc,IDE_STAT
+                in    a,(c)
+                bit   3,a
+                jr    z,rs_poll
+                ld    hl,secbuf
+                ld    de,512
+                ld    bc,IDE_DATA
+rs_read         in    a,(c)
+                ld    (hl),a
+                inc   hl
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,rs_read
+                ret
+
+want_name       db    "BIG     TXT"
+txt_nf          db    "NOT FOUND",0
+
+spc             db    0
+fat_lba         dw    0
+root_lba        dw    0
+root_secs       db    0
+data_lba        dw    0
+want_ptr        dw    0
+file_clus       dw    0
+file_size       dw    0
+load_dst        dw    0
+ff_lba          dw    0
+ff_secsleft     db    0
+rf_secs         dw    0
+rf_clus         dw    0
+rf_sic          db    0
+secbuf          defs  512
+filebuf         defs  6144
+prog_end
+                save  "LOADTEST",start,prog_end-start,DSK,"build/loadtest.dsk"
+                save  "build/LOADTEST.RAW",start,prog_end-start


### PR DESCRIPTION
The branch has 2 commits:
- 75253f1 — fs_load_file (read a file's contents off FAT16/IDE, cluster‑chain following).
- b41b9bc — GEOBENCH.CFG parser (KEY=VALUE, # comments, defaults), wired in at startup with ICONS as the first setting.