### PR TITLE
Easy grabs: more window-drag room + table-driven ext->app

### DIFF
--- a/apps/filemgr/filemgr.asm
+++ b/apps/filemgr/filemgr.asm
@@ -9,7 +9,8 @@
                 include "../../lib/gbapp.inc"
 
 WIN_W           equ   56           ; window size
-WIN_H           equ   150
+WIN_H           equ   130          ; shorter than the screen so it can be dragged
+                                   ; around (still fits the directory list)
 ROW_OFF         equ   18           ; first row, below the title bar
 ROW_PITCH       equ   18
 DCLICK          equ   40

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -735,11 +735,39 @@ k_getarg
                 ld    hl,launch_arg
                 ret
 
-; app_for_ext: HL = the app for fs_ent_name's type. For now every type opens in
-; VIEWER; this is where a real extension table will branch.
+; app_for_ext: HL = the app for fs_ent_name's type. Walks app_table: each entry
+; is a 3-char extension + an 11-char 8.3 app name; a 0 ends the table -> default.
+; (Only VIEWER exists today, so most types fall through to it; add rows as new
+; apps land.)
 app_for_ext
+                ld    hl,app_table
+afe_loop
+                ld    a,(hl)                  ; 0 = end of table -> default app
+                or    a
+                jr    z,afe_default
+                push  hl                       ; compare the 3-char extension
+                ld    de,fs_ent_name+8
+                ld    b,3
+afe_cmp
+                ld    a,(de)
+                cp    (hl)
+                jr    nz,afe_miss
+                inc   hl
+                inc   de
+                djnz  afe_cmp
+                pop   de                       ; matched -> HL = the app name (after ext)
+                ret
+afe_miss
+                pop   hl                       ; skip this entry (3 ext + 11 name)
+                ld    de,14
+                add   hl,de
+                jr    afe_loop
+afe_default
                 ld    hl,name_viewer
                 ret
+app_table
+                db    "TXT","VIEWER  BIN"      ; .TXT -> VIEWER
+                db    0                          ; end of table
 name_viewer     db    "VIEWER  BIN"
 launch_arg      defs  11
 


### PR DESCRIPTION
Two quick wins.

## More window-drag room
The file-manager window is shorter (`WIN_H` 150 -> 130), so it can be dragged further vertically (~42 -> ~62 lines of play) while still fitting the ~6-row directory list. The save-under buffer shrinks to match.

## Table-driven `app_for_ext` (ext -> app)
Replace the always-VIEWER stub with a walk over `app_table`: each entry is a 3-char extension + an 11-char 8.3 app name, terminated by `0` -> default app. Only VIEWER exists today (`.TXT -> VIEWER`, everything else -> default VIEWER), but the mechanism is real now — add one row per new app/type.

Independent of the open icon-layout PR (touches FILEMGR + kernel, not the desktop). The intermittent cursor-on-top-bar artifact is deferred pending a repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)