### PR TITLE
Icons: validate the .IST (magic, size, dimensions) before using it

### DIFF
--- a/desktop/main.asm
+++ b/desktop/main.asm
@@ -24,24 +24,31 @@ geobench
                 include "../lib/text.asm"
                 include "../lib/window.asm"
 ; --- Icon set ------------------------------------------------------------
-; The active icons live contiguously in slot order under icon_set, so each
-; icon's label (icon_floppy, icon_binary, ...) is also its slot address. At
-; startup icon_load overwrites this buffer with <ICONS>.IST from disk (or these
-; compiled-in defaults are kept if there's no set file). The .IST is just the
-; raw icons in this same slot order. Each icon is 256 bytes (8 x 32).
-icon_set
-                include "../lib/icon_floppy.asm"     ; slot 0
-                include "../lib/icon_ide.asm"        ; slot 1
-                include "../lib/icon_clock.asm"      ; slot 2
-                include "../lib/icon_trash.asm"      ; slot 3
-                include "../lib/icon_geobench.asm"   ; slot 4
-                include "../lib/icon_basic.asm"      ; slot 5
-                include "../lib/icon_binary.asm"     ; slot 6
-                include "../lib/icon_picture.asm"    ; slot 7
-                include "../lib/icon_text.asm"       ; slot 8
-icon_set_end
-                defs  256                     ; slack so a whole-sector load fits
-ICONSET_BYTES   equ   icon_set_end - icon_set  ; 9 * 256 = 2304
+; The active icons live in the icon_set RAM buffer; each icon label is its slot
+; address there. At startup icon_load validates <ICONS>.IST and copies its icons
+; into icon_set, else keeps the compiled-in default set (icon_rom). The .IST has
+; a 16-byte header (GBIS magic, version, count, width, height) then the icons.
+ICON_SLOT       equ   256          ; bytes per icon (8 bytes x 32 rows, Mode 1)
+ICON_NSLOT      equ   9
+IST_HDR         equ   16           ; .IST header size
+ICONSET_BYTES   equ   ICON_NSLOT*ICON_SLOT      ; 2304
+IST_SIZE        equ   IST_HDR + ICONSET_BYTES   ; 2320
+ICON_LOAD_MAX   equ   2560         ; cap on a set's on-disk size (floppy adds an
+                                   ; AMSDOS header); also bounds the load buffer
+
+icon_rom_data   incbin "../build/DEFAULT.IST"  ; compiled-in default set (header + icons)
+icon_rom        equ   icon_rom_data + IST_HDR  ; its raw icons (the fallback)
+
+icon_set        defs  ICON_LOAD_MAX+128        ; active icons (RAM); icon_load fills it
+icon_floppy     equ   icon_set + 0*ICON_SLOT
+icon_ide        equ   icon_set + 1*ICON_SLOT
+icon_clock      equ   icon_set + 2*ICON_SLOT
+icon_trash      equ   icon_set + 3*ICON_SLOT
+icon_geobench   equ   icon_set + 4*ICON_SLOT
+icon_basic      equ   icon_set + 5*ICON_SLOT
+icon_binary     equ   icon_set + 6*ICON_SLOT
+icon_picture    equ   icon_set + 7*ICON_SLOT
+icon_text       equ   icon_set + 8*ICON_SLOT
                 include "../lib/fs.asm"
                 include "../lib/fs_ide_fat.asm"
                 include "../lib/fs_amsdos.asm"
@@ -1215,6 +1222,13 @@ icon_word
 ; over icon_set. If the file is absent (or no storage), the compiled-in default
 ; icons are kept. Call after cfg_load, before drawing icons.
 icon_load
+                ld    hl,ICON_LOAD_MAX        ; never load more than the buffer holds
+                ld    (fs_load_max),hl
+                ld    hl,icon_rom            ; default: the compiled-in icons
+                ld    de,icon_set
+                ld    bc,ICONSET_BYTES
+                ldir
+
                 ld    hl,cfg_icons           ; fs_req_name = cfg_icons.IST (8.3)
                 ld    de,fs_req_name
                 ld    b,8
@@ -1244,7 +1258,48 @@ il_ext
                 ld    (de),a
                 ld    hl,icon_set
                 ld    (fs_load_dst),hl
-                jp    fs_load_file            ; NC -> keep compiled-in defaults
+                call  fs_load_file
+                jr    nc,il_keepdef          ; missing / too big -> keep default
+
+                ld    a,(icon_set+0)         ; validate header: magic "GBIS"
+                cp    'G'
+                jr    nz,il_restore
+                ld    a,(icon_set+1)
+                cp    'B'
+                jr    nz,il_restore
+                ld    a,(icon_set+2)
+                cp    'I'
+                jr    nz,il_restore
+                ld    a,(icon_set+3)
+                cp    'S'
+                jr    nz,il_restore
+                ld    a,(icon_set+5)         ; count
+                cp    ICON_NSLOT
+                jr    nz,il_restore
+                ld    a,(icon_set+6)         ; width (bytes)
+                cp    8
+                jr    nz,il_restore
+                ld    a,(icon_set+7)         ; height (rows)
+                cp    32
+                jr    nz,il_restore
+                ld    hl,(fs_ent_size)       ; size
+                ld    de,IST_SIZE
+                or    a
+                sbc   hl,de
+                jr    nz,il_restore
+
+                ld    hl,icon_set+IST_HDR    ; valid -> drop the header
+                ld    de,icon_set
+                ld    bc,ICONSET_BYTES
+                ldir
+                ret
+il_restore
+                ld    hl,icon_rom            ; bad set -> restore the default icons
+                ld    de,icon_set
+                ld    bc,ICONSET_BYTES
+                ldir
+il_keepdef
+                ret
 
 ; build_desktop_icons: probe storage and fill the live icon arrays from
 ; cand_tbl. Present drives stack down the left column (y from 258, step -108);
@@ -2066,7 +2121,5 @@ end
 ; before assembling -- tools/build.sh does that.
 cfg_file        incbin "../GEOBENCH.CFG.example"
 cfg_file_end
-ist_file        incbin "../build/DEFAULT.IST"
-ist_file_end
                 save  "GEOBENCH.CFG",cfg_file,cfg_file_end-cfg_file,DSK,"build/geobench.dsk"
-                save  "DEFAULT.IST",ist_file,ist_file_end-ist_file,DSK,"build/geobench.dsk"
+                save  "DEFAULT.IST",icon_rom_data,IST_SIZE,DSK,"build/geobench.dsk"

--- a/lib/config.asm
+++ b/lib/config.asm
@@ -24,6 +24,8 @@ cfg_load
                 ld    de,fs_req_name
                 ld    bc,11
                 ldir
+                ld    hl,CFG_BUF_SZ          ; don't overrun cfg_buf
+                ld    (fs_load_max),hl
                 ld    hl,cfg_buf
                 ld    (fs_load_dst),hl
                 call  fs_load_file

--- a/lib/fs.asm
+++ b/lib/fs.asm
@@ -82,3 +82,4 @@ fs_ent_attr     defb  0
 fs_ent_size     defs  4
 fs_req_name     defs  11           ; fs_load_file: 8.3 name to load
 fs_load_dst     defw  0            ; fs_load_file: destination buffer
+fs_load_max     defw  #FFFF        ; fs_load_file: max bytes to read (buffer guard)

--- a/lib/fs_amsdos.asm
+++ b/lib/fs_amsdos.asm
@@ -374,11 +374,27 @@ fslf_next
                 add   ix,de
                 pop   bc
                 djnz  fslf_scan
+fslf_toobig
                 call  fsam_motor_off
-                or    a                               ; not found
+                or    a                               ; not found / too big
                 ret
 
 fslf_found
+                ld    a,(ix+15)                      ; on-disk bytes = Rc*128 > buffer?
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl                           ; Rc * 128
+                ld    de,(fs_load_max)
+                ex    de,hl
+                or    a
+                sbc   hl,de                           ; max - Rc*128
+                jr    c,fslf_toobig                   ; Rc*128 > max -> refuse
                 push  ix                              ; copy 16 block numbers out
                 pop   hl
                 ld    de,16

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -180,9 +180,15 @@ flf_find
                 call  fside_dir_next
                 jr    flf_find
 flf_notfound
+flf_toobig
                 or    a
                 ret
 flf_found                                      ; fs_ent_clus + fs_ent_size set
+                ld    hl,(fs_load_max)        ; size > caller's buffer? refuse
+                ld    de,(fs_ent_size)
+                or    a
+                sbc   hl,de
+                jr    c,flf_toobig
                 ld    hl,(fs_ent_size)        ; sectors = ceil(size/512)
                 ld    de,511
                 add   hl,de

--- a/tools/packicons.py
+++ b/tools/packicons.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python3
 """packicons - pack CPC icon .asm files into a GEOBENCH icon set (.IST).
 
-A GEOBENCH icon set is just the raw 256-byte (8x32, Mode 1) icons concatenated
-in the desktop's fixed slot order, no header. The desktop loads it over its
-icon_set buffer, so the byte layout must match the slot order exactly.
+A GEOBENCH icon set is a 16-byte header followed by the raw Mode 1 icons
+concatenated in the desktop's fixed slot order. The desktop validates the
+header, then loads the icons over its icon_set buffer.
+
+Header (16 bytes):
+    0-3   magic "GBIS"
+    4     version (1)
+    5     icon count
+    6     icon width in bytes (8 = 32 px)
+    7     icon height in rows (32)
+    8-15  reserved (0)
 
 Slot order (must match desktop/main.asm icon_set):
     floppy ide clock trash geobench basic binary picture text
@@ -13,6 +21,12 @@ Usage:
 Each .asm must be a png2cpc 32x32 icon (exactly 256 bytes of db data).
 """
 import sys, re
+
+MAGIC = b'GBIS'
+VERSION = 1
+ICON_W = 8       # bytes per row (32 px in Mode 1)
+ICON_H = 32      # rows
+ICON_BYTES = ICON_W * ICON_H   # 256
 
 def asm_bytes(path):
     data = bytearray()
@@ -26,15 +40,22 @@ def main(argv):
     if len(argv) < 3:
         sys.exit("usage: packicons.py <out.IST> <icon.asm> ...")
     out, asms = argv[1], argv[2:]
-    data = bytearray()
+    header = bytearray(16)
+    header[0:4] = MAGIC
+    header[4] = VERSION
+    header[5] = len(asms)
+    header[6] = ICON_W
+    header[7] = ICON_H
+    data = bytearray(header)
     for a in asms:
         b = asm_bytes(a)
-        if len(b) != 256:
-            sys.exit(f"{a}: {len(b)} bytes (expected 256)")
+        if len(b) != ICON_BYTES:
+            sys.exit(f"{a}: {len(b)} bytes (expected {ICON_BYTES})")
         data += b
     with open(out, 'wb') as f:
         f.write(data)
-    print(f"{out}: {len(asms)} icons, {len(data)} bytes")
+    print(f"{out}: {len(asms)} icons, {len(data)} bytes "
+          f"(16 header + {len(asms)}x{ICON_BYTES})")
 
 if __name__ == '__main__':
     main(sys.argv)


### PR DESCRIPTION
A bad or wrong-size icon set no longer corrupts the desktop icons.

- .IST now has a 16-byte header: magic "GBIS", version, icon count, icon width (bytes) and height (rows), then the icons. tools/packicons.py emits it; the width/height fields leave room for non-32x32 sets later.
- desktop/main.asm: the icon set is now a RAM buffer (icon_set) with the compiled-in default set (icon_rom, incbin'd) as the fallback; icon labels are EQUs into icon_set. icon_load copies the default in, loads <ICONS>.IST, then validates magic + count + 8x32 + size == 2320; on success it drops the header, on any failure it restores the default. The same incbin'd set is saved onto the floppy .dsk.
- fs_load_max (lib/fs.asm): both load backends now refuse a file larger than the caller's buffer (fside/fsam check before reading), so an oversized set can't overflow icon_set. cfg_load caps to the config buffer too.

Verified in 1984: valid set loads (IDE + floppy, the latter through both the AMSDOS and GBIS headers); a wrong-magic same-size set and a 5000-byte oversized set both fall back to the compiled-in defaults with no corruption.