### PR TITLE
10 icons are selectable sets in config file

### DIFF
--- a/GEOBENCH.CFG.example
+++ b/GEOBENCH.CFG.example
@@ -1,0 +1,3 @@
+# GEOBENCH configuration
+# ICONS: name of the icon set to load (<name>.IST); default DEFAULT
+ICONS=DEFAULT

--- a/desktop/main.asm
+++ b/desktop/main.asm
@@ -23,15 +23,25 @@ geobench
                 include "../lib/font.asm"
                 include "../lib/text.asm"
                 include "../lib/window.asm"
-                include "../lib/icon_floppy.asm"
-                include "../lib/icon_clock.asm"
-                include "../lib/icon_trash.asm"
-                include "../lib/icon_basic.asm"
-                include "../lib/icon_binary.asm"
-                include "../lib/icon_picture.asm"
-                include "../lib/icon_text.asm"
-                include "../lib/icon_ide.asm"
-                include "../lib/icon_geobench.asm"
+; --- Icon set ------------------------------------------------------------
+; The active icons live contiguously in slot order under icon_set, so each
+; icon's label (icon_floppy, icon_binary, ...) is also its slot address. At
+; startup icon_load overwrites this buffer with <ICONS>.IST from disk (or these
+; compiled-in defaults are kept if there's no set file). The .IST is just the
+; raw icons in this same slot order. Each icon is 256 bytes (8 x 32).
+icon_set
+                include "../lib/icon_floppy.asm"     ; slot 0
+                include "../lib/icon_ide.asm"        ; slot 1
+                include "../lib/icon_clock.asm"      ; slot 2
+                include "../lib/icon_trash.asm"      ; slot 3
+                include "../lib/icon_geobench.asm"   ; slot 4
+                include "../lib/icon_basic.asm"      ; slot 5
+                include "../lib/icon_binary.asm"     ; slot 6
+                include "../lib/icon_picture.asm"    ; slot 7
+                include "../lib/icon_text.asm"       ; slot 8
+icon_set_end
+                defs  256                     ; slack so a whole-sector load fits
+ICONSET_BYTES   equ   icon_set_end - icon_set  ; 9 * 256 = 2304
                 include "../lib/fs.asm"
                 include "../lib/fs_ide_fat.asm"
                 include "../lib/fs_amsdos.asm"
@@ -106,6 +116,7 @@ desktop_start
                 call  clock_init             ; RTC? else software clock -> time_str
                 call  fs_init                ; pick default backend (IDE? else floppy)
                 call  cfg_load               ; read GEOBENCH.CFG -> cfg_* settings
+                call  icon_load              ; load <ICONS>.IST over icon_set
                 call  build_desktop_icons    ; probe drives -> live icon table
                 call  TXT_CUR_DISABLE        ; no blinking text cursor blob
                 call  TXT_CUR_OFF
@@ -1199,6 +1210,41 @@ icon_word
                 ld    h,(hl)
                 ld    l,a
                 ret
+
+; icon_load: load the icon set named by cfg_icons (e.g. "DEFAULT" -> DEFAULT.IST)
+; over icon_set. If the file is absent (or no storage), the compiled-in default
+; icons are kept. Call after cfg_load, before drawing icons.
+icon_load
+                ld    hl,cfg_icons           ; fs_req_name = cfg_icons.IST (8.3)
+                ld    de,fs_req_name
+                ld    b,8
+il_name
+                ld    a,(hl)
+                or    a
+                jr    z,il_pad               ; cfg_icons ended -> space-pad
+                ld    (de),a
+                inc   hl
+                inc   de
+                djnz  il_name
+                jr    il_ext
+il_pad
+                ld    a,' '
+il_padloop
+                ld    (de),a
+                inc   de
+                djnz  il_padloop
+il_ext
+                ld    a,'I'
+                ld    (de),a
+                inc   de
+                ld    a,'S'
+                ld    (de),a
+                inc   de
+                ld    a,'T'
+                ld    (de),a
+                ld    hl,icon_set
+                ld    (fs_load_dst),hl
+                jp    fs_load_file            ; NC -> keep compiled-in defaults
 
 ; build_desktop_icons: probe storage and fill the live icon arrays from
 ; cand_tbl. Present drives stack down the left column (y from 258, step -108);

--- a/desktop/main.asm
+++ b/desktop/main.asm
@@ -2059,3 +2059,14 @@ md_last         dw    0
 end
                 save  "GEOBENCH.BIN",geobench,end-geobench,DSK,"build/geobench.dsk"
                 save  "build/GEOBENCH.RAW",geobench,end-geobench
+
+; Put the config and default icon set on the floppy too, so a floppy-only
+; machine loads them just like the IDE build (fsam_load_file strips the AMSDOS
+; header RASM adds). build/DEFAULT.IST must be packed (tools/packicons.py)
+; before assembling -- tools/build.sh does that.
+cfg_file        incbin "../GEOBENCH.CFG.example"
+cfg_file_end
+ist_file        incbin "../build/DEFAULT.IST"
+ist_file_end
+                save  "GEOBENCH.CFG",cfg_file,cfg_file_end-cfg_file,DSK,"build/geobench.dsk"
+                save  "DEFAULT.IST",ist_file,ist_file_end-ist_file,DSK,"build/geobench.dsk"

--- a/lib/fs.asm
+++ b/lib/fs.asm
@@ -32,7 +32,7 @@ fsi_floppy
                 ld    (fs_p_first),hl
                 ld    hl,fsam_dir_next
                 ld    (fs_p_next),hl
-                ld    hl,fs_load_none         ; floppy file-read: TODO
+                ld    hl,fsam_load_file
                 ld    (fs_p_load),hl
                 ret
 

--- a/lib/fs_amsdos.asm
+++ b/lib/fs_amsdos.asm
@@ -345,7 +345,218 @@ fsam_present
                 scf
                 ret
 
+; ---------------------------------------------------------------------------
+; fsam_load_file: load fs_req_name (8.3) from the floppy into (fs_load_dst).
+; Single extent (Ex=0, <=16KB) only; strips a 128-byte AMSDOS header if present.
+; CF set = loaded (fs_ent_size = byte size), NC = not found.
+;
+; AMSDOS DATA format: 1KB allocation blocks = 2 sectors. Block B's two 512-byte
+; sectors are logical sectors L = B*2 and B*2+1; L -> track = L/9, physical
+; sector = &C1 + (L mod 9).
+fsam_load_file
+                call  fsam_motor_on                  ; spin up + recalibrate
+                call  fsam_read_dir                  ; directory -> fsam_buf
+
+                ld    ix,fsam_buf                    ; find Ex=0 entry by name
+                ld    b,64
+fslf_scan
+                ld    a,(ix+0)
+                cp    #E5
+                jr    z,fslf_next
+                ld    a,(ix+12)                      ; first extent only
+                or    a
+                jr    nz,fslf_next
+                call  fsam_namematch
+                jr    z,fslf_found
+fslf_next
+                push  bc
+                ld    de,32
+                add   ix,de
+                pop   bc
+                djnz  fslf_scan
+                call  fsam_motor_off
+                or    a                               ; not found
+                ret
+
+fslf_found
+                push  ix                              ; copy 16 block numbers out
+                pop   hl
+                ld    de,16
+                add   hl,de
+                ld    de,fslf_blocks
+                ld    bc,16
+                ldir
+                ld    a,(ix+15)                      ; Rc records -> sectors = ceil(Rc/4)
+                add   a,3
+                rrca                                  ; /4 (Rc<=128 so bit7 clear after +3)
+                rrca
+                and   #3F
+                ld    (fslf_secs),a
+                ld    a,(ix+15)                      ; remember Rc for the no-header size
+                ld    (fslf_rc),a
+
+                ld    hl,(fs_load_dst)
+                ld    (fsam_dst),hl                  ; fsam_read_sector advances this
+                xor   a
+                ld    (fslf_si),a
+                ld    a,#FF
+                ld    (fslf_curtrk),a                ; force a seek on the first sector
+fslf_rd
+                ld    a,(fslf_secs)
+                or    a
+                jr    z,fslf_done
+                dec   a
+                ld    (fslf_secs),a
+
+                ld    a,(fslf_si)                    ; block index = si / 2
+                srl   a
+                ld    e,a
+                ld    d,0
+                ld    hl,fslf_blocks
+                add   hl,de
+                ld    l,(hl)                          ; L = block*2 + (si & 1)
+                ld    h,0
+                add   hl,hl
+                ld    a,(fslf_si)
+                and   1
+                or    l
+                ld    l,a
+                call  fsam_div9                       ; HL/9 -> B=track, A=remainder
+                ld    c,a                             ; remainder
+                ld    a,b                             ; track changed? seek
+                ld    e,a                             ; keep track in E
+                ld    a,(fslf_curtrk)
+                cp    e
+                jr    z,fslf_noseek
+                ld    a,e
+                ld    (fslf_curtrk),a
+                push  bc
+                ld    a,e
+                call  fsam_seek
+                pop   bc
+fslf_noseek
+                ld    a,(fslf_curtrk)
+                ld    d,a                             ; D = track
+                ld    a,#C1
+                add   a,c
+                ld    e,a                             ; E = physical sector
+                call  fsam_read_sector
+
+                ld    a,(fslf_si)
+                inc   a
+                ld    (fslf_si),a
+                jr    fslf_rd
+fslf_done
+                call  fsam_motor_off
+                ; --- strip a 128-byte AMSDOS header if the checksum matches ---
+                ld    hl,(fs_load_dst)
+                ld    de,0                            ; sum of bytes [0..66]
+                ld    b,67
+fslf_sum
+                ld    a,(hl)
+                add   a,e
+                ld    e,a
+                jr    nc,fslf_nc
+                inc   d
+fslf_nc
+                inc   hl
+                djnz  fslf_sum
+                ld    hl,(fs_load_dst)               ; compare to word at [67]
+                ld    bc,67
+                add   hl,bc
+                ld    a,(hl)
+                cp    e
+                jr    nz,fslf_nohdr
+                inc   hl
+                ld    a,(hl)
+                cp    d
+                jr    nz,fslf_nohdr
+                ld    hl,(fs_load_dst)               ; header: length = word @ [24]
+                ld    bc,24
+                add   hl,bc
+                ld    c,(hl)
+                inc   hl
+                ld    b,(hl)
+                ld    (fs_ent_size),bc
+                ld    hl,0
+                ld    (fs_ent_size+2),hl
+                ld    hl,(fs_load_dst)               ; shift content down past header
+                ld    de,128
+                add   hl,de
+                ld    de,(fs_load_dst)
+                ld    bc,(fs_ent_size)
+                ld    a,b
+                or    c
+                jr    z,fslf_ok                       ; zero-length -> nothing to move
+                ldir
+                jr    fslf_ok
+fslf_nohdr
+                ld    a,(fslf_rc)                    ; no header: size = Rc * 128
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl                           ; *128
+                ld    (fs_ent_size),hl
+                ld    hl,0
+                ld    (fs_ent_size+2),hl
+fslf_ok
+                scf
+                ret
+
+; fsam_namematch: IX = dir entry; Z if its 8.3 name == fs_req_name (11 bytes).
+fsam_namematch
+                push  ix
+                pop   hl
+                inc   hl                              ; entry name starts at +1
+                ld    de,fs_req_name
+                ld    b,11
+fnm_loop
+                ld    a,(hl)
+                and   #7F                             ; drop attribute bits
+                ld    c,a
+                ld    a,(de)
+                cp    c
+                jr    nz,fnm_no
+                inc   hl
+                inc   de
+                djnz  fnm_loop
+                xor   a
+                ret
+fnm_no
+                or    1
+                ret
+
+; fsam_div9: HL / 9 -> B = quotient, A = remainder (0..8). Clobbers DE.
+fsam_div9
+                ld    b,0
+fd9_loop
+                ld    a,h
+                or    a
+                jr    nz,fd9_sub
+                ld    a,l
+                cp    9
+                jr    c,fd9_done
+fd9_sub
+                or    a
+                ld    de,9
+                sbc   hl,de
+                inc   b
+                jr    fd9_loop
+fd9_done
+                ld    a,l
+                ret
+
 ; --- state ---------------------------------------------------------------
+fslf_blocks     defs  16           ; allocation block numbers of the found extent
+fslf_secs       defb  0            ; sectors left to read
+fslf_si         defb  0            ; sector index within the file
+fslf_rc         defb  0            ; record count (for the no-header size)
+fslf_curtrk     defb  0            ; track the head is currently on
 fsam_unit       defb  0            ; selected drive: 0 = A, 1 = B
 fsam_base       defb  #C1
 fsam_track      defb  0

--- a/tests/floadtest.asm
+++ b/tests/floadtest.asm
@@ -1,0 +1,78 @@
+; floadtest - read a named file's contents off the AMSDOS floppy via the real
+; lib/fs_amsdos.asm fsam_load_file, and print it. The test file TFILE.BIN is
+; saved onto the same .dsk (with an AMSDOS header, which the reader must strip).
+
+SCR_SET_MODE    equ   #BC0E
+TXT_OUTPUT      equ   #BB5A
+
+                org   #4000
+start
+                ld    a,1
+                call  SCR_SET_MODE
+                xor   a
+                ld    (fsam_unit),a           ; drive A
+
+                ld    hl,want
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    hl,buf
+                ld    (fs_load_dst),hl
+                call  fsam_load_file
+                jr    nc,nf
+
+                ld    hl,(fs_ent_size)
+                ld    de,buf
+ploop           ld    a,h
+                or    l
+                jr    z,done
+                ld    a,(de)
+                push  hl
+                push  de
+                call  putc
+                pop   de
+                pop   hl
+                inc   de
+                dec   hl
+                jr    ploop
+nf              ld    hl,nfmsg
+nfl             ld    a,(hl)
+                or    a
+                jr    z,done
+                push  hl
+                call  TXT_OUTPUT
+                pop   hl
+                inc   hl
+                jr    nfl
+done            jr    done
+
+putc            cp    32
+                jr    nc,pc1
+                cp    13
+                jr    z,pc1
+                cp    10
+                jr    z,pc1
+                ld    a,'.'
+pc1             jp    TXT_OUTPUT
+
+want            db    "TFILE   BIN"
+nfmsg           db    "NOT FOUND",0
+
+; the file contents, saved onto the .dsk as TFILE.BIN below
+tfdata          db    "Hello from the floppy file reader!",13,10
+                db    "Second line of the AMSDOS test file.",13,10
+tfend
+
+; --- symbols the library expects from lib/fs.asm ------------------------
+fs_ent_name     defs  11
+fs_ent_attr     defb  0
+fs_ent_size     defs  4
+fs_req_name     defs  11
+fs_load_dst     defw  0
+buf             defs  1024
+
+                include "../lib/fs_amsdos.asm"
+prog_end
+                save  "FLTEST",start,prog_end-start,DSK,"build/floadtest.dsk"
+                save  "TFILE.BIN",tfdata,tfend-tfdata,DSK,"build/floadtest.dsk"
+                save  "build/FLOADTEST.RAW",start,prog_end-start

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,15 +1,25 @@
 #!/usr/bin/env bash
 # Assemble GEOBENCH into a bootable .dsk image.
 #
-# Output: build/geobench.dsk  (contains GEOBENCH.BIN, AMSDOS-headed)
-# Run with:  ../1984/1984 --disk-a=build/geobench.dsk --autostart=GEOBENCH
+# Output: build/geobench.dsk  (GEOBENCH.BIN + GEOBENCH.CFG + DEFAULT.IST) and
+#         build/GEOBENCH.RAW. Run with:
+#   ../1984/1984 --disk-a=build/geobench.dsk --autostart=GEOBENCH
 #
-# Uses $RASM if set, else 'rasm' from PATH.
+# The icon set is packed first because desktop/main.asm incbins build/DEFAULT.IST
+# onto the .dsk. Uses $RASM if set, else 'rasm' from PATH.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."          # repo root
 RASM="${RASM:-rasm}"
 
 mkdir -p build
+
+# Default icon set, packed in the desktop's slot order (keep in sync with
+# icon_set in desktop/main.asm).
+python3 tools/packicons.py build/DEFAULT.IST \
+    lib/icon_floppy.asm lib/icon_ide.asm lib/icon_clock.asm lib/icon_trash.asm \
+    lib/icon_geobench.asm lib/icon_basic.asm lib/icon_binary.asm \
+    lib/icon_picture.asm lib/icon_text.asm
+
 "$RASM" desktop/main.asm -eo          # -eo: overwrite the .dsk if it exists
-echo "Built build/geobench.dsk"
+echo "Built build/geobench.dsk + build/GEOBENCH.RAW"

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -20,15 +20,8 @@ IMG="${GEOBENCH_IMG:-$HOME/Downloads/GEOBENCH.IMG}"
 [ -f "$IMG" ] || { echo "IDE image not found: $IMG" >&2; exit 1; }
 
 mkdir -p build
-"$RASM" desktop/main.asm -eo                  # -> build/GEOBENCH.RAW + .dsk
+bash tools/build.sh                           # packs DEFAULT.IST, -> .dsk + RAW
 python3 tools/amsdos_header.py build/GEOBENCH.RAW build/GEOBENCH.BIN GEOBENCH BIN 0x4000
-
-# Default icon set (DEFAULT.IST), packed from the icons in the desktop's slot
-# order. Keep this list in sync with icon_set in desktop/main.asm.
-python3 tools/packicons.py build/DEFAULT.IST \
-    lib/icon_floppy.asm lib/icon_ide.asm lib/icon_clock.asm lib/icon_trash.asm \
-    lib/icon_geobench.asm lib/icon_basic.asm lib/icon_binary.asm \
-    lib/icon_picture.asm lib/icon_text.asm
 
 MTOOLS_SKIP_CHECK=1 mcopy -o -i "$IMG" build/GEOBENCH.BIN ::/
 MTOOLS_SKIP_CHECK=1 mcopy -o -i "$IMG" build/DEFAULT.IST ::/

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -23,5 +23,18 @@ mkdir -p build
 "$RASM" desktop/main.asm -eo                  # -> build/GEOBENCH.RAW + .dsk
 python3 tools/amsdos_header.py build/GEOBENCH.RAW build/GEOBENCH.BIN GEOBENCH BIN 0x4000
 
+# Default icon set (DEFAULT.IST), packed from the icons in the desktop's slot
+# order. Keep this list in sync with icon_set in desktop/main.asm.
+python3 tools/packicons.py build/DEFAULT.IST \
+    lib/icon_floppy.asm lib/icon_ide.asm lib/icon_clock.asm lib/icon_trash.asm \
+    lib/icon_geobench.asm lib/icon_basic.asm lib/icon_binary.asm \
+    lib/icon_picture.asm lib/icon_text.asm
+
 MTOOLS_SKIP_CHECK=1 mcopy -o -i "$IMG" build/GEOBENCH.BIN ::/
-echo "Deployed GEOBENCH.BIN -> $IMG"
+MTOOLS_SKIP_CHECK=1 mcopy -o -i "$IMG" build/DEFAULT.IST ::/
+# Seed GEOBENCH.CFG only if the image doesn't already have one (user-editable).
+if ! MTOOLS_SKIP_CHECK=1 mdir -i "$IMG" ::GEOBENCH.CFG >/dev/null 2>&1; then
+    MTOOLS_SKIP_CHECK=1 mcopy -i "$IMG" GEOBENCH.CFG.example ::/GEOBENCH.CFG
+    echo "Seeded GEOBENCH.CFG"
+fi
+echo "Deployed GEOBENCH.BIN + DEFAULT.IST -> $IMG"

--- a/tools/packicons.py
+++ b/tools/packicons.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""packicons - pack CPC icon .asm files into a GEOBENCH icon set (.IST).
+
+A GEOBENCH icon set is just the raw 256-byte (8x32, Mode 1) icons concatenated
+in the desktop's fixed slot order, no header. The desktop loads it over its
+icon_set buffer, so the byte layout must match the slot order exactly.
+
+Slot order (must match desktop/main.asm icon_set):
+    floppy ide clock trash geobench basic binary picture text
+
+Usage:
+    tools/packicons.py <out.IST> <icon0.asm> <icon1.asm> ...
+Each .asm must be a png2cpc 32x32 icon (exactly 256 bytes of db data).
+"""
+import sys, re
+
+def asm_bytes(path):
+    data = bytearray()
+    for line in open(path):
+        s = line.strip()
+        if s.startswith('db'):
+            data += bytes(int(h, 16) for h in re.findall(r'#([0-9A-Fa-f]{2})', s))
+    return bytes(data)
+
+def main(argv):
+    if len(argv) < 3:
+        sys.exit("usage: packicons.py <out.IST> <icon.asm> ...")
+    out, asms = argv[1], argv[2:]
+    data = bytearray()
+    for a in asms:
+        b = asm_bytes(a)
+        if len(b) != 256:
+            sys.exit(f"{a}: {len(b)} bytes (expected 256)")
+        data += b
+    with open(out, 'wb') as f:
+        f.write(data)
+    print(f"{out}: {len(asms)} icons, {len(data)} bytes")
+
+if __name__ == '__main__':
+    main(sys.argv)


### PR DESCRIPTION
Two commits:
- de04e9a — disk‑loaded, config‑selectable icon sets (ICONS= → <name>.IST loaded over icon_set; packicons.py; GEOBENCH.CFG.example).
- edaaf93 — floppy/AMSDOS file‑read (fsam_load_file, header‑stripping) + self‑contained floppy .dsk (carries GEOBENCH.CFG + DEFAULT.IST).