### PR TITLE
C-app spike: SDCC C program as a first-class banked app

### DIFF
--- a/apps/chello/crt0.s
+++ b/apps/chello/crt0.s
@@ -1,0 +1,27 @@
+;; crt0.s - SDCC startup for a GEOBENCH banked C app.
+;;
+;; The kernel loads the app image at APP_BASE (#4000) and CALLs it there, with a
+;; resident stack already set up. So the entry just runs SDCC's static init
+;; (empty for apps with no initialised globals) and main(), then RETs back to
+;; the kernel launcher. Link this object FIRST so _start lands at #4000.
+        .module crt0
+        .globl  _main
+
+        .area   _CODE
+_start::
+        call    gsinit          ; SDCC global/static initialisers
+        call    _main
+        ret                     ; back to the kernel's launch_app
+
+        .area   _GSINIT
+gsinit::
+        .area   _GSFINAL
+        ret
+
+        ;; area ordering for the linker
+        .area   _HOME
+        .area   _INITIALIZER
+        .area   _DATA
+        .area   _INITIALIZED
+        .area   _BSS
+        .area   _HEAP

--- a/apps/chello/gb.h
+++ b/apps/chello/gb.h
@@ -1,0 +1,21 @@
+/* gb.h - minimal C bindings for the GEOBENCH kernel API (the libgb spike).
+ *
+ * Each function below is a thin asm trampoline (apps/chello/gblib.s) over a
+ * fixed entry in the kernel jump table (lib/gbapp.inc). A C app includes this,
+ * is compiled by SDCC to run in an expansion bank at #4000, and reaches the
+ * resident kernel through these calls. Grows one entry per kernel service as
+ * C apps need them. */
+#ifndef GB_H
+#define GB_H
+
+/* poll flag bits (the D byte from GB_POLL) */
+#define GB_CLICK 0x01 /* fresh press this frame */
+#define GB_QUIT  0x02 /* ESC pressed */
+#define GB_FIRE  0x04 /* fire held */
+
+void gb_cls(void);                                       /* clear screen + home */
+void gb_text(unsigned char col, unsigned char line,      /* 6x8 text, white on   */
+             const char *s);                             /* the blue backdrop    */
+unsigned char gb_poll(void);                             /* frame poll -> flags  */
+
+#endif /* GB_H */

--- a/apps/chello/gblib.s
+++ b/apps/chello/gblib.s
@@ -1,0 +1,37 @@
+;; gblib.s - C bindings for the GEOBENCH kernel API (see gb.h).
+;;
+;; Maps SDCC's calling convention (__sdcccall, callee-cleans) onto the kernel
+;; jump table. SDCC packs the first small args into A then L, and pushes the
+;; trailing pointer arg on the stack; an unsigned-char result comes back in A.
+;; The jump-table addresses mirror lib/gbapp.inc.
+        .module gblib
+        .globl  _gb_cls
+        .globl  _gb_text
+        .globl  _gb_poll
+
+        .area   _CODE
+
+;; void gb_cls(void);
+_gb_cls:
+        jp      0x8003          ; GB_CLS
+
+;; void gb_text(unsigned char col, unsigned char line, const char *s);
+;;   SDCC: A = col, L = line, [SP+2] = s (pushed), caller does NOT clean up.
+;;   GB_TEXT wants B = col, C = line, D = pen, E = paper, HL = string.
+;;   The pop / ex (sp),hl pair loads HL = s and collapses the pushed arg into the
+;;   return slot, so a plain `ret` cleans the stack (callee-clean).
+_gb_text:
+        ld      b, a            ; B = col
+        ld      c, l            ; C = line
+        ld      d, #1           ; pen   = 1 (white)
+        ld      e, #0           ; paper = 0 (blue backdrop)
+        pop     hl              ; HL = return address; SP -> s
+        ex      (sp), hl        ; HL = s; return address into the arg slot
+        call    0x800C          ; GB_TEXT
+        ret
+
+;; unsigned char gb_poll(void);    -> flags in A
+_gb_poll:
+        call    0x801E          ; GB_POLL -> B=col C=line D=flags
+        ld      a, d
+        ret

--- a/apps/chello/main.c
+++ b/apps/chello/main.c
@@ -1,0 +1,26 @@
+/* chello - the GEOBENCH C-app spike.
+ *
+ * Proof that a C program (SDCC-compiled) can run as a first-class GEOBENCH app:
+ * it is built to load at #4000 inside an expansion bank and reaches the kernel
+ * purely through libgb (see gb.h / gblib.s). It clears the screen, greets via
+ * the kernel's 6x8 text renderer, and waits for ESC to quit cleanly back to the
+ * desktop - exercising the full app lifecycle (enter -> draw -> poll -> return)
+ * from C.
+ *
+ * Launched from the desktop by double-clicking the Clock icon. */
+#include "gb.h"
+
+void main(void)
+{
+    gb_cls();
+    gb_text(1,  16, "Hello from C!");
+    gb_text(1,  40, "This app is SDCC-compiled, runs in");
+    gb_text(1,  52, "an expansion bank, and calls the");
+    gb_text(1,  64, "GEOBENCH kernel through libgb - the");
+    gb_text(1,  76, "same jump table the asm apps use.");
+    gb_text(1, 110, "Press ESC to return to the desktop.");
+
+    while (!(gb_poll() & GB_QUIT)) {
+        /* idle until ESC; GB_POLL paces frames and runs the pointer */
+    }
+}

--- a/apps/desktop/desktop.asm
+++ b/apps/desktop/desktop.asm
@@ -81,10 +81,16 @@ dl_click
                 ld    a,(click_icon)
                 cp    b
                 jr    nz,dl_first
-                ld    a,(click_icon)         ; double-click: only Disk (0) opens
-                or    a
-                jr    nz,dl_dcdone
+                ld    a,(click_icon)         ; double-click: Disk (0) -> file manager,
+                or    a                        ; Clock (1) -> the C-app spike
+                jr    nz,dl_dc_clock
                 ld    hl,name_filemgr
+                jr    dl_dc_run
+dl_dc_clock
+                cp    1
+                jr    nz,dl_dcdone
+                ld    hl,name_chello
+dl_dc_run
                 call  GB_RUN
                 call  dt_paint
                 jp    dt_reset
@@ -338,11 +344,12 @@ hi_next
                 ret
 
 ; --- data ----------------------------------------------------------------
-help_msg        db    "Hold fire to drag - double-click Disk",0
+help_msg        db    "Dbl-click: Disk=files, Clock=C demo",0
 lbl_disk        db    "Disk A",0
 lbl_clock       db    "Clock",0
 lbl_trash       db    "Trash",0
 name_filemgr    db    "FILEMGR BIN"
+name_chello     db    "CHELLO  BIN"
 
 ic_x            db    0,72,72       ; icon positions (byte col) - mutable (drag)
 ic_y            db    35,35,160     ; icon positions (line)

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -712,6 +712,8 @@ la_done
                 dec   (hl)
                 pop   af                       ; caller's page
                 call  bank_set
+                call  draw_topbar             ; the app may have wiped it (e.g. a C
+                                              ; app's gb_cls) - the bar is the kernel's
                 ei
                 ret
 launch_depth    db    0
@@ -1340,6 +1342,8 @@ app_img         incbin "../build/FILEMGR.RAW"   ; packaged on the disk as FILEMG
 app_imgend
 vwr_img         incbin "../build/VIEWER.RAW"    ; packaged on the disk as VIEWER.BIN
 vwr_imgend
+chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.BIN
+chl_imgend
 font_img        incbin "../build/DEFAULT.FNT"   ; packaged on the disk as DEFAULT.FNT
 font_imgend
 icon_img        incbin "../build/DEFAULT.IST"   ; packaged on the disk as DEFAULT.IST
@@ -1348,6 +1352,7 @@ icon_imgend
                 save  "DESKTOP.BIN",dtp_img,dtp_imgend-dtp_img,DSK,"build/gbkern.dsk"
                 save  "FILEMGR.BIN",app_img,app_imgend-app_img,DSK,"build/gbkern.dsk"
                 save  "VIEWER.BIN",vwr_img,vwr_imgend-vwr_img,DSK,"build/gbkern.dsk"
+                save  "CHELLO.BIN",chl_img,chl_imgend-chl_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.FNT",font_img,font_imgend-font_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.IST",icon_img,icon_imgend-icon_img,DSK,"build/gbkern.dsk"
                 save  "build/GBKERN.RAW",GB_KERNEL,kern_end-GB_KERNEL

--- a/tools/build_capp.sh
+++ b/tools/build_capp.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Build a GEOBENCH C app with SDCC into a raw #4000 image - the same format as
+# the RASM .RAW app binaries, so the kernel can incbin/package it identically.
+#
+# The C app (apps/<name>/main.c) reaches the kernel through libgb (gblib.s);
+# crt0.s provides the #4000 entry. Linked: crt0 FIRST (so _start is at #4000),
+# then main, then the libgb trampolines.
+#
+#   tools/build_capp.sh [app_dir] [out.RAW]
+#   tools/build_capp.sh apps/chello build/CHELLO.RAW   (defaults)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+APP="${1:-apps/chello}"
+OUT="${2:-build/CHELLO.RAW}"
+
+SDCC="${SDCC:-sdcc}"
+BIN="$(dirname "$(command -v "$SDCC")")"   # sdasz80 / makebin sit beside sdcc
+SDAS="$BIN/sdasz80"
+MAKEBIN="$BIN/makebin"
+
+work="build/$(basename "$APP")"
+mkdir -p "$work"
+
+"$SDAS" -o "$work/crt0.rel"  "$APP/crt0.s"
+"$SDAS" -o "$work/gblib.rel" "$APP/gblib.s"
+"$SDCC" -mz80 -c "$APP/main.c" -o "$work/main.rel"
+"$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x6000 \
+    "$work/crt0.rel" "$work/main.rel" "$work/gblib.rel" -o "$work/app.ihx"
+"$MAKEBIN" -p "$work/app.ihx" "$work/app.bin"
+
+# makebin emits a flat image from #0000; the app lives at #4000 -> strip low 16K.
+tail -c +16385 "$work/app.bin" > "$OUT"
+echo "Built $OUT ($(stat -c%s "$OUT") bytes) from $APP"

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -21,5 +21,6 @@ python3 tools/packicons.py build/DEFAULT.IST \
 "$RASM" apps/desktop/desktop.asm -eo         # -> build/DESKTOP.RAW
 "$RASM" apps/filemgr/filemgr.asm -eo         # -> build/FILEMGR.RAW
 "$RASM" apps/viewer/viewer.asm -eo           # -> build/VIEWER.RAW
+tools/build_capp.sh apps/chello build/CHELLO.RAW   # C app (SDCC) -> build/CHELLO.RAW
 "$RASM" kernel/gbkern.asm -eo                # incbins apps + font + icons -> .dsk
-echo "Built build/gbkern.dsk (GBKERN + DESKTOP + FILEMGR + VIEWER + assets)"
+echo "Built build/gbkern.dsk (GBKERN + DESKTOP + FILEMGR + VIEWER + CHELLO + assets)"


### PR DESCRIPTION
Proves the **hybrid model** we discussed: kernel stays in asm, new apps can be written in **C**.

`CHELLO` is a C program (SDCC) compiled to load at `#4000` in an expansion bank and run as a normal GEOBENCH app, reaching the resident kernel only through a small **libgb**.

### What's here
- `apps/chello/main.c` - the app: clear screen, greet via the 6x8 renderer, poll until ESC, quit.
- `apps/chello/gb.h` / `gblib.s` - C bindings. The asm trampolines map SDCC's `__sdcccall` convention onto the `GB_*` jump table: a single pointer arg arrives in `HL` (bare `jp`); multi-arg `gb_text` reads SDCC's `A`/`L` + the pushed pointer and uses `pop` / `ex (sp),hl` to satisfy callee-clean; an `unsigned char` result returns in `A`.
- `apps/chello/crt0.s` - `#4000` entry: gsinit, main, `ret` to the launcher.
- `tools/build_capp.sh` - SDCC -> raw `#4000` image (same format as the RASM `.RAW` apps), so the kernel packages it identically.

### Wiring
`build_kernel.sh` builds CHELLO before the kernel; the kernel packages `CHELLO.BIN` onto the disk; **double-click the desktop Clock icon** to launch it. `launch_app` now redraws the top bar when an app returns (a C app's `gb_cls` wipes the whole screen, and the bar is the kernel's).

### Verified
Booted directly in 1984 (128K): the C app clears the screen and renders all its text through libgb -> the kernel, identical to the asm apps.

### Try it
Build, boot the desktop, double-click **Clock** -> the C demo; **ESC** returns to the desktop.

If this proves out for you, the plan is: keep the asm apps as-is, write **new** apps in C (next candidate: VIEWER-with-contents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)