### PR TITLE
Window dragging: movable file-manager window (save-under + XOR rubber-band)

### DIFF
--- a/apps/filemgr/filemgr.asm
+++ b/apps/filemgr/filemgr.asm
@@ -1,133 +1,270 @@
-; filemgr - the GEOBENCH file manager (a separate banked app).
-;
-; Opens a window via the kernel and lists the active drive's directory: a
-; half-height type icon + the (name-only) filename per entry. The pointer +
-; input come from the kernel (GB_CURSHOW/GB_POLL); a click selects a row (red
-; frame), a double-click LAUNCHES the entry's app (GB_LAUNCH) in another bank
-; page; when that app quits we redraw the list.
+; filemgr - the GEOBENCH file manager (banked app). Lists the active drive's
+; directory in a MOVABLE window: a half-height type icon + name per entry. The
+; pointer/input come from the kernel. Click selects a row (red frame),
+; double-click launches the entry's app (GB_LAUNCH). The title bar can be
+; dragged: a rubber-band outline (GB_XORFRAME) follows the pointer, and on drop
+; the window restores the desktop behind it (save-under) and reopens at the new
+; spot. The close gadget / ESC quit.
 
                 include "../../lib/gbapp.inc"
 
-ROW_Y0          equ   44           ; first row line (below the title bar)
-ROW_PITCH       equ   18           ; row pitch (16px icon band + 2px gap)
-ROW_MAXY        equ   150          ; stop adding rows past here
-DCLICK          equ   40           ; double-click window (frames ~0.8s)
+WIN_W           equ   56           ; window size
+WIN_H           equ   150
+ROW_OFF         equ   18           ; first row, below the title bar
+ROW_PITCH       equ   18
+DCLICK          equ   40
 NONE            equ   #FF
+WXMAX           equ   80-WIN_W     ; window drag clamps
+WYMIN           equ   8
+WYMAX           equ   200-WIN_H
 
                 org   APP_BASE
-app_entry
-                call  fm_draw                ; window + list + pointer
+fm_entry
+                call  fm_savereg             ; save the desktop behind the window
+                call  fm_draw
+fm_reset
+                ld    a,NONE
+                ld    (sel_row),a
+                xor   a
+                ld    (dc_timer),a
+                ld    (held_prev),a
+                ld    (win_dragging),a
 
 ; --- event loop ----------------------------------------------------------
-ev_loop
+fm_loop
                 call  GB_POLL                ; B=col, C=line, D=flags
-                ld    a,(dc_timer)           ; count down the double-click window
+                ld    a,b
+                ld    (cur_col),a
+                ld    a,c
+                ld    (cur_line),a
+                ld    a,d
+                ld    (poll_flags),a
+                ld    a,(dc_timer)
                 or    a
-                jr    z,ev_flags
+                jr    z,fl_q
                 dec   a
                 ld    (dc_timer),a
-ev_flags
-                bit   1,d                     ; ESC -> quit
-                jp    nz,app_done
-                bit   0,d                     ; fresh click?
-                jr    z,ev_loop
+fl_q
+                ld    a,(poll_flags)
+                bit   1,a                     ; ESC -> quit
+                jp    nz,fm_done
+                and   4                        ; fire held?
+                ld    (held_now),a
 
-                ld    a,b                     ; close gadget? cols [4,8) lines [26,40)
-                cp    4
-                jr    c,ev_row
-                cp    8
-                jr    nc,ev_row
-                ld    a,c
-                cp    26
-                jr    c,ev_row
-                cp    40
-                jr    nc,ev_row
-                jp    app_done
-ev_row
-                ld    a,c                     ; row = (line - ROW_Y0) / ROW_PITCH
-                sub   ROW_Y0
-                jr    c,ev_loop
-                ld    e,0
-ev_rdiv
-                cp    ROW_PITCH
-                jr    c,ev_rdone
-                sub   ROW_PITCH
-                inc   e
-                jr    ev_rdiv
-ev_rdone
-                ld    a,(n_entries)          ; row < n_entries ?
-                cp    e
-                jr    c,ev_loop
-                jr    z,ev_loop
-                ld    a,e
-                ld    (click_row),a
-                call  GB_CURHIDE             ; lift pointer before drawing under it
-                call  select_row             ; highlight it
-
-                ld    a,(dc_timer)           ; double-click = same row, timer live
+                ld    a,(held_prev)           ; falling edge -> drop a window drag
                 or    a
-                jr    z,ev_firstclick
-                ld    a,(dc_row)
+                jr    z,fl_nofall
+                ld    a,(held_now)
+                or    a
+                jr    nz,fl_nofall
+                ld    a,(win_dragging)
+                or    a
+                jr    z,fl_nofall
+                call  win_drop
+                jp    fm_loop
+fl_nofall
+                ld    a,(held_now)
+                ld    (held_prev),a
+                ld    a,(win_dragging)        ; dragging -> move the outline
+                or    a
+                jr    z,fl_click
+                call  win_dragmove
+                jp    fm_loop
+fl_click
+                ld    a,(poll_flags)          ; a fresh press?
+                bit   0,a
+                jp    z,fm_loop
+                call  hit_close              ; close gadget -> quit
+                jr    c,fm_done
+                call  hit_title              ; title bar -> drag the window
+                jr    c,fl_grab
+                call  hit_row                ; a list row?
+                jp    nc,fm_loop
+                call  GB_CURHIDE
+                call  select_row
+                ld    a,(dc_timer)           ; double-click = open
+                or    a
+                jr    z,fl_setdc
+                ld    a,(dc_idx)
                 ld    b,a
                 ld    a,(click_row)
                 cp    b
-                jr    nz,ev_firstclick
-                call  launch_row             ; second click -> open in its app
-                call  fm_draw                ; redraw after the app returns
-                jp    ev_loop
-ev_firstclick
+                jr    nz,fl_setdc
+                call  launch_row
+                call  fm_draw
+                jp    fm_reset
+fl_setdc
                 ld    a,(click_row)
-                ld    (dc_row),a
+                ld    (dc_idx),a
                 ld    a,DCLICK
                 ld    (dc_timer),a
-                call  GB_CURSHOW             ; pointer back on top
-                jp    ev_loop
-app_done
-                ret                            ; back to the desktop kernel
+                call  GB_CURSHOW
+                jp    fm_loop
+fl_grab
+                call  win_grab
+                jp    fm_loop
+fm_done
+                ret
 
-; --- draw the window + directory list, pointer on top --------------------
+; --- window drag ---------------------------------------------------------
+win_grab
+                ld    a,(cur_col)            ; grab offset within the window
+                ld    hl,win_x
+                sub   (hl)
+                ld    (grab_dx),a
+                ld    a,(cur_line)
+                ld    hl,win_y
+                sub   (hl)
+                ld    (grab_dy),a
+                ld    a,(win_x)
+                ld    (out_x),a
+                ld    a,(win_y)
+                ld    (out_y),a
+                call  GB_CURHIDE
+                call  draw_xorframe          ; rubber-band over the window
+                call  GB_CURSHOW
+                ld    a,1
+                ld    (win_dragging),a
+                ret
+
+win_dragmove
+                ld    a,(cur_col)            ; new x = cursor - grab, clamped
+                ld    hl,grab_dx
+                sub   (hl)
+                jr    nc,wm_xp
+                xor   a
+wm_xp
+                cp    WXMAX+1
+                jr    c,wm_xok
+                ld    a,WXMAX
+wm_xok
+                ld    (new_x),a
+                ld    a,(cur_line)
+                ld    hl,grab_dy
+                sub   (hl)
+                jr    nc,wm_yp
+                xor   a
+wm_yp
+                cp    WYMIN
+                jr    nc,wm_ylo
+                ld    a,WYMIN
+wm_ylo
+                cp    WYMAX+1
+                jr    c,wm_yok
+                ld    a,WYMAX
+wm_yok
+                ld    (new_y),a
+                ld    a,(new_x)             ; moved?
+                ld    hl,out_x
+                cp    (hl)
+                jr    nz,wm_go
+                ld    a,(new_y)
+                ld    hl,out_y
+                cp    (hl)
+                ret   z
+wm_go
+                call  GB_CURHIDE
+                call  draw_xorframe          ; erase old outline (XOR is reversible)
+                ld    a,(new_x)
+                ld    (out_x),a
+                ld    a,(new_y)
+                ld    (out_y),a
+                call  draw_xorframe          ; draw new outline
+                jp    GB_CURSHOW
+
+win_drop
+                call  GB_CURHIDE
+                call  draw_xorframe          ; erase the outline
+                call  fm_restorereg          ; reveal the desktop at the old spot
+                ld    a,(out_x)
+                ld    (win_x),a
+                ld    a,(out_y)
+                ld    (win_y),a
+                call  fm_savereg             ; save the desktop behind the new spot
+                xor   a
+                ld    (win_dragging),a
+                jp    fm_draw
+
+draw_xorframe
+                ld    a,(out_x)
+                ld    b,a
+                ld    a,(out_y)
+                ld    c,a
+                ld    d,WIN_W
+                ld    e,WIN_H
+                jp    GB_XORFRAME
+
+fm_savereg
+                ld    a,(win_x)
+                ld    b,a
+                ld    a,(win_y)
+                ld    c,a
+                ld    d,WIN_W
+                ld    e,WIN_H
+                ld    hl,win_buf
+                jp    GB_SAVERECT
+fm_restorereg
+                ld    a,(win_x)
+                ld    b,a
+                ld    a,(win_y)
+                ld    c,a
+                ld    d,WIN_W
+                ld    e,WIN_H
+                ld    hl,win_buf
+                jp    GB_RESTORERECT
+
+; --- draw the window + list, pointer on top ------------------------------
 fm_draw
-                ld    b,4                     ; window at (4,26), 56x150
-                ld    c,26
-                ld    d,56
-                ld    e,150
+                ld    a,(win_x)
+                ld    b,a
+                ld    a,(win_y)
+                ld    c,a
+                ld    d,WIN_W
+                ld    e,WIN_H
                 ld    hl,win_title
                 call  GB_WINDOW
                 xor   a
                 ld    (n_entries),a
-                ld    a,ROW_Y0
+                ld    a,(win_y)
+                add   a,ROW_OFF
                 ld    (row_y),a
                 call  GB_DIR1
                 jr    nc,fd_done
 fd_loop
-                push  hl                       ; HL = entry name
+                push  hl
+                ld    a,(win_x)
+                add   a,2
+                ld    b,a
                 ld    a,(row_y)
                 ld    c,a
-                ld    b,6
-                call  GB_BLITE               ; type icon
+                call  GB_BLITE
+                ld    a,(win_x)
+                add   a,11
+                ld    b,a
                 ld    a,(row_y)
                 add   a,5
                 ld    c,a
-                ld    b,15
                 ld    d,1
                 ld    e,0
                 pop   hl
-                call  GB_TEXT                ; name
+                call  GB_TEXT
                 ld    hl,n_entries
                 inc   (hl)
                 ld    a,(row_y)
                 add   a,ROW_PITCH
                 ld    (row_y),a
-                cp    ROW_MAXY
+                ld    a,(win_y)
+                add   a,WIN_H-20
+                ld    b,a
+                ld    a,(row_y)
+                cp    b
                 jr    nc,fd_done
                 call  GB_DIRN
                 jr    c,fd_loop
 fd_done
                 ld    a,NONE
                 ld    (sel_row),a
-                xor   a
-                ld    (dc_timer),a
-                jp    GB_CURSHOW             ; pointer on top (tail)
+                jp    GB_CURSHOW
 
 ; --- selection -----------------------------------------------------------
 select_row
@@ -138,19 +275,18 @@ select_row
                 ld    a,(click_row)
                 cp    b
                 ret   z
-                ld    a,b                     ; erase old frame (pen 0)
+                ld    a,b
                 call  row_frame_y
                 xor   a
                 call  draw_frame
 sr_draw
                 ld    a,(click_row)
                 call  row_frame_y
-                ld    a,3                     ; pen 3 (red accent)
+                ld    a,3
                 call  draw_frame
                 ld    a,(click_row)
                 ld    (sel_row),a
                 ret
-
 row_frame_y
                 ld    b,a
                 add   a,a
@@ -161,23 +297,91 @@ row_frame_y
                 add   a,a
                 add   a,a
                 add   a,c                     ; row*18
-                add   a,ROW_Y0-1
+                ld    b,a
+                ld    a,(win_y)
+                add   a,ROW_OFF-1
+                add   a,b
                 ld    (frame_y),a
                 ret
-
 draw_frame
                 ld    (df_pen),a
-                ld    b,5
+                ld    a,(win_x)
+                inc   a
+                ld    b,a
                 ld    a,(frame_y)
                 ld    c,a
-                ld    d,54
+                ld    d,WIN_W-2
                 ld    e,17
                 ld    a,(df_pen)
                 jp    GB_FRAME
 
+; --- hit tests -----------------------------------------------------------
+hit_close                                      ; CF if over the close gadget
+                ld    a,(cur_col)
+                ld    hl,win_x
+                cp    (hl)
+                jr    c,h_no
+                ld    a,(win_x)
+                add   a,4
+                ld    b,a
+                ld    a,(cur_col)
+                cp    b
+                jr    nc,h_no
+                jr    in_titleband
+hit_title                                      ; CF if over the title bar (not close)
+                ld    a,(win_x)
+                add   a,4
+                ld    b,a
+                ld    a,(cur_col)
+                cp    b
+                jr    c,h_no
+                ld    a,(win_x)
+                add   a,WIN_W
+                ld    b,a
+                ld    a,(cur_col)
+                cp    b
+                jr    nc,h_no
+in_titleband
+                ld    a,(cur_line)
+                ld    hl,win_y
+                cp    (hl)
+                jr    c,h_no
+                ld    a,(win_y)
+                add   a,14
+                ld    b,a
+                ld    a,(cur_line)
+                cp    b
+                jr    nc,h_no
+                scf
+                ret
+h_no
+                or    a
+                ret
+hit_row                                        ; CF set + click_row if over a row
+                ld    a,(win_y)
+                add   a,ROW_OFF
+                ld    b,a
+                ld    a,(cur_line)
+                sub   b
+                jr    c,h_no
+                ld    e,0
+hr_div
+                cp    ROW_PITCH
+                jr    c,hr_done
+                sub   ROW_PITCH
+                inc   e
+                jr    hr_div
+hr_done
+                ld    a,(n_entries)
+                cp    e
+                jr    c,h_no
+                jr    z,h_no
+                ld    a,e
+                ld    (click_row),a
+                scf
+                ret
+
 ; --- launch ---------------------------------------------------------------
-; launch_row: re-enumerate to the clicked entry (so fs_ent_name is set) and
-; open it with its app.
 launch_row
                 call  GB_DIR1
                 ld    a,(click_row)
@@ -190,16 +394,32 @@ lr_loop
                 pop   bc
                 djnz  lr_loop
 lr_go
-                jp    GB_LAUNCH              ; fs_ent_name = clicked entry
+                jp    GB_LAUNCH
 
+; --- data ----------------------------------------------------------------
 win_title       db    "DISK A",0
+win_x           db    4
+win_y           db    26
 row_y           db    0
 n_entries       db    0
 sel_row         db    0
 click_row       db    0
 dc_timer        db    0
-dc_row          db    0
+dc_idx          db    0
 frame_y         db    0
 df_pen          db    0
+cur_col         db    0
+cur_line        db    0
+poll_flags      db    0
+held_now        db    0
+held_prev       db    0
+win_dragging    db    0
+grab_dx         db    0
+grab_dy         db    0
+out_x           db    0
+out_y           db    0
+new_x           db    0
+new_y           db    0
+win_buf         defs  WIN_W*WIN_H
 app_end
                 save  "build/FILEMGR.RAW",APP_BASE,app_end-APP_BASE

--- a/apps/filemgr/filemgr.asm
+++ b/apps/filemgr/filemgr.asm
@@ -20,7 +20,8 @@ WYMAX           equ   200-WIN_H
 
                 org   APP_BASE
 fm_entry
-                call  fm_savereg             ; save the desktop behind the window
+                call  GB_CURHIDE             ; lift the desktop's pointer first so it
+                call  fm_savereg             ; isn't baked into the window save-under
                 call  fm_draw
 fm_reset
                 ld    a,NONE

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -36,6 +36,9 @@
                 jp    k_run                  ; GB_RUN     #802D
                 jp    k_icon                 ; GB_ICON    #8030
                 jp    k_fill                 ; GB_FILL    #8033
+                jp    k_saverect             ; GB_SAVERECT    #8036
+                jp    k_restorerect          ; GB_RESTORERECT #8039
+                jp    k_xorframe             ; GB_XORFRAME    #803C
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -803,6 +806,110 @@ k_fill
                 ld    (fb_val),a
                 jp    fill_block
 kf_pen          db    0
+
+; k_saverect / k_restorerect (GB_SAVERECT / GB_RESTORERECT): save/restore a
+; screen rectangle to/from a caller buffer. B=x C=y D=w E=h HL=buffer (w*h
+; bytes). The buffer lives in the caller's page (mapped during the call); the
+; screen is resident, so no page swap is needed.
+k_saverect
+                call  set_sb
+                jp    save_block
+k_restorerect
+                call  set_sb
+                jp    restore_block
+set_sb
+                ld    a,b
+                ld    (sb_x),a
+                ld    a,c
+                ld    (sb_y),a
+                ld    a,d
+                ld    (sb_w),a
+                ld    a,e
+                ld    (sb_h),a
+                ld    (sb_buf),hl
+                ret
+
+; k_xorframe (GB_XORFRAME): XOR a 1px rectangle outline into the screen. B=x
+; C=y D=w E=h. Self-erasing rubber-band: call again at the same spot to undo.
+k_xorframe
+                ld    a,b
+                ld    (xf_x),a
+                ld    a,c
+                ld    (xf_y),a
+                ld    a,d
+                ld    (xf_w),a
+                ld    a,e
+                ld    (xf_h),a
+                ld    a,(xf_x)               ; top edge
+                ld    d,a
+                ld    a,(xf_y)
+                ld    e,a
+                ld    a,(xf_w)
+                ld    b,a
+                call  xf_hline
+                ld    a,(xf_x)               ; bottom edge (y+h-1)
+                ld    d,a
+                ld    a,(xf_y)
+                ld    b,a
+                ld    a,(xf_h)
+                add   a,b
+                dec   a
+                ld    e,a
+                ld    a,(xf_w)
+                ld    b,a
+                call  xf_hline
+                ld    a,(xf_x)               ; left edge
+                ld    d,a
+                ld    a,(xf_y)
+                ld    e,a
+                ld    a,(xf_h)
+                ld    b,a
+                call  xf_vline
+                ld    a,(xf_x)               ; right edge (x+w-1)
+                ld    b,a
+                ld    a,(xf_w)
+                add   a,b
+                dec   a
+                ld    d,a
+                ld    a,(xf_y)
+                ld    e,a
+                ld    a,(xf_h)
+                ld    b,a
+                jp    xf_vline
+xf_hline                                       ; D=x E=y B=count -> XOR a row of bytes
+                ld    a,b
+                ld    (xf_cnt),a
+                call  scr_addr
+                ld    a,(xf_cnt)
+                ld    b,a
+xfh_loop
+                ld    a,(hl)
+                xor   #FF
+                ld    (hl),a
+                inc   hl
+                djnz  xfh_loop
+                ret
+xf_vline                                       ; D=x E=y B=rows -> XOR a column
+                ld    a,b
+                ld    (xf_cnt),a
+xfv_loop
+                push  de
+                call  scr_addr
+                ld    a,(hl)
+                xor   #FF
+                ld    (hl),a
+                pop   de
+                inc   e
+                ld    a,(xf_cnt)
+                dec   a
+                ld    (xf_cnt),a
+                jr    nz,xfv_loop
+                ret
+xf_x            db    0
+xf_y            db    0
+xf_w            db    0
+xf_h            db    0
+xf_cnt          db    0
 
 ; ===========================================================================
 ; Top bar (kernel-owned): total RAM (left) + clock (right) on lines 0-7. The

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -63,3 +63,9 @@ GB_RUN          equ   GB_KERNEL+45 ; #802D  run a named app: HL = 8.3 app name;
                                    ;        runs in the next bank page, returns on quit
 GB_ICON         equ   GB_KERNEL+48 ; #8030  full icon blit: A=slot B=x C=y
 GB_FILL         equ   GB_KERNEL+51 ; #8033  filled rect: B=x C=y D=w E=h A=pen
+GB_SAVERECT     equ   GB_KERNEL+54 ; #8036  save a screen rect to a buffer:
+                                   ;        B=x C=y D=w E=h HL=buf (w*h bytes)
+GB_RESTORERECT  equ   GB_KERNEL+57 ; #8039  restore a screen rect from a buffer
+GB_XORFRAME     equ   GB_KERNEL+60 ; #803C  XOR a 1px rect outline into the screen
+                                   ;        (rubber-band): B=x C=y D=w E=h. Draw
+                                   ;        once to show, again to erase exactly.


### PR DESCRIPTION
Restore window dragging (lost when the desktop/file-manager split into separate banked apps), re-homed for the new model.

## Kernel services
- `GB_SAVERECT` / `GB_RESTORERECT` — save/restore a screen rectangle into a caller buffer (wrap `screen.asm`'s `save_block`/`restore_block`). Lets an app keep what's behind its window so moving it reveals the desktop.
- `GB_XORFRAME` — a 1px rectangle outline drawn by XORing the screen (rubber-band). Self-erasing, so it leaves **no nicks** on the desktop — which FILEMGR can't repaint, since it's a different app.

## FILEMGR
- Window position is now `win_x`/`win_y`, and all content (frame, rows, icons, labels, selection, hit-tests) is relative to it — defaults to (4,26) so the layout is identical to before.
- On open it saves the desktop region behind the window (`win_buf`, 8.4 KB in its bank), lifting the pointer first so the cursor isn't baked into the save-under.
- The **title bar** (minus the close gadget) is a drag handle: grab shows the XOR outline; holding moves it (cursor − grab offset, clamped); release restores the desktop at the old spot, commits the new position, re-saves under it, and redraws the window there.
- Close gadget / ESC quit; file select + double-click open unchanged.

Verified interactively at 128K: the window drags via the title bar, the desktop is revealed cleanly behind it (no ghost cursor), and files still select/open.

Note: the window roams a limited range (it's 150 lines tall) — easy to shrink later if more room is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)