### PR TITLE
Storage write layer + Notepad (editable, saves to disk)

### DIFF
--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -111,7 +111,8 @@ void main(void)
         mx = gb_mx();
         my = gb_my();
         if (dc_timer) dc_timer--;
-        if (flags & GB_QUIT) return;           /* ESC -> back to BASIC */
+        /* the desktop is the permanent root - ESC doesn't exit GEOBENCH (you reboot
+           the CPC to leave); it only closes apps launched on top of it */
 
         held = flags & GB_FIRE;
         if (held_prev && !held && drag_active) {   /* fire released -> drop */

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -78,6 +78,7 @@ static void launch(unsigned char idx)
     char *p = gb_dir1();
     for (i = 0; i < idx && p; i++) p = gb_dirn();
     gb_launch();
+    gb_fill(0, 8, 80, 192, 0);   /* clear the launched app's window (no save-under) */
     nsel = 0;
     draw_list();
 }

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -1,0 +1,103 @@
+/* notepad - the GEOBENCH text editor (C), and the first app that writes to disk.
+ *
+ * Launched by the file manager when a .TXT is double-clicked. Loads the file
+ * (gb_fs_load), shows it word-wrapped with a cursor, and edits it from the
+ * keyboard (gb_getkey):
+ *
+ *   printable keys  append a character
+ *   Enter           newline
+ *   Delete/Backspace remove the last character
+ *   Ctrl-S          save (overwrites the file in place; the title shows * when
+ *                   there are unsaved changes)
+ *   ESC             quit back to the file manager
+ *
+ * v1 edits at the end of the buffer (append / backspace); mid-text cursor
+ * movement and scrolling past one screenful are follow-ups. Save overwrites in
+ * place, so the text must fit the file's existing disk allocation. */
+#include "gb.h"
+
+#define NP_MAX    1024   /* edit buffer */
+#define WIN_X     2
+#define WIN_Y     14
+#define WIN_W     76
+#define WIN_H     180
+#define TX_COL    4
+#define TX_Y0     28
+#define LINE_H    10
+#define MAX_LINES 14
+#define WRAP      44
+
+#define K_ENTER   0x0D
+#define K_DEL     0x7F
+#define K_BS      0x08
+#define K_SAVE    0x13   /* Ctrl-S */
+#define K_ESC     0x1B
+
+static char buf[NP_MAX];
+static char line[WRAP + 2];
+static unsigned int len;
+static unsigned char dirty;
+
+/* draw: window + the buffer, word-wrapped, with a '_' cursor at the end. */
+static void draw(void)
+{
+    unsigned int i = 0;
+    unsigned char row = 0, col = 0, c;
+
+    gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, dirty ? "NOTEPAD *" : "NOTEPAD");
+    gb_text(TX_COL, WIN_Y + WIN_H - 11, "Ctrl-S=save  ESC=quit");
+
+    while (i < len && row < MAX_LINES) {
+        c = buf[i++];
+        if (c == '\n') {
+            line[col] = 0;
+            gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
+            row++; col = 0;
+            continue;
+        }
+        if (c < 32) continue;
+        line[col++] = c;
+        if (col == WRAP) {
+            line[col] = 0;
+            gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
+            row++; col = 0;
+        }
+    }
+    if (row < MAX_LINES) {              /* the partial line + the cursor marker */
+        line[col++] = '_';
+        line[col] = 0;
+        gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
+    }
+}
+
+void main(void)
+{
+    unsigned char k;
+
+    gb_curhide();                      /* a keyboard editor: no pointer */
+    len = gb_fs_load(buf, NP_MAX);
+    dirty = 0;
+    draw();
+
+    for (;;) {
+        k = gb_getkey();
+        if (!k) continue;
+        if (k == K_ESC) return;
+        if (k == K_SAVE) {
+            if (gb_fs_save(buf, len)) dirty = 0;
+            draw();
+            continue;
+        }
+        if (k == K_DEL || k == K_BS) {
+            if (len) { len--; dirty = 1; draw(); }
+            continue;
+        }
+        if (k == K_ENTER) {
+            if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; draw(); }
+            continue;
+        }
+        if (k >= 32 && k < 127) {
+            if (len < NP_MAX) { buf[len++] = (char)k; dirty = 1; draw(); }
+        }
+    }
+}

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -1,22 +1,25 @@
 /* notepad - the GEOBENCH text editor (C), and the first app that writes to disk.
  *
  * Launched by the file manager when a .TXT is double-clicked. Loads the file
- * (gb_fs_load), shows it word-wrapped with a cursor, and edits it from the
- * keyboard (gb_getkey):
+ * (gb_fs_load), shows it word-wrapped with a red underline cursor, and edits it
+ * from the keyboard (gb_getkey):
  *
- *   printable keys  append a character
- *   Enter           newline
+ *   printable keys   append a character
+ *   Enter            newline
  *   Delete/Backspace remove the last character
- *   Ctrl-S          save (overwrites the file in place; the title shows * when
- *                   there are unsaved changes)
- *   ESC             quit back to the file manager
+ *   Ctrl-S           save (overwrites in place; the title shows * when unsaved)
+ *   ESC              quit back to the file manager
  *
- * v1 edits at the end of the buffer (append / backspace); mid-text cursor
- * movement and scrolling past one screenful are follow-ups. Save overwrites in
- * place, so the text must fit the file's existing disk allocation. */
+ * The view scrolls to keep the end of the text (where editing happens) on
+ * screen. v1 edits at the end (append / backspace); mid-text cursor movement is
+ * a follow-up. Save overwrites in place, so the text must fit the file's current
+ * disk allocation.
+ *
+ * It paces with gb_vsync (no pointer) and reads only the keyboard, so the
+ * desktop's pointer/joystick never disturb it. */
 #include "gb.h"
 
-#define NP_MAX    1024   /* edit buffer */
+#define NP_MAX    1024
 #define WIN_X     2
 #define WIN_Y     14
 #define WIN_W     76
@@ -31,73 +34,102 @@
 #define K_DEL     0x7F
 #define K_BS      0x08
 #define K_SAVE    0x13   /* Ctrl-S */
+#define K_ESC     0x1B
 
 static char buf[NP_MAX];
 static char line[WRAP + 2];
 static unsigned int len;
 static unsigned char dirty;
 
-/* draw: window + the buffer, word-wrapped, with a '_' cursor at the end. */
+/* count_lines: index of the last display line (total lines = result + 1), with
+   the same wrap rule the renderer uses. */
+static unsigned char count_lines(void)
+{
+    unsigned int i;
+    unsigned char col = 0, n = 0, ch;
+    for (i = 0; i < len; i++) {
+        ch = buf[i];
+        if (ch == '\n') { n++; col = 0; }
+        else if (ch >= 32) { if (++col == WRAP) { n++; col = 0; } }
+    }
+    return n;
+}
+
+/* draw: window + the last screenful of text (so the end stays visible), then a
+   red underline cursor at the end of the text. */
 static void draw(void)
 {
-    unsigned int i = 0;
-    unsigned char row = 0, col = 0, c;
+    unsigned int i;
+    unsigned char ch, col = 0, lineno = 0, row = 0, first, total;
+    unsigned char curcol = 0, currow = 0, cx;
+
+    total = count_lines();
+    first = (total >= MAX_LINES) ? (total - MAX_LINES + 1) : 0;
 
     gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, dirty ? "NOTEPAD *" : "NOTEPAD");
     gb_text(TX_COL, WIN_Y + WIN_H - 11, "Ctrl-S=save  ESC=quit");
 
-    while (i < len && row < MAX_LINES) {
-        c = buf[i++];
-        if (c == '\n') {
-            line[col] = 0;
-            gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
-            row++; col = 0;
-            continue;
-        }
-        if (c < 32) continue;
-        line[col++] = c;
-        if (col == WRAP) {
-            line[col] = 0;
-            gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
-            row++; col = 0;
+    for (i = 0; i < len; i++) {
+        ch = buf[i];
+        if (ch == '\n') {
+            if (lineno >= first && row < MAX_LINES) {
+                line[col] = 0;
+                gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
+                row++;
+            }
+            col = 0; lineno++;
+        } else if (ch >= 32) {
+            if (lineno >= first) line[col] = ch;
+            if (++col == WRAP) {
+                if (lineno >= first && row < MAX_LINES) {
+                    line[col] = 0;
+                    gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
+                    row++;
+                }
+                col = 0; lineno++;
+            }
         }
     }
-    if (row < MAX_LINES) {              /* the partial line + the cursor marker */
-        line[col++] = '_';
+    if (lineno >= first && row < MAX_LINES) {   /* the partial last line */
         line[col] = 0;
         gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
+        curcol = col; currow = row;
     }
+
+    cx = TX_COL + (curcol * 3) / 2;             /* ~cursor pixel column / 4 */
+    gb_fill(cx, TX_Y0 + currow * LINE_H + 7, 2, 2, 3);   /* red underline */
 }
 
 void main(void)
 {
-    unsigned char flags, c, n, changed;
+    unsigned char c, n, changed;
 
-    gb_curhide();                      /* a keyboard editor: keep the pointer hidden */
+    gb_curhide();
     len = gb_fs_load(buf, NP_MAX);
     dirty = 0;
-    for (n = 64; n; n--)               /* discard keys buffered while navigating here */
-        if (!gb_getkey()) break;       /* (the desktop's fire-clicks land here as ' ') */
+    for (n = 64; n; n--)                        /* drop keys buffered while navigating */
+        if (!gb_getkey()) break;
     draw();
 
     for (;;) {
-        flags = gb_poll();             /* pace one frame; reliable ESC via the key matrix */
-        if (flags & GB_QUIT) return;
+        gb_vsync();                             /* pace 50 Hz, no pointer */
         changed = 0;
-        for (n = 32; n; n--) {         /* drain a bounded burst of typed keys this frame */
+        for (n = 32; n; n--) {                  /* drain a bounded burst of typed keys */
             c = gb_getkey();
             if (!c) break;
+            if (c == K_ESC) return;
             if (c == K_SAVE) {
                 if (gb_fs_save(buf, len)) dirty = 0;
+                changed = 1;
             } else if (c == K_DEL || c == K_BS) {
-                if (len) { len--; dirty = 1; }
+                if (len) { len--; dirty = 1; changed = 1; }
             } else if (c == K_ENTER) {
-                if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; }
+                if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; changed = 1; }
             } else if (c >= 32 && c < 127) {
-                if (len < NP_MAX) { buf[len++] = (char)c; dirty = 1; }
+                if (len < NP_MAX) { buf[len++] = (char)c; dirty = 1; changed = 1; }
             }
-            changed = 1;
+            /* other keys (cursor, etc.) are ignored - no redraw */
         }
-        if (changed) draw();           /* at most one redraw per frame -> no flicker */
+        if (changed) draw();
     }
 }

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -7,16 +7,18 @@
  *   printable keys   append a character
  *   Enter            newline
  *   Delete/Backspace remove the last character
- *   Ctrl-S           save (overwrites in place; the title shows * when unsaved)
+ *   Ctrl-S           save (overwrites in place; the status line reports the result)
  *   ESC              quit back to the file manager
  *
- * The view scrolls to keep the end of the text (where editing happens) on
- * screen. v1 edits at the end (append / backspace); mid-text cursor movement is
- * a follow-up. Save overwrites in place, so the text must fit the file's current
- * disk allocation.
+ * The view scrolls so the end of the text (where editing happens) stays visible.
+ * Typing within a line repaints only that line; the whole window is redrawn only
+ * on a newline, a scroll, or a save. It paces with gb_vsync (no pointer), reads
+ * only the keyboard, and quits when gb_vsync reports ESC held - so the desktop's
+ * pointer/joystick never disturb it.
  *
- * It paces with gb_vsync (no pointer) and reads only the keyboard, so the
- * desktop's pointer/joystick never disturb it. */
+ * v1 edits at the end (append / backspace); mid-text cursor movement is a
+ * follow-up. Save overwrites in place, so the text must fit the file's current
+ * disk allocation. */
 #include "gb.h"
 
 #define NP_MAX    1024
@@ -40,9 +42,9 @@ static char buf[NP_MAX];
 static char line[WRAP + 2];
 static unsigned int len;
 static unsigned char dirty;
+static unsigned char status;       /* 0 none, 1 saved, 2 save failed */
+static unsigned char prev_total;   /* line count at the last full draw */
 
-/* count_lines: index of the last display line (total lines = result + 1), with
-   the same wrap rule the renderer uses. */
 static unsigned char count_lines(void)
 {
     unsigned int i;
@@ -55,19 +57,32 @@ static unsigned char count_lines(void)
     return n;
 }
 
-/* draw: window + the last screenful of text (so the end stays visible), then a
-   red underline cursor at the end of the text. */
+static void status_line(void)
+{
+    gb_text(TX_COL, WIN_Y + WIN_H - 11,
+            status == 1 ? "saved" :
+            status == 2 ? "SAVE FAILED - too big to fit" :
+                          "Ctrl-S=save  ESC=quit");
+}
+
+static void cursor_at(unsigned char col, unsigned char row)
+{
+    gb_fill(TX_COL + (col * 3) / 2, TX_Y0 + row * LINE_H + 7, 2, 2, 3);
+}
+
+/* draw: full repaint - window, the last screenful of text, status, cursor. */
 static void draw(void)
 {
     unsigned int i;
     unsigned char ch, col = 0, lineno = 0, row = 0, first, total;
-    unsigned char curcol = 0, currow = 0, cx;
+    unsigned char curcol = 0, currow = 0;
 
     total = count_lines();
+    prev_total = total;
     first = (total >= MAX_LINES) ? (total - MAX_LINES + 1) : 0;
 
     gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, dirty ? "NOTEPAD *" : "NOTEPAD");
-    gb_text(TX_COL, WIN_Y + WIN_H - 11, "Ctrl-S=save  ESC=quit");
+    status_line();
 
     for (i = 0; i < len; i++) {
         ch = buf[i];
@@ -90,46 +105,74 @@ static void draw(void)
             }
         }
     }
-    if (lineno >= first && row < MAX_LINES) {   /* the partial last line */
+    if (lineno >= first && row < MAX_LINES) {
         line[col] = 0;
         gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
         curcol = col; currow = row;
     }
+    cursor_at(curcol, currow);
+}
 
-    cx = TX_COL + (curcol * 3) / 2;             /* ~cursor pixel column / 4 */
-    gb_fill(cx, TX_Y0 + currow * LINE_H + 7, 2, 2, 3);   /* red underline */
+/* draw_tail: repaint just the current (last) line - used when an append/backspace
+   doesn't change the line count, so the whole window needn't flicker. */
+static void draw_tail(void)
+{
+    unsigned int i, ls = 0;
+    unsigned char ch, col = 0, lineno = 0, first, currow;
+
+    for (i = 0; i < len; i++) {
+        ch = buf[i];
+        if (ch == '\n') { lineno++; col = 0; ls = i + 1; }
+        else if (ch >= 32) { if (++col == WRAP) { lineno++; col = 0; ls = i + 1; } }
+    }
+    first = (lineno >= MAX_LINES) ? (lineno - MAX_LINES + 1) : 0;
+    currow = lineno - first;
+
+    col = 0;
+    for (i = ls; i < len; i++) { ch = buf[i]; if (ch >= 32) line[col++] = ch; }
+    line[col] = 0;
+
+    gb_fill(WIN_X + 1, TX_Y0 + currow * LINE_H, WIN_W - 2, LINE_H, 0); /* clear line */
+    gb_text(TX_COL, TX_Y0 + currow * LINE_H, line);
+    cursor_at(col, currow);
+    status_line();
 }
 
 void main(void)
 {
-    unsigned char c, n, changed;
+    unsigned char c, n, edited, need_full, t;
 
     gb_curhide();
     len = gb_fs_load(buf, NP_MAX);
-    dirty = 0;
-    for (n = 64; n; n--)                        /* drop keys buffered while navigating */
+    dirty = 0; status = 0;
+    for (n = 64; n; n--)               /* drop keys buffered while navigating here */
         if (!gb_getkey()) break;
     draw();
 
     for (;;) {
-        gb_vsync();                             /* pace 50 Hz, no pointer */
-        changed = 0;
-        for (n = 32; n; n--) {                  /* drain a bounded burst of typed keys */
+        if (gb_vsync()) return;        /* pace + reliable ESC via the key matrix */
+        edited = 0; need_full = 0;
+        for (n = 32; n; n--) {
             c = gb_getkey();
             if (!c) break;
             if (c == K_ESC) return;
             if (c == K_SAVE) {
-                if (gb_fs_save(buf, len)) dirty = 0;
-                changed = 1;
+                status = gb_fs_save(buf, len) ? 1 : 2;
+                if (status == 1) dirty = 0;
+                edited = 1; need_full = 1;
             } else if (c == K_DEL || c == K_BS) {
-                if (len) { len--; dirty = 1; changed = 1; }
+                if (len) { len--; dirty = 1; status = 0; edited = 1; }
             } else if (c == K_ENTER) {
-                if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; changed = 1; }
+                if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; status = 0; edited = 1; need_full = 1; }
             } else if (c >= 32 && c < 127) {
-                if (len < NP_MAX) { buf[len++] = (char)c; dirty = 1; changed = 1; }
+                if (len < NP_MAX) { buf[len++] = (char)c; dirty = 1; status = 0; edited = 1; }
             }
             /* other keys (cursor, etc.) are ignored - no redraw */
         }
-        if (changed) draw();
+        if (edited) {
+            t = count_lines();
+            if (need_full || t != prev_total) draw();   /* draw() updates prev_total */
+            else draw_tail();
+        }
     }
 }

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -36,7 +36,7 @@
 #define K_DEL     0x7F
 #define K_BS      0x08
 #define K_SAVE    0x13   /* Ctrl-S */
-#define K_ESC     0x1B
+#define K_QUIT    0x11   /* Ctrl-Q */
 
 static char buf[NP_MAX];
 static char line[WRAP + 2];
@@ -62,7 +62,7 @@ static void status_line(void)
     gb_text(TX_COL, WIN_Y + WIN_H - 11,
             status == 1 ? "saved" :
             status == 2 ? "SAVE FAILED - too big to fit" :
-                          "Ctrl-S=save  ESC=quit");
+                          "Ctrl-S=save  Ctrl-Q=quit");
 }
 
 static void cursor_at(unsigned char col, unsigned char row)
@@ -150,12 +150,12 @@ void main(void)
     draw();
 
     for (;;) {
-        if (gb_vsync()) return;        /* pace + reliable ESC via the key matrix */
+        gb_vsync();                    /* pace one frame (50 Hz) */
         edited = 0; need_full = 0;
         for (n = 32; n; n--) {
             c = gb_getkey();
             if (!c) break;
-            if (c == K_ESC) return;
+            if (c == K_QUIT) return;   /* Ctrl-Q -> quit (ESC is a no-op now) */
             if (c == K_SAVE) {
                 status = gb_fs_save(buf, len) ? 1 : 2;
                 if (status == 1) dirty = 0;

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -31,7 +31,6 @@
 #define K_DEL     0x7F
 #define K_BS      0x08
 #define K_SAVE    0x13   /* Ctrl-S */
-#define K_ESC     0x1B
 
 static char buf[NP_MAX];
 static char line[WRAP + 2];
@@ -72,32 +71,33 @@ static void draw(void)
 
 void main(void)
 {
-    unsigned char k;
+    unsigned char flags, c, n, changed;
 
-    gb_curhide();                      /* a keyboard editor: no pointer */
+    gb_curhide();                      /* a keyboard editor: keep the pointer hidden */
     len = gb_fs_load(buf, NP_MAX);
     dirty = 0;
+    for (n = 64; n; n--)               /* discard keys buffered while navigating here */
+        if (!gb_getkey()) break;       /* (the desktop's fire-clicks land here as ' ') */
     draw();
 
     for (;;) {
-        k = gb_getkey();
-        if (!k) continue;
-        if (k == K_ESC) return;
-        if (k == K_SAVE) {
-            if (gb_fs_save(buf, len)) dirty = 0;
-            draw();
-            continue;
+        flags = gb_poll();             /* pace one frame; reliable ESC via the key matrix */
+        if (flags & GB_QUIT) return;
+        changed = 0;
+        for (n = 32; n; n--) {         /* drain a bounded burst of typed keys this frame */
+            c = gb_getkey();
+            if (!c) break;
+            if (c == K_SAVE) {
+                if (gb_fs_save(buf, len)) dirty = 0;
+            } else if (c == K_DEL || c == K_BS) {
+                if (len) { len--; dirty = 1; }
+            } else if (c == K_ENTER) {
+                if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; }
+            } else if (c >= 32 && c < 127) {
+                if (len < NP_MAX) { buf[len++] = (char)c; dirty = 1; }
+            }
+            changed = 1;
         }
-        if (k == K_DEL || k == K_BS) {
-            if (len) { len--; dirty = 1; draw(); }
-            continue;
-        }
-        if (k == K_ENTER) {
-            if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; draw(); }
-            continue;
-        }
-        if (k >= 32 && k < 127) {
-            if (len < NP_MAX) { buf[len++] = (char)k; dirty = 1; draw(); }
-        }
+        if (changed) draw();           /* at most one redraw per frame -> no flicker */
     }
 }

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -42,6 +42,7 @@
                 jp    k_fsload               ; GB_FSLOAD      #803F
                 jp    k_fssave               ; GB_FSSAVE      #8042
                 jp    k_getkey               ; GB_GETKEY      #8045
+                jp    MC_WAIT_FLYBACK        ; GB_VSYNC       #8048
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -172,36 +173,68 @@ poll_line       db    0
 ; clamped. Returns DE = new x, HL = new y. Does NOT write cursor_x/y - that is
 ; left to cursor_move_to, which only redraws when the position actually changes.
 poll_move
+                ld    a,(in_dirs)            ; acceleration: a held direction steps
+                or    a                       ; finely for the first few frames (so a
+                jr    nz,pm_held              ; tap nudges ~1px) then faster when held
+                ld    (pm_accel),a           ; nothing held -> reset the ramp
+                jr    pm_setstep
+pm_held
+                ld    a,(pm_accel)
+                inc   a
+                cp    40
+                jr    c,pm_accsave
+                ld    a,39                    ; cap the ramp counter
+pm_accsave
+                ld    (pm_accel),a
+pm_setstep
+                ld    a,(pm_accel)
+                cp    7
+                ld    a,2                     ; 2 units (~1px): precise
+                jr    c,pm_havestep
+                ld    a,12                    ; held a while -> 12 units (~6px): fast
+pm_havestep
+                ld    (pm_step),a
                 ld    a,(in_dirs)
                 ld    c,a
                 ld    hl,(cursor_x)
                 bit   2,c                     ; DIR_LEFT
                 jr    z,pm_right
-                ld    de,-12
-                add   hl,de
+                call  pm_sub
 pm_right
                 bit   3,c                     ; DIR_RIGHT
                 jr    z,pm_xclamp
-                ld    de,12
-                add   hl,de
+                call  pm_add
 pm_xclamp
                 call  clamp638
                 ld    (pm_newx),hl
                 ld    hl,(cursor_y)
                 bit   0,c                     ; DIR_UP -> +y (screen up)
                 jr    z,pm_down
-                ld    de,12
-                add   hl,de
+                call  pm_add
 pm_down
                 bit   1,c                     ; DIR_DOWN -> -y
                 jr    z,pm_yclamp
-                ld    de,-12
-                add   hl,de
+                call  pm_sub
 pm_yclamp
                 call  clamp398               ; HL = new y
                 ld    de,(pm_newx)           ; DE = new x
                 ret
+pm_add                                         ; HL += pm_step
+                ld    a,(pm_step)
+                ld    e,a
+                ld    d,0
+                add   hl,de
+                ret
+pm_sub                                         ; HL -= pm_step
+                ld    a,(pm_step)
+                ld    e,a
+                ld    d,0
+                or    a
+                sbc   hl,de
+                ret
 pm_newx         dw    0
+pm_step         db    0
+pm_accel        db    0
 clamp638
                 ld    de,638
                 jr    clamp_hl

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -42,7 +42,7 @@
                 jp    k_fsload               ; GB_FSLOAD      #803F
                 jp    k_fssave               ; GB_FSSAVE      #8042
                 jp    k_getkey               ; GB_GETKEY      #8045
-                jp    MC_WAIT_FLYBACK        ; GB_VSYNC       #8048
+                jp    k_vsync                ; GB_VSYNC       #8048
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -816,6 +816,18 @@ k_getkey
                 call  KM_READ_CHAR           ; CF + A = char, or NC = none
                 ret   c
                 xor   a
+                ret
+
+; k_vsync (GB_VSYNC): wait for the frame flyback (50 Hz pace, no pointer/clock),
+; then report whether ESC is held -> A = 1 if so, 0 otherwise. Lets a keyboard app
+; quit reliably via the key matrix instead of a guessed ESC char code.
+k_vsync
+                call  MC_WAIT_FLYBACK
+                ld    a,66                   ; KEY_ESC
+                call  KM_TEST_KEY            ; NZ if held
+                ld    a,0
+                ret   z
+                inc   a
                 ret
 
 ; app_for_ext: HL = the app for fs_ent_name's type. Walks app_table: each entry

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -822,11 +822,9 @@ k_fssave
 ; k_getkey (GB_GETKEY): A = a typed character from the keyboard buffer, or 0 if
 ; none is waiting. Non-blocking (the firmware's IRQ scan fills the buffer).
 k_getkey
-                push  ix                      ; KM_READ_CHAR clobbers IX - which is the
-                call  KM_READ_CHAR           ; C frame pointer, so a caller's stack frame
-                pop   ix                      ; (and its `ld sp,ix` epilogue) would be
-                ret   c                       ; wrecked -> crash to BASIC on return
-                xor   a
+                call  KM_READ_CHAR           ; CF + A = char, or NC = none. (Apps frame
+                ret   c                       ; on IY now, so KM_READ_CHAR clobbering IX
+                xor   a                       ; is harmless - see build_capp.sh.)
                 ret
 
 ; k_vsync (GB_VSYNC): wait for the frame flyback (50 Hz pace, no pointer/clock),

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -751,6 +751,10 @@ la_done
                 call  draw_topbar             ; the app may have wiped it (e.g. a C
                                               ; app's gb_cls) - the bar is the kernel's
                 ei
+la_escwait                                     ; if the app quit on ESC, wait for the
+                ld    a,66                     ; key to be released before the parent
+                call  KM_TEST_KEY              ; runs - else the same press quits it too,
+                jr    nz,la_escwait            ; cascading all the way back to BASIC
                 ret
 launch_depth    db    0
 

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -40,6 +40,7 @@
                 jp    k_restorerect          ; GB_RESTORERECT #8039
                 jp    k_xorframe             ; GB_XORFRAME    #803C
                 jp    k_fsload               ; GB_FSLOAD      #803F
+                jp    k_fssave               ; GB_FSSAVE      #8042
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -758,6 +759,22 @@ k_fsload
                 ld    bc,(fs_ent_size)        ; content length (header already stripped)
                 scf
                 ret
+
+; k_fssave (GB_FSSAVE): save the file the app was opened with (launch_arg). HL =
+; src (caller's page, stays mapped), DE = byte count. Overwrites in place. CF set
+; on success.
+k_fssave
+                ld    (fs_save_src),hl
+                ex    de,hl
+                ld    (fs_save_len),hl
+                ld    hl,launch_arg          ; save by the launched file's name
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                di
+                call  fs_save_file
+                ei
+                ret                            ; CF = saved
 
 ; app_for_ext: HL = the app for fs_ent_name's type. Walks app_table: each entry
 ; is a 3-char extension + an 11-char 8.3 app name; a 0 ends the table -> default.

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -818,8 +818,9 @@ k_fssave
 ; k_getkey (GB_GETKEY): A = a typed character from the keyboard buffer, or 0 if
 ; none is waiting. Non-blocking (the firmware's IRQ scan fills the buffer).
 k_getkey
-                call  KM_READ_CHAR           ; CF + A = char, or NC = none
-                ret   c
+                call  KM_DISARM_BREAK        ; KM_READ_CHAR would otherwise let ESC
+                call  KM_READ_CHAR           ; trigger the firmware BREAK (reset to
+                ret   c                       ; BASIC); keep it disarmed every read
                 xor   a
                 ret
 

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -50,7 +50,11 @@ kernel_main
                 call  SCR_SET_MODE           ; mode 1, screen cleared
                 call  TXT_CUR_DISABLE        ; no blinking firmware cursor blob
                 call  TXT_CUR_OFF
-                call  KM_DISARM_BREAK        ; ESC is ours, not a reset-to-BASIC key
+                call  KM_DISARM_BREAK        ; ESC is ours, not a reset-to-BASIC key:
+                ld    a,#C9                   ; disarm the break event AND patch the
+                ld    (#BDEE),a               ; KM TEST BREAK indirection to RET (that's
+                                              ; what actually resets on ESC; disarm alone
+                                              ; doesn't touch it)
                 call  set_palette            ; GEOBENCH 4-pen palette
                 call  fs_init                ; pick storage backend (floppy here)
                 di                            ; probe RAM BEFORE PAGE_DATA is filled
@@ -818,9 +822,8 @@ k_fssave
 ; k_getkey (GB_GETKEY): A = a typed character from the keyboard buffer, or 0 if
 ; none is waiting. Non-blocking (the firmware's IRQ scan fills the buffer).
 k_getkey
-                call  KM_DISARM_BREAK        ; KM_READ_CHAR would otherwise let ESC
-                call  KM_READ_CHAR           ; trigger the firmware BREAK (reset to
-                ret   c                       ; BASIC); keep it disarmed every read
+                call  KM_READ_CHAR           ; CF + A = char, or NC = none
+                ret   c
                 xor   a
                 ret
 

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -41,6 +41,7 @@
                 jp    k_xorframe             ; GB_XORFRAME    #803C
                 jp    k_fsload               ; GB_FSLOAD      #803F
                 jp    k_fssave               ; GB_FSSAVE      #8042
+                jp    k_getkey               ; GB_GETKEY      #8045
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -776,6 +777,14 @@ k_fssave
                 ei
                 ret                            ; CF = saved
 
+; k_getkey (GB_GETKEY): A = a typed character from the keyboard buffer, or 0 if
+; none is waiting. Non-blocking (the firmware's IRQ scan fills the buffer).
+k_getkey
+                call  KM_READ_CHAR           ; CF + A = char, or NC = none
+                ret   c
+                xor   a
+                ret
+
 ; app_for_ext: HL = the app for fs_ent_name's type. Walks app_table: each entry
 ; is a 3-char extension + an 11-char 8.3 app name; a 0 ends the table -> default.
 ; (Only VIEWER exists today, so most types fall through to it; add rows as new
@@ -807,7 +816,7 @@ afe_default
                 ld    hl,name_viewer
                 ret
 app_table
-                db    "TXT","VIEWER  BIN"      ; .TXT -> VIEWER
+                db    "TXT","NOTEPAD BIN"      ; .TXT -> NOTEPAD (edit + save)
                 db    0                          ; end of table
 name_viewer     db    "VIEWER  BIN"
 launch_arg      defs  11
@@ -1381,6 +1390,8 @@ app_img         incbin "../build/FILEMGR.RAW"   ; packaged on the disk as FILEMG
 app_imgend
 vwr_img         incbin "../build/VIEWER.RAW"    ; packaged on the disk as VIEWER.BIN
 vwr_imgend
+npd_img         incbin "../build/NOTEPAD.RAW"   ; packaged on the disk as NOTEPAD.BIN
+npd_imgend
 chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.BIN
 chl_imgend
 font_img        incbin "../build/DEFAULT.FNT"   ; packaged on the disk as DEFAULT.FNT
@@ -1393,6 +1404,7 @@ wel_imgend
                 save  "DESKTOP.BIN",dtp_img,dtp_imgend-dtp_img,DSK,"build/gbkern.dsk"
                 save  "FILEMGR.BIN",app_img,app_imgend-app_img,DSK,"build/gbkern.dsk"
                 save  "VIEWER.BIN",vwr_img,vwr_imgend-vwr_img,DSK,"build/gbkern.dsk"
+                save  "NOTEPAD.BIN",npd_img,npd_imgend-npd_img,DSK,"build/gbkern.dsk"
                 save  "CHELLO.BIN",chl_img,chl_imgend-chl_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.FNT",font_img,font_imgend-font_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.IST",icon_img,icon_imgend-icon_img,DSK,"build/gbkern.dsk"

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -50,6 +50,7 @@ kernel_main
                 call  SCR_SET_MODE           ; mode 1, screen cleared
                 call  TXT_CUR_DISABLE        ; no blinking firmware cursor blob
                 call  TXT_CUR_OFF
+                call  KM_DISARM_BREAK        ; ESC is ours, not a reset-to-BASIC key
                 call  set_palette            ; GEOBENCH 4-pen palette
                 call  fs_init                ; pick storage backend (floppy here)
                 di                            ; probe RAM BEFORE PAGE_DATA is filled

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -822,8 +822,10 @@ k_fssave
 ; k_getkey (GB_GETKEY): A = a typed character from the keyboard buffer, or 0 if
 ; none is waiting. Non-blocking (the firmware's IRQ scan fills the buffer).
 k_getkey
-                call  KM_READ_CHAR           ; CF + A = char, or NC = none
-                ret   c
+                push  ix                      ; KM_READ_CHAR clobbers IX - which is the
+                call  KM_READ_CHAR           ; C frame pointer, so a caller's stack frame
+                pop   ix                      ; (and its `ld sp,ix` epilogue) would be
+                ret   c                       ; wrecked -> crash to BASIC on return
                 xor   a
                 ret
 

--- a/lib/firmware.inc
+++ b/lib/firmware.inc
@@ -25,6 +25,7 @@ GRA_TEST_ABS    equ   #BBF0       ; DE = x, HL = y  -> A = pen at that point
 
 ; --- Keyboard ------------------------------------------------------------
 KM_READ_CHAR    equ   #BB09       ; -> CF + A = char from the buffer, or NC = none
+KM_DISARM_BREAK equ   #BB48       ; disable the ESC->BREAK (reset) mechanism
 KM_TEST_KEY     equ   #BB1E       ; A = key number; exit NZ if pressed
 KM_GET_JOYSTICK equ   #BB24       ; A = joystick 0 state, H = joystick 1
 

--- a/lib/firmware.inc
+++ b/lib/firmware.inc
@@ -24,6 +24,7 @@ GRA_PLOT_ABS    equ   #BBEA       ; DE = x, HL = y  (plot in current pen)
 GRA_TEST_ABS    equ   #BBF0       ; DE = x, HL = y  -> A = pen at that point
 
 ; --- Keyboard ------------------------------------------------------------
+KM_READ_CHAR    equ   #BB09       ; -> CF + A = char from the buffer, or NC = none
 KM_TEST_KEY     equ   #BB1E       ; A = key number; exit NZ if pressed
 KM_GET_JOYSTICK equ   #BB24       ; A = joystick 0 state, H = joystick 1
 

--- a/lib/fs.asm
+++ b/lib/fs.asm
@@ -26,6 +26,8 @@ fs_init
                 ld    (fs_p_next),hl
                 ld    hl,fside_load_file
                 ld    (fs_p_load),hl
+                ld    hl,fside_save_file
+                ld    (fs_p_save),hl
                 ret
 fsi_floppy
                 ld    hl,fsam_dir_first
@@ -34,6 +36,8 @@ fsi_floppy
                 ld    (fs_p_next),hl
                 ld    hl,fsam_load_file
                 ld    (fs_p_load),hl
+                ld    hl,fsam_save_file
+                ld    (fs_p_save),hl
                 ret
 
 ; fs_dir_first / fs_dir_next / fs_load_file: route to the selected backend.
@@ -46,6 +50,11 @@ fs_dir_next
 ; fs_load_file: load file (fs_req_name) into (fs_load_dst). CF set = loaded.
 fs_load_file
                 ld    hl,(fs_p_load)
+                jp    (hl)
+; fs_save_file: save fs_save_len bytes from (fs_save_src) to fs_req_name (must
+; exist; overwrite in place). CF set = saved, NC = failed.
+fs_save_file
+                ld    hl,(fs_p_save)
                 jp    (hl)
 fs_load_none
                 or    a                        ; not implemented -> NC
@@ -77,9 +86,12 @@ fsip_absent
 fs_p_first      defw  fside_dir_first   ; default IDE; fs_init rewrites on detect
 fs_p_next       defw  fside_dir_next
 fs_p_load       defw  fside_load_file
+fs_p_save       defw  fside_save_file
 fs_ent_name     defs  11
 fs_ent_attr     defb  0
 fs_ent_size     defs  4
-fs_req_name     defs  11           ; fs_load_file: 8.3 name to load
+fs_req_name     defs  11           ; fs_load_file/fs_save_file: 8.3 name
 fs_load_dst     defw  0            ; fs_load_file: destination buffer
 fs_load_max     defw  #FFFF        ; fs_load_file: max bytes to read (buffer guard)
+fs_save_src     defw  0            ; fs_save_file: source buffer
+fs_save_len     defw  0            ; fs_save_file: bytes to write

--- a/lib/fs_amsdos.asm
+++ b/lib/fs_amsdos.asm
@@ -524,6 +524,284 @@ fslf_ok
                 scf
                 ret
 
+; ---------------------------------------------------------------------------
+; fsam_write_sector: D=track, E=sector id. Writes 512 bytes from (fsam_src) to
+; the sector and advances fsam_src. Mirrors fsam_read_sector with WRITE DATA.
+fsam_write_sector
+                push  de
+                ld    a,#45                          ; WRITE DATA, MFM
+                call  fsam_send
+                ld    a,(fsam_unit)
+                call  fsam_send                      ; (head<<2)|drive
+                ld    a,d
+                call  fsam_send                      ; C = track
+                ld    a,0
+                call  fsam_send                      ; H = head
+                ld    a,e
+                call  fsam_send                      ; R = sector
+                ld    a,2
+                call  fsam_send                      ; N = 2 (512)
+                ld    a,e
+                call  fsam_send                      ; EOT = R (single sector)
+                ld    a,#2A
+                call  fsam_send                      ; GPL
+                ld    a,#FF
+                call  fsam_send                      ; DTL
+                ld    hl,(fsam_src)
+                ld    de,512
+fwr_exec
+                ld    bc,FSAM_MSR
+                in    a,(c)
+                bit   7,a                            ; RQM?
+                jr    z,fwr_exec
+                bit   5,a                            ; still in execution phase?
+                jr    z,fwr_result
+                ld    a,(hl)
+                ld    bc,FSAM_DATA
+                out   (c),a
+                inc   hl
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,fwr_exec
+fwr_result
+                ld    (fsam_src),hl
+                ld    b,7                             ; drain the 7 result bytes
+fwr_res_loop
+                push  bc
+                call  fsam_recv
+                pop   bc
+                djnz  fwr_res_loop
+                pop   de
+                ret
+
+; ---------------------------------------------------------------------------
+; fsam_save_file: overwrite fs_req_name (must already exist, single extent) with
+; fs_save_len bytes from (fs_save_src). Writes a 128-byte AMSDOS header + the data
+; into the file's existing allocation blocks, updates the record count, and writes
+; the directory back. CF set = saved; NC = not found, or won't fit the current
+; allocation (no block allocation / file creation yet).
+fsam_save_file
+                call  fsam_motor_on
+                call  fsam_read_dir                  ; directory -> fsam_buf
+                ld    ix,fsam_buf                    ; find the Ex=0 entry by name
+                ld    b,64
+fsv_scan
+                ld    a,(ix+0)
+                cp    #E5
+                jr    z,fsv_next
+                ld    a,(ix+12)
+                or    a
+                jr    nz,fsv_next
+                call  fsam_namematch
+                jr    z,fsv_found
+fsv_next
+                push  bc
+                ld    de,32
+                add   ix,de
+                pop   bc
+                djnz  fsv_scan
+fsv_fail
+                call  fsam_motor_off
+                or    a                               ; NC
+                ret
+fsv_found
+                ld    hl,(fs_save_len)                ; total = 128 + len
+                ld    de,128
+                add   hl,de
+                ld    de,127                          ; Rc = ceil(total/128)
+                add   hl,de
+                ld    a,h
+                add   a,a
+                ld    d,a
+                ld    a,l
+                rlca
+                and   1
+                add   a,d
+                ld    (fsam_rc),a
+                push  ix                              ; capacity = (#blocks)*8 records
+                pop   hl
+                ld    de,16
+                add   hl,de                           ; HL = block list
+                ld    b,16
+                ld    c,0
+fsv_cnt
+                ld    a,(hl)
+                or    a
+                jr    z,fsv_cntsk
+                inc   c
+fsv_cntsk
+                inc   hl
+                djnz  fsv_cnt
+                ld    a,c
+                add   a,a
+                add   a,a
+                add   a,a                              ; blocks*8
+                ld    b,a
+                ld    a,(fsam_rc)
+                cp    b
+                jr    z,fsv_fits
+                jr    nc,fsv_fail                      ; Rc > capacity -> won't fit
+fsv_fits
+                ld    hl,fsam_wbuf                    ; build the 128-byte header
+                ld    de,fsam_wbuf+1
+                ld    bc,127
+                ld    (hl),0
+                ldir                                  ; zero 128 bytes
+                ld    hl,fs_req_name                  ; name -> [1..11]
+                ld    de,fsam_wbuf+1
+                ld    bc,11
+                ldir
+                ld    a,2
+                ld    (fsam_wbuf+18),a                ; type = binary
+                ld    hl,(fs_save_len)
+                ld    (fsam_wbuf+24),hl               ; logical length
+                ld    (fsam_wbuf+64),hl               ; real length (low 16)
+                ld    hl,fsam_wbuf                    ; checksum = sum [0..66]
+                ld    de,0
+                ld    b,67
+fsv_sum
+                ld    a,(hl)
+                add   a,e
+                ld    e,a
+                jr    nc,fsv_snc
+                inc   d
+fsv_snc
+                inc   hl
+                djnz  fsv_sum
+                ex    de,hl
+                ld    (fsam_wbuf+67),hl
+                ld    hl,(fs_save_src)                ; data stream
+                ld    (fsv_dptr),hl
+                ld    hl,(fs_save_len)
+                ld    (fsv_drem),hl
+                xor   a
+                ld    (fsv_si),a
+                ld    a,#FF
+                ld    (fsv_curtrk),a                  ; force a seek
+                ld    a,(fsam_rc)                     ; nsec = ceil(Rc/4)
+                add   a,3
+                rrca
+                rrca
+                and   #3F
+                ld    (fsv_nsec),a
+fsv_wr
+                ld    a,(fsv_nsec)
+                or    a
+                jr    z,fsv_dir
+                dec   a
+                ld    (fsv_nsec),a
+                ld    a,(fsv_si)                      ; assemble the sector
+                or    a
+                jr    nz,fsv_body
+                ld    hl,fsam_wbuf+128                ; sector 0: header + data
+                ld    bc,384
+                call  fsv_filldata
+                jr    fsv_emit
+fsv_body
+                ld    hl,fsam_wbuf
+                ld    bc,512
+                call  fsv_filldata
+fsv_emit
+                ld    a,(fsv_si)                      ; block = blocklist[si/2]
+                srl   a
+                ld    e,a
+                ld    d,0
+                push  ix
+                pop   hl
+                ld    bc,16
+                add   hl,bc
+                add   hl,de
+                ld    l,(hl)
+                ld    h,0
+                add   hl,hl                            ; block*2
+                ld    a,(fsv_si)
+                and   1
+                or    l
+                ld    l,a                              ; L = block*2 + (si&1)
+                call  fsam_div9                        ; HL/9 -> B=track, A=remainder
+                ld    c,a
+                ld    a,b
+                ld    e,a                              ; E = track
+                ld    a,(fsv_curtrk)
+                cp    e
+                jr    z,fsv_noseek
+                ld    a,e
+                ld    (fsv_curtrk),a
+                push  bc
+                ld    a,e
+                call  fsam_seek
+                pop   bc
+fsv_noseek
+                ld    a,(fsv_curtrk)
+                ld    d,a                              ; D = track
+                ld    a,#C1
+                add   a,c
+                ld    e,a                              ; E = physical sector
+                ld    hl,fsam_wbuf
+                ld    (fsam_src),hl
+                call  fsam_write_sector
+                ld    a,(fsv_si)
+                inc   a
+                ld    (fsv_si),a
+                jr    fsv_wr
+fsv_dir
+                ld    a,(fsam_rc)                     ; commit the new record count
+                ld    (ix+15),a
+                xor   a
+                ld    (ix+12),a                        ; Ex = 0 (single extent)
+                ld    a,(fsam_track)                  ; write the directory back
+                call  fsam_seek
+                ld    hl,fsam_buf
+                ld    (fsam_src),hl
+                ld    a,(fsam_base)
+                ld    e,a
+                ld    b,4
+fsv_dirloop
+                push  bc
+                ld    a,(fsam_track)
+                ld    d,a
+                call  fsam_write_sector
+                pop   bc
+                inc   e
+                djnz  fsv_dirloop
+                call  fsam_motor_off
+                scf
+                ret
+
+; fsv_filldata: HL=dest, BC=count. Copy min(count, fsv_drem) bytes from (fsv_dptr)
+; advancing it, then pad the rest with 0.
+fsv_filldata
+                ld    a,b
+                or    c
+                ret   z
+                push  hl
+                ld    hl,(fsv_drem)
+                ld    a,h
+                or    l
+                pop   hl
+                jr    z,fsv_fdpad
+                push  bc
+                ld    bc,(fsv_dptr)
+                ld    a,(bc)
+                inc   bc
+                ld    (fsv_dptr),bc
+                pop   bc
+                ld    (hl),a
+                inc   hl
+                push  hl
+                ld    hl,(fsv_drem)
+                dec   hl
+                ld    (fsv_drem),hl
+                pop   hl
+                dec   bc
+                jr    fsv_filldata
+fsv_fdpad
+                ld    (hl),0
+                inc   hl
+                dec   bc
+                jr    fsv_filldata
+
 ; fsam_namematch: IX = dir entry; Z if its 8.3 name == fs_req_name (11 bytes).
 fsam_namematch
                 push  ix
@@ -578,4 +856,12 @@ fsam_base       defb  #C1
 fsam_track      defb  0
 fsam_idx        defb  0
 fsam_dst        defw  0
+fsam_src        defw  0            ; fsam_write_sector source pointer
+fsam_rc         defb  0            ; save: record count being written
+fsv_nsec        defb  0            ; save: sectors left to write
+fsv_si          defb  0            ; save: sector index within the file
+fsv_curtrk      defb  0            ; save: track the head is on
+fsv_dptr        defw  0            ; save: pointer into the source data
+fsv_drem        defw  0            ; save: source bytes left
 fsam_buf        defs  2048
+fsam_wbuf       defs  512          ; save: one assembled 512-byte sector

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -168,6 +168,13 @@ fdn_end
                 ret
 
 ; ---------------------------------------------------------------------------
+; fside_save_file: not yet implemented for the IDE/FAT16 backend. NC = failed.
+; (The floppy/AMSDOS backend has the write path; FAT16 write is a follow-up.)
+fside_save_file
+                or    a
+                ret
+
+; ---------------------------------------------------------------------------
 ; fside_load_file: load the file named in fs_req_name (11-byte 8.3) into the
 ; buffer at (fs_load_dst). CF set = loaded (fs_ent_size = byte size), NC = not
 ; found. Follows the FAT16 cluster chain. 16-bit LBA (files in the first 32MB).

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -38,4 +38,5 @@ unsigned int gb_fs_load(char *buf, unsigned int max);    /* load opened file -> 
 unsigned char gb_fs_save(char *buf, unsigned int len);   /* save opened file ->   */
                                                          /* 1 ok / 0 fail         */
 unsigned char gb_getkey(void);        /* typed char from the keyboard, 0 if none  */
+void gb_vsync(void);                  /* wait one frame (no pointer/clock effects)*/
 #endif /* GB_H */

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -38,5 +38,5 @@ unsigned int gb_fs_load(char *buf, unsigned int max);    /* load opened file -> 
 unsigned char gb_fs_save(char *buf, unsigned int len);   /* save opened file ->   */
                                                          /* 1 ok / 0 fail         */
 unsigned char gb_getkey(void);        /* typed char from the keyboard, 0 if none  */
-void gb_vsync(void);                  /* wait one frame (no pointer/clock effects)*/
+unsigned char gb_vsync(void);         /* wait one frame -> 1 if ESC held, else 0  */
 #endif /* GB_H */

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -35,4 +35,6 @@ void gb_launch(void);                 /* launch the current dir entry           
 void gb_run(const char *name);        /* run a named app, return when it quits    */
 unsigned int gb_fs_load(char *buf, unsigned int max);    /* load opened file ->   */
                                                          /* byte count            */
+unsigned char gb_fs_save(char *buf, unsigned int len);   /* save opened file ->   */
+                                                         /* 1 ok / 0 fail         */
 #endif /* GB_H */

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -37,4 +37,5 @@ unsigned int gb_fs_load(char *buf, unsigned int max);    /* load opened file -> 
                                                          /* byte count            */
 unsigned char gb_fs_save(char *buf, unsigned int len);   /* save opened file ->   */
                                                          /* 1 ok / 0 fail         */
+unsigned char gb_getkey(void);        /* typed char from the keyboard, 0 if none  */
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -25,6 +25,7 @@
         .globl  _gb_launch
         .globl  _gb_run
         .globl  _gb_fs_load
+        .globl  _gb_fs_save
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -168,4 +169,12 @@ _gb_fs_load:
         call    0x803F          ; GB_FSLOAD -> BC = byte count
         ld      d, b
         ld      e, c
+        ret
+
+;; unsigned char gb_fs_save(char *buf, unsigned int len);   buf=HL, len=DE -> 1/0
+_gb_fs_save:
+        call    0x8042          ; GB_FSSAVE -> CF = saved
+        ld      a, #0
+        ret     nc
+        inc     a
         ret

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -27,6 +27,7 @@
         .globl  _gb_fs_load
         .globl  _gb_fs_save
         .globl  _gb_getkey
+        .globl  _gb_vsync
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -183,3 +184,7 @@ _gb_fs_save:
 ;; unsigned char gb_getkey(void);   -> typed char in A, or 0 if none
 _gb_getkey:
         jp      0x8045          ; GB_GETKEY (returns the char in A)
+
+;; void gb_vsync(void);   wait one frame (50 Hz), no pointer/clock side effects
+_gb_vsync:
+        jp      0x8048          ; GB_VSYNC

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -26,6 +26,7 @@
         .globl  _gb_run
         .globl  _gb_fs_load
         .globl  _gb_fs_save
+        .globl  _gb_getkey
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -178,3 +179,7 @@ _gb_fs_save:
         ret     nc
         inc     a
         ret
+
+;; unsigned char gb_getkey(void);   -> typed char in A, or 0 if none
+_gb_getkey:
+        jp      0x8045          ; GB_GETKEY (returns the char in A)

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -74,3 +74,8 @@ GB_FSLOAD       equ   GB_KERNEL+63 ; #803F  load the file this app was opened wi
                                    ;        (caller's page), DE=max bytes. -> BC =
                                    ;        byte count (0 = missing / too big), CF
                                    ;        set on success. AMSDOS header stripped.
+GB_FSSAVE       equ   GB_KERNEL+66 ; #8042  save the file this app was opened with:
+                                   ;        HL=src (caller's page), DE=byte count.
+                                   ;        Overwrites in place (the file must exist
+                                   ;        and the data must fit its current
+                                   ;        allocation). CF set = saved.

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -79,3 +79,6 @@ GB_FSSAVE       equ   GB_KERNEL+66 ; #8042  save the file this app was opened wi
                                    ;        Overwrites in place (the file must exist
                                    ;        and the data must fit its current
                                    ;        allocation). CF set = saved.
+GB_GETKEY       equ   GB_KERNEL+69 ; #8045  -> A = a typed character from the
+                                   ;        keyboard buffer, or 0 if none waiting.
+                                   ;        Non-blocking; IRQs must be on.

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -82,6 +82,7 @@ GB_FSSAVE       equ   GB_KERNEL+66 ; #8042  save the file this app was opened wi
 GB_GETKEY       equ   GB_KERNEL+69 ; #8045  -> A = a typed character from the
                                    ;        keyboard buffer, or 0 if none waiting.
                                    ;        Non-blocking; IRQs must be on.
-GB_VSYNC        equ   GB_KERNEL+72 ; #8048  wait for the frame flyback (50 Hz pace),
-                                   ;        without touching the pointer or clock -
-                                   ;        for keyboard apps that don't use GB_POLL.
+GB_VSYNC        equ   GB_KERNEL+72 ; #8048  wait for the frame flyback (50 Hz pace,
+                                   ;        no pointer/clock) -> A = 1 if ESC is held
+                                   ;        else 0. For keyboard apps that drive
+                                   ;        their own loop instead of GB_POLL.

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -82,3 +82,6 @@ GB_FSSAVE       equ   GB_KERNEL+66 ; #8042  save the file this app was opened wi
 GB_GETKEY       equ   GB_KERNEL+69 ; #8045  -> A = a typed character from the
                                    ;        keyboard buffer, or 0 if none waiting.
                                    ;        Non-blocking; IRQs must be on.
+GB_VSYNC        equ   GB_KERNEL+72 ; #8048  wait for the frame flyback (50 Hz pace),
+                                   ;        without touching the pointer or clock -
+                                   ;        for keyboard apps that don't use GB_POLL.

--- a/tools/build_capp.sh
+++ b/tools/build_capp.sh
@@ -25,7 +25,11 @@ mkdir -p "$work"
 
 "$SDAS" -o "$work/crt0.rel"  "$GB/crt0.s"
 "$SDAS" -o "$work/gblib.rel" "$GB/gblib.s"
-"$SDCC" -mz80 -I "$GB" -c "$APP/main.c" -o "$work/main.rel"
+# --fomit-frame-pointer: frame on IY, not IX. The kernel/fs code uses IX as a
+# scratch (it never touches IY) and firmware calls preserve the caller's IY, so
+# this stops a kernel call from wrecking an app's frame pointer (which crashed
+# the notepad's return - SDCC's epilogue is `ld sp,<fp>`).
+"$SDCC" -mz80 --fomit-frame-pointer -I "$GB" -c "$APP/main.c" -o "$work/main.rel"
 "$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x6000 \
     "$work/crt0.rel" "$work/main.rel" "$work/gblib.rel" -o "$work/app.ihx"
 "$MAKEBIN" -p "$work/app.ihx" "$work/app.bin"

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -21,6 +21,7 @@ python3 tools/packicons.py build/DEFAULT.IST \
 tools/build_capp.sh apps/desktop build/DESKTOP.RAW # DESKTOP (C/SDCC) -> build/DESKTOP.RAW
 tools/build_capp.sh apps/filemgr build/FILEMGR.RAW # FILEMGR (C/SDCC) -> build/FILEMGR.RAW
 tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VIEWER.RAW
+tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD (C/SDCC) -> build/NOTEPAD.RAW
 tools/build_capp.sh apps/chello build/CHELLO.RAW   # C app (SDCC) -> build/CHELLO.RAW
 "$RASM" kernel/gbkern.asm -eo                # incbins apps + font + icons -> .dsk
-echo "Built build/gbkern.dsk (GBKERN + DESKTOP + FILEMGR + VIEWER + CHELLO + assets)"
+echo "Built build/gbkern.dsk (GBKERN + DESKTOP + FILEMGR + VIEWER + NOTEPAD + CHELLO + assets)"


### PR DESCRIPTION
Adds the plan's Phase 3 (storage write) and Phase 4 (a notepad), plus the input/firmware fixes that surfaced along the way.

## Features
- **Storage write layer** - `GB_FSSAVE`: a raw-FDC AMSDOS write path (`fsam_write_sector` + `fsam_save_file`, overwrite-in-place), verified end-to-end (an app writes a bank buffer, it round-trips back from disk).
- **Notepad** (`apps/notepad`, C) - opens a `.TXT` (the type->app table routes TXT here), loads it, edits from the keyboard (type / Delete / Enter), **Ctrl-S to save**, **Ctrl-Q to quit**. Scrolls to keep the cursor (red underline) on screen; repaints only the current line while typing.
- **`GB_GETKEY`** (non-blocking keyboard char read) and **`GB_VSYNC`** (frame pace + ESC state) kernel services.

## Fixes (mostly from interactive testing)
- **Pointer acceleration** - fine for taps, fast when held.
- **ESC never resets to BASIC** - the desktop is now a permanent root, and the firmware's `KM TEST BREAK` indirection (`&BDEE`) is patched to RET (disarming alone doesn't touch it).
- **Apps build with `--fomit-frame-pointer`** - the kernel/floppy code uses `IX` as a scratch, which wrecked an app's SDCC frame pointer; framing on `IY` (the kernel never uses it; firmware preserves it) fixes app returns crashing to BASIC.
- File manager clears the backdrop when a launched app returns.

## Known follow-ups
- Notepad: mid-text editing (arrow keys + insert/delete); save is overwrite-in-place (no file create/grow yet - needs AMSDOS block allocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)