### PR TITLE
Kernel logic → C modules: config parser, wired into boot (#30)

### DIFF
--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -16,6 +16,14 @@
                 include "../lib/gbapp.inc"
                 include "../lib/firmware.inc"
 
+; Config transfer area - resident low RAM (stays main RAM under banking, so the
+; paged-in GBCFG module can reach it). The kernel fills text/len, runs the
+; module, then reads the parsed ICONS=/FONT= stems back. See kernel/kc/.
+KCFG_TEXT       equ   #1000        ; GEOBENCH.CFG contents (<=512 bytes)
+KCFG_LEN        equ   #1200        ; word: cfg-text byte count (0 = no file)
+KCFG_ICONS      equ   #1202        ; 9 bytes: parsed icon-set stem (NUL-term)
+KCFG_FONT       equ   #120C        ; 9 bytes: parsed font-set stem (NUL-term)
+
                 org   GB_KERNEL
 ; --- fixed API jump table (order is the ABI; see lib/gbapp.inc) -----------
                 jp    kernel_main            ; GB_INIT  #8000
@@ -71,6 +79,9 @@ kernel_main
                 ld    de,64
                 add   hl,de
                 call  fmt_mem                ; -> mem_str
+                call  cfg_boot               ; parse GEOBENCH.CFG (C module) ->
+                                             ; KCFG_ICONS / KCFG_FONT (before the
+                                             ; font/icon loaders consume them)
                 call  font_init              ; load the font into PAGE_DATA
                 call  icon_init              ; load the icon set into PAGE_DATA
                 call  clock_init             ; RTC or software clock -> time_str
@@ -677,16 +688,105 @@ ext_scr         db    "SCR"
 ext_txt         db    "TXT"
 name_geobench   db    "GEOBENCH"
 
+; --- config (C kernel module) --------------------------------------------
+; cfg_boot: seed defaults, load GEOBENCH.CFG into the transfer area, then run the
+; GBCFG C module (paged into a bank) to parse it into KCFG_ICONS / KCFG_FONT.
+; Absent file -> length 0 -> the parser is a no-op and the defaults stand.
+cfg_boot
+                ld    hl,cfg_default         ; KCFG_ICONS = "DEFAULT"
+                ld    de,KCFG_ICONS
+                ld    bc,9
+                ldir
+                ld    hl,cfg_default         ; KCFG_FONT  = "DEFAULT"
+                ld    de,KCFG_FONT
+                ld    bc,9
+                ldir
+                ld    hl,0                    ; default: no config text
+                ld    (KCFG_LEN),hl
+                ld    hl,cfg_fname           ; fs_req_name = "GEOBENCH.CFG"
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    hl,#0200               ; cfg text buffer is 512 bytes
+                ld    (fs_load_max),hl
+                ld    hl,KCFG_TEXT
+                ld    (fs_load_dst),hl
+                call  fs_load_file
+                jr    nc,cfgb_run            ; no file -> KCFG_LEN stays 0
+                ld    hl,(fs_ent_size)        ; file <512 so the low word is the size
+                ld    (KCFG_LEN),hl
+cfgb_run
+                jp    run_cfgmod
+cfg_default     db    "DEFAULT",0,0          ; 9 bytes
+cfg_fname       db    "GEOBENCHCFG"          ; "GEOBENCH.CFG" (8.3)
+
+; run_cfgmod: load GBCFG.BIN into PAGE_APP0 and CALL it (it parses the transfer
+; area). Mirrors launch_app's load path; runs under DI (the module needs no
+; interrupts) with no top-bar/ESC handling - this is boot time.
+run_cfgmod
+                ld    hl,cfgmod_name
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    a,(bank_cur)           ; save the current page
+                push  af
+                di
+                ld    a,PAGE_APP0
+                call  bank_set
+                ld    hl,#3F00
+                ld    (fs_load_max),hl
+                ld    hl,APP_BASE
+                ld    (fs_load_dst),hl
+                call  fs_load_file
+                jr    nc,rcm_done            ; module missing -> keep defaults
+                call  APP_BASE               ; crt0 _start -> main -> gb_cfg_parse
+rcm_done
+                pop   af                       ; restore the caller's page
+                call  bank_set
+                ei
+                ret
+cfgmod_name     db    "GBCFG   BIN"          ; 8.3, space-padded
+
+; name_from_stem: HL = NUL-terminated stem (<=8 chars), DE = 3-char extension.
+; Builds fs_req_name as an 8.3 name (8 chars space-padded + the extension), so a
+; config stem like "CLASSIC" becomes "CLASSIC FNT".
+name_from_stem
+                ld    (nfs_ext),de
+                ld    de,fs_req_name
+                ld    b,8
+nfs_name
+                ld    a,(hl)
+                or    a
+                jr    z,nfs_pad
+                ld    (de),a
+                inc   hl
+                inc   de
+                djnz  nfs_name
+                jr    nfs_doext
+nfs_pad
+                ld    a,' '
+nfs_padl
+                ld    (de),a
+                inc   de
+                djnz  nfs_padl
+nfs_doext
+                ld    hl,(nfs_ext)
+                ld    bc,3
+                ldir
+                ret
+nfs_ext         dw    0
+ext_fnt         db    "FNT"
+ext_ist         db    "IST"
+
 ; --- font in PAGE_DATA ----------------------------------------------------
-; font_init: page PAGE_DATA in, load DEFAULT.FNT into it, cache the geometry.
+; font_init: page PAGE_DATA in, load <FONT>.FNT into it, cache the geometry.
 font_init
                 di
                 ld    a,PAGE_DATA
                 call  bank_set
-                ld    hl,font_name           ; fs_req_name = "DEFAULT FNT"
-                ld    de,fs_req_name
-                ld    bc,11
-                ldir
+                ld    hl,KCFG_FONT           ; fs_req_name = "<FONT>.FNT" (config)
+                ld    de,ext_fnt
+                call  name_from_stem
                 ld    hl,#1000               ; font fits easily
                 ld    (fs_load_max),hl
                 ld    hl,DATA_FONT           ; load into PAGE_DATA
@@ -697,17 +797,15 @@ font_init
                 call  bank_normal
                 ei
                 ret
-font_name       db    "DEFAULT FNT"          ; 8.3, space-padded
 
-; icon_init: load DEFAULT.IST into PAGE_DATA at DATA_ICONS.
+; icon_init: load <ICONS>.IST into PAGE_DATA at DATA_ICONS.
 icon_init
                 di
                 ld    a,PAGE_DATA
                 call  bank_set
-                ld    hl,icon_name           ; fs_req_name = "DEFAULT IST"
-                ld    de,fs_req_name
-                ld    bc,11
-                ldir
+                ld    hl,KCFG_ICONS          ; fs_req_name = "<ICONS>.IST" (config)
+                ld    de,ext_ist
+                call  name_from_stem
                 ld    hl,#0C00               ; .IST <= 3K
                 ld    (fs_load_max),hl
                 ld    hl,DATA_ICONS
@@ -716,7 +814,6 @@ icon_init
                 call  bank_normal
                 ei
                 ret
-icon_name       db    "DEFAULT IST"          ; 8.3, space-padded
 
 ; --- app launch ----------------------------------------------------------
 ; launch_app: HL = 8.3 app name. Load it into the next bank page (PAGE_APP0 +
@@ -1448,6 +1545,8 @@ npd_img         incbin "../build/NOTEPAD.RAW"   ; packaged on the disk as NOTEPA
 npd_imgend
 chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.BIN
 chl_imgend
+cfg_img         incbin "../build/GBCFG.RAW"     ; config-parser C module, as GBCFG.BIN
+cfg_imgend
 font_img        incbin "../build/DEFAULT.FNT"   ; packaged on the disk as DEFAULT.FNT
 font_imgend
 icon_img        incbin "../build/DEFAULT.IST"   ; packaged on the disk as DEFAULT.IST
@@ -1460,6 +1559,7 @@ wel_imgend
                 save  "VIEWER.BIN",vwr_img,vwr_imgend-vwr_img,DSK,"build/gbkern.dsk"
                 save  "NOTEPAD.BIN",npd_img,npd_imgend-npd_img,DSK,"build/gbkern.dsk"
                 save  "CHELLO.BIN",chl_img,chl_imgend-chl_img,DSK,"build/gbkern.dsk"
+                save  "GBCFG.BIN",cfg_img,cfg_imgend-cfg_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.FNT",font_img,font_imgend-font_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.IST",icon_img,icon_imgend-icon_img,DSK,"build/gbkern.dsk"
                 save  "WELCOME.TXT",wel_img,wel_imgend-wel_img,DSK,"build/gbkern.dsk"

--- a/kernel/kc/README.md
+++ b/kernel/kc/README.md
@@ -38,19 +38,38 @@ kernel/kc/run_tests.sh        # host parity tests (no emulator)
 tools/build_kmod.sh kernel/kc/kcfg.c   # SDCC -mz80 + size report
 ```
 
-## Open integration step (next on #30)
+## How it is wired into the kernel
 
-The module compiles and is proven correct; it is **not yet wired into the
-kernel**. Remaining work:
+`kcfg_mod.c` is the loadable wrapper: built by `tools/build_cfgmod.sh` into
+`build/GBCFG.RAW` (crt0 first, so `_start` is at `#4000`), packaged on the disk
+as `GBCFG.BIN`, and loaded into a bank page + `call`ed exactly like an app. No
+inter-bank argument ABI was needed: the module reads/writes a **fixed resident
+transfer area in low RAM** (`#1000` text, `#1200` length, `#1202` ICONS out,
+`#120C` FONT out) which stays main RAM under banking, so `crt0` enters with a
+plain `call _main`.
 
-1. Pick the module's bank/load address and define the inter-bank entry ABI
-   (an asm shim, placed first in the module image, that reads a transfer block —
-   text ptr, length, two resident output ptrs — and calls `gb_cfg_parse`). The
-   output buffers (`cfg_icons`/`cfg_font`) must be **resident** so they survive
-   paging the module back out.
-2. At boot, the nucleus `fs_load_file`s `GEOBENCH.CFG`, pages the module in,
-   calls it, pages back.
-3. Have `font_init`/`icon_init` build the `.FNT`/`.IST` filename from the parsed
-   names (DEFAULT fallback = today's behavior, so default config is no
-   regression), reconnecting the `ICONS=`/`FONT=` keys that went dead when the
-   monolithic desktop was slimmed into the resident kernel.
+Boot flow (`kernel/gbkern.asm`):
+
+1. `cfg_boot` seeds the outputs with `DEFAULT`, `fs_load_file`s `GEOBENCH.CFG`
+   into the transfer area (length 0 if absent), then `run_cfgmod` pages
+   `GBCFG.BIN` into `PAGE_APP0` and calls it — the C parser fills the outputs.
+2. `font_init` / `icon_init` build `<FONT>.FNT` / `<ICONS>.IST` from the parsed
+   stems via `name_from_stem`, so `ICONS=`/`FONT=` select the set loaded (these
+   keys had gone dead when the monolithic desktop was slimmed into the kernel).
+
+Verified three ways in 1984 (`--memory=128`): no cfg → defaults → clean desktop;
+`ICONS=DEFAULT`/`FONT=DEFAULT` → identical (cfg load + parse + filename build all
+correct); `ICONS=NONE` → icons fail to load (the parsed value really selects the
+file). The resident kernel grew 9676 → **9839 bytes** for the boot glue, leaving
+~12 bytes under the `~#A67B` ceiling — proof that *further* migration must move
+logic into modules, not add resident asm.
+
+## Follow-ups
+
+- **DEFAULT fallback** when a configured `.FNT`/`.IST` is missing (today a bad
+  `ICONS=`/`FONT=` value loads nothing and draws garbage). Deferred because the
+  retry costs resident bytes we do not currently have — it pairs with trimming
+  the nucleus.
+- Retire `lib/config.asm` once nothing else references it (it is already
+  orphaned; left in place for this PR to keep the diff to the migration).
+- Next subsystem (directory parsing) follows the same module pattern.

--- a/kernel/kc/README.md
+++ b/kernel/kc/README.md
@@ -1,0 +1,56 @@
+# Kernel C modules
+
+The honest answer to "rewrite the kernel in C" (issue #30): you can't, fully.
+An irreducible **asm nucleus** must stay — the fixed jump table at `#8000`,
+banking / inter-bank trampolines, the hardware/firmware leaf routines, and the
+hot-path compositor. What *can* move to C is the branchy **logic**, and the
+resident region (`#8000`–`~#A67B`) is nearly full (~175 bytes free over the
+9676-byte kernel), so that logic lives in **paged bank modules** the nucleus
+calls through the trampoline — the SymbOS model.
+
+This directory holds those modules. Each is pure logic: no I/O, no firmware
+calls, no globals if avoidable. The nucleus owns memory and devices and hands
+the module pointers.
+
+## Modules
+
+| File | Replaces | Role |
+|------|----------|------|
+| `kcfg.c` | `lib/config.asm` (`cfg_parse`/`cfg_keymatch`/`cfg_copyval`) | Parse `GEOBENCH.CFG` KEY=VALUE text into the `ICONS=`/`FONT=` set names. |
+
+## Why C costs more here
+
+`kcfg.c` is **673 bytes** of Z80 (`tools/build_kmod.sh`); the asm it mirrors is
+~140 bytes. ~4.8× on a small routine — overhead-heavy at this size. That is the
+size argument for banking modules rather than keeping them resident, and the
+reason the migration is per-subsystem, not a big-bang rewrite.
+
+## Verifying the logic
+
+`run_tests.sh` builds `kcfg.c` with the host `cc` and runs `test_kcfg.c`, which
+encodes every behavior of the original asm (defaults, comments, CR/LF vs LF,
+8-char value cap, key-at-line-start only, empty value, repeated keys). The C must
+pass these before the asm is retired — the migration is "prove parity, then
+delete the asm," not "rewrite and hope."
+
+```
+kernel/kc/run_tests.sh        # host parity tests (no emulator)
+tools/build_kmod.sh kernel/kc/kcfg.c   # SDCC -mz80 + size report
+```
+
+## Open integration step (next on #30)
+
+The module compiles and is proven correct; it is **not yet wired into the
+kernel**. Remaining work:
+
+1. Pick the module's bank/load address and define the inter-bank entry ABI
+   (an asm shim, placed first in the module image, that reads a transfer block —
+   text ptr, length, two resident output ptrs — and calls `gb_cfg_parse`). The
+   output buffers (`cfg_icons`/`cfg_font`) must be **resident** so they survive
+   paging the module back out.
+2. At boot, the nucleus `fs_load_file`s `GEOBENCH.CFG`, pages the module in,
+   calls it, pages back.
+3. Have `font_init`/`icon_init` build the `.FNT`/`.IST` filename from the parsed
+   names (DEFAULT fallback = today's behavior, so default config is no
+   regression), reconnecting the `ICONS=`/`FONT=` keys that went dead when the
+   monolithic desktop was slimmed into the resident kernel.

--- a/kernel/kc/kcfg.c
+++ b/kernel/kc/kcfg.c
@@ -1,0 +1,82 @@
+/* kcfg.c - GEOBENCH config parser, the first kernel subsystem ported to C.
+ *
+ * This is a faithful translation of lib/config.asm's cfg_parse/cfg_keymatch/
+ * cfg_copyval. The asm nucleus still does the I/O (fs_load_file of GEOBENCH.CFG)
+ * and seeds the defaults; this module is the branchy text-walking logic, which
+ * is exactly the kind of code that is clearer and safer in C.
+ *
+ * Semantics preserved from the asm, exactly:
+ *   - Lines are separated by CR (13) or LF (10); blank/extra terminators eaten.
+ *   - A '#' at the start of a line is a comment -> the whole line is skipped.
+ *   - A key only matches at the start of a line; the match is case-sensitive and
+ *     includes the '=' ("ICONS=", "FONT="). The value follows immediately.
+ *   - A value is copied up to GB_CFG_VAL_MAX chars, stopping at CR/LF/NUL, and is
+ *     NUL-terminated. Unknown lines are skipped. Absent keys leave the output as
+ *     the caller seeded it (the default).
+ *
+ * No libc, no globals: builds the same for the host test harness (gcc) and for
+ * the CPC (SDCC -mz80).
+ */
+#include "kcfg.h"
+
+static char is_eol(char c)
+{
+    return c == 13 || c == 10;
+}
+
+/* match_key: if the line at [p,e) starts with the NUL-terminated `key`, return a
+ * pointer to the value (just past the key); otherwise return 0. */
+static const char *match_key(const char *p, const char *e, const char *key)
+{
+    while (*key) {
+        if (p >= e || *p != *key)
+            return 0;
+        ++p;
+        ++key;
+    }
+    return p;
+}
+
+/* copy_val: copy the value at [p,e) into dst (max chars), stopping at CR/LF/NUL,
+ * then NUL-terminate dst. */
+static void copy_val(const char *p, const char *e, char *dst, unsigned char max)
+{
+    unsigned char n = 0;
+    while (n < max && p < e) {
+        char c = *p;
+        if (c == 0 || is_eol(c))
+            break;
+        dst[n++] = c;
+        ++p;
+    }
+    dst[n] = 0;
+}
+
+void gb_cfg_parse(const char *buf, unsigned int len,
+                  char *icons_out, char *font_out)
+{
+    const char *p = buf;
+    const char *e = buf + len;
+    const char *v;
+
+    while (p < e) {
+        char c = *p;
+        if (is_eol(c)) {            /* eat line terminators / blank lines */
+            ++p;
+            continue;
+        }
+        if (c == '#') {             /* comment: skip the whole line */
+            while (p < e && !is_eol(*p))
+                ++p;
+            continue;
+        }
+
+        if ((v = match_key(p, e, "ICONS=")) != 0)
+            copy_val(v, e, icons_out, GB_CFG_VAL_MAX);
+        else if ((v = match_key(p, e, "FONT=")) != 0)
+            copy_val(v, e, font_out, GB_CFG_VAL_MAX);
+
+        while (p < e && !is_eol(*p))  /* advance to the end of this line */
+            ++p;
+    }
+}

--- a/kernel/kc/kcfg.h
+++ b/kernel/kc/kcfg.h
@@ -1,0 +1,26 @@
+/* kcfg.h - GEOBENCH config parser (first C kernel module).
+ *
+ * Pure logic, no I/O: the asm nucleus loads GEOBENCH.CFG off disk and owns the
+ * memory; this module just walks the text. See kcfg.c for the semantics it
+ * mirrors from the original lib/config.asm.
+ */
+#ifndef GB_KCFG_H
+#define GB_KCFG_H
+
+/* Filename-stem cap for a parsed value (8.3 -> 8 chars), matching the asm. */
+#define GB_CFG_VAL_MAX 8
+
+/* gb_cfg_parse: walk `len` bytes of KEY=VALUE text at `buf`. For each known key
+ * found at the start of a line, copy its value (up to GB_CFG_VAL_MAX chars,
+ * NUL-terminated) into the matching output buffer. Outputs are left untouched
+ * when their key is absent, so the caller seeds them with defaults first.
+ *
+ *   icons_out  <- ICONS=   (>= GB_CFG_VAL_MAX+1 bytes)
+ *   font_out   <- FONT=    (>= GB_CFG_VAL_MAX+1 bytes)
+ *
+ * '#' at the start of a line is a comment; CR (13) and LF (10) end lines.
+ */
+void gb_cfg_parse(const char *buf, unsigned int len,
+                  char *icons_out, char *font_out);
+
+#endif /* GB_KCFG_H */

--- a/kernel/kc/kcfg_mod.c
+++ b/kernel/kc/kcfg_mod.c
@@ -1,0 +1,28 @@
+/* kcfg_mod.c - loadable wrapper that runs the config parser as a kernel module.
+ *
+ * The kernel loads this image into a bank page at #4000 (like an app) and CALLs
+ * it through crt0's _start. It is the concrete realisation of the asm-nucleus +
+ * paged-C-module design (issue #30): the parser logic runs paged-in, while all
+ * I/O is through a fixed transfer area in low RAM that stays main RAM under
+ * banking (so it is reachable while this code is paged into the window).
+ *
+ * The kernel fills the area before the call and reads it after:
+ *   #1000  cfg text (<=512 bytes, the GEOBENCH.CFG contents)
+ *   #1200  length   (word: number of cfg-text bytes; 0 = no file)
+ *   #1202  ICONS out (9 bytes, seeded with the default, NUL-terminated)
+ *   #120C  FONT  out (9 bytes, seeded with the default, NUL-terminated)
+ *
+ * Using fixed addresses (not function args) means crt0 can enter with a plain
+ * `call _main` - no inter-bank argument-passing ABI to hand-roll in asm.
+ */
+#include "kcfg.h"
+
+#define KCFG_TEXT   ((const char *)0x1000)
+#define KCFG_LEN    (*(unsigned int *)0x1200)
+#define KCFG_ICONS  ((char *)0x1202)
+#define KCFG_FONT   ((char *)0x120C)
+
+void main(void)
+{
+    gb_cfg_parse(KCFG_TEXT, KCFG_LEN, KCFG_ICONS, KCFG_FONT);
+}

--- a/kernel/kc/run_tests.sh
+++ b/kernel/kc/run_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Host parity tests for the C config parser (kernel/kc/kcfg.c). Builds with the
+# host cc and runs the test harness; pure logic, no CPC/emulator needed.
+#   kernel/kc/run_tests.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CC="${CC:-cc}"
+out="$(mktemp -d)/test_kcfg"
+"$CC" -Wall -Wextra -std=c99 -o "$out" test_kcfg.c kcfg.c
+"$out"

--- a/kernel/kc/test_kcfg.c
+++ b/kernel/kc/test_kcfg.c
@@ -1,0 +1,58 @@
+/* test_kcfg.c - host (gcc) parity tests for the C config parser.
+ *
+ * Every case here encodes a behavior of the original lib/config.asm so we can be
+ * sure the C port is byte-for-byte equivalent before the asm is retired. Build
+ * and run with kernel/kc/run_tests.sh.
+ */
+#include <stdio.h>
+#include <string.h>
+#include "kcfg.h"
+
+static int failures = 0;
+
+/* Seed defaults like the asm cfg_load does, parse, and check both outputs. */
+static void check(const char *name, const char *cfg, unsigned int len,
+                  const char *want_icons, const char *want_font)
+{
+    char icons[GB_CFG_VAL_MAX + 1];
+    char font[GB_CFG_VAL_MAX + 1];
+    strcpy(icons, "DEFAULT");
+    strcpy(font, "DEFAULT");
+
+    gb_cfg_parse(cfg, len, icons, font);
+
+    if (strcmp(icons, want_icons) != 0 || strcmp(font, want_font) != 0) {
+        printf("FAIL %-28s icons=\"%s\" (want \"%s\")  font=\"%s\" (want \"%s\")\n",
+               name, icons, want_icons, font, want_font);
+        ++failures;
+    } else {
+        printf("ok   %-28s icons=\"%s\" font=\"%s\"\n", name, icons, font);
+    }
+}
+
+#define CHECK(name, lit, wi, wf) check((name), (lit), (unsigned)sizeof(lit) - 1, (wi), (wf))
+
+int main(void)
+{
+    CHECK("empty",                 "",                              "DEFAULT", "DEFAULT");
+    CHECK("comment only",          "# just a comment\r\n",          "DEFAULT", "DEFAULT");
+    CHECK("both keys crlf",        "ICONS=CLASSIC\r\nFONT=BIG\r\n", "CLASSIC", "BIG");
+    CHECK("lf only endings",       "ICONS=MONO\nFONT=TINY\n",       "MONO",    "TINY");
+    CHECK("no trailing newline",   "ICONS=MONO",                    "MONO",    "DEFAULT");
+    CHECK("8 char cap",            "ICONS=ABCDEFGHIJK\r\n",         "ABCDEFGH","DEFAULT");
+    CHECK("comment then key",      "# hi\r\nFONT=TINY\r\n",         "DEFAULT", "TINY");
+    CHECK("unknown key ignored",   "FOO=BAR\r\nICONS=X\r\n",        "X",       "DEFAULT");
+    CHECK("key not at line start", "X ICONS=NO\r\n",                "DEFAULT", "DEFAULT");
+    CHECK("empty value",           "ICONS=\r\n",                    "",        "DEFAULT");
+    CHECK("blank lines",           "\r\n\r\nFONT=Z\r\n",            "DEFAULT", "Z");
+    CHECK("repeated key last wins","ICONS=A\r\nICONS=B\r\n",        "B",       "DEFAULT");
+    CHECK("font then icons",       "FONT=F1\r\nICONS=I1\r\n",       "I1",      "F1");
+    CHECK("crlf mixed with lf",    "ICONS=AA\nFONT=BB\r\n",         "AA",      "BB");
+
+    if (failures) {
+        printf("\n%d test(s) FAILED\n", failures);
+        return 1;
+    }
+    printf("\nall tests passed\n");
+    return 0;
+}

--- a/tools/build_cfgmod.sh
+++ b/tools/build_cfgmod.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Build the GBCFG kernel module: the config parser as a loadable #4000 image the
+# kernel pages into a bank and CALLs at boot (issue #30). Same image format as
+# the C apps (crt0 first -> _start at #4000), but linked without libgb - the
+# module reaches nothing in the kernel, it only reads/writes the low-RAM transfer
+# area (see kernel/kc/kcfg_mod.c).
+#
+#   tools/build_cfgmod.sh [out.RAW]      (default build/GBCFG.RAW)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+OUT="${1:-build/GBCFG.RAW}"
+GB="lib/gb"
+KC="kernel/kc"
+
+SDCC="${SDCC:-sdcc}"
+BIN="$(dirname "$(command -v "$SDCC")")"
+SDAS="$BIN/sdasz80"
+MAKEBIN="$BIN/makebin"
+
+work="build/cfgmod"
+mkdir -p "$work"
+
+"$SDAS" -o "$work/crt0.rel" "$GB/crt0.s"
+# --fomit-frame-pointer to match the app/kernel IX convention (the parser does
+# not care, but keep the toolchain flags uniform across all GEOBENCH C).
+"$SDCC" -mz80 --fomit-frame-pointer -I "$KC" -c "$KC/kcfg_mod.c" -o "$work/kcfg_mod.rel"
+"$SDCC" -mz80 --fomit-frame-pointer -I "$KC" -c "$KC/kcfg.c"     -o "$work/kcfg.rel"
+"$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x6000 \
+    "$work/crt0.rel" "$work/kcfg_mod.rel" "$work/kcfg.rel" -o "$work/mod.ihx"
+"$MAKEBIN" -p "$work/mod.ihx" "$work/mod.bin"
+
+# makebin emits from #0000; the module lives at #4000 -> strip the low 16K.
+tail -c +16385 "$work/mod.bin" > "$OUT"
+echo "Built $OUT ($(stat -c%s "$OUT") bytes)"

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -23,5 +23,6 @@ tools/build_capp.sh apps/filemgr build/FILEMGR.RAW # FILEMGR (C/SDCC) -> build/F
 tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VIEWER.RAW
 tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD (C/SDCC) -> build/NOTEPAD.RAW
 tools/build_capp.sh apps/chello build/CHELLO.RAW   # C app (SDCC) -> build/CHELLO.RAW
+tools/build_cfgmod.sh build/GBCFG.RAW              # config-parser C kernel module -> build/GBCFG.RAW
 "$RASM" kernel/gbkern.asm -eo                # incbins apps + font + icons -> .dsk
 echo "Built build/gbkern.dsk (GBKERN + DESKTOP + FILEMGR + VIEWER + NOTEPAD + CHELLO + assets)"

--- a/tools/build_kmod.sh
+++ b/tools/build_kmod.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Build a GEOBENCH kernel C module (SDCC -mz80) and report its code size.
+#
+# Kernel modules are the SymbOS-style answer to "kernel in C": the resident asm
+# nucleus (jump table, banking, hardware leaves) stays asm, and branchy *logic*
+# moves into C modules that live in a paged bank and are called through the
+# inter-bank trampoline. We measure code size because the resident region
+# (#8000..~#A67B) is nearly full, so modules must be banked, not resident.
+#
+#   tools/build_kmod.sh kernel/kc/kcfg.c   -> build/kc/kcfg.rel + size report
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SRC="${1:-kernel/kc/kcfg.c}"
+SDCC="${SDCC:-sdcc}"
+work="build/kc"
+mkdir -p "$work"
+
+base="$(basename "${SRC%.c}")"
+rel="$work/$base.rel"
+
+# --fomit-frame-pointer: frame on IY, matching the app build (the kernel uses IX
+# as scratch). The module is pure logic -> expect _DATA/_INITIALIZER = 0.
+"$SDCC" -mz80 --fomit-frame-pointer -I "$(dirname "$SRC")" -c "$SRC" -o "$rel"
+
+code_hex="$(awk '/^A _CODE size/ {print $4; exit}' "$rel")"
+data_hex="$(awk '/^A _DATA size/ {print $4; exit}' "$rel")"
+init_hex="$(awk '/^A _INITIALIZER size/ {print $4; exit}' "$rel")"
+printf 'built %s\n  _CODE        = %5d bytes (0x%s)\n  _DATA        = %5d bytes\n  _INITIALIZER = %5d bytes\n' \
+    "$rel" "$((16#${code_hex:-0}))" "${code_hex:-0}" "$((16#${data_hex:-0}))" "$((16#${init_hex:-0}))"


### PR DESCRIPTION
Implements the first slice of #30: an **asm-nucleus + paged-C-module** kernel, end to end.

## What it does
The config parser (`GEOBENCH.CFG` KEY=VALUE) is rewritten as a C kernel module and **wired into boot**. The `ICONS=`/`FONT=` keys — dead since the monolithic desktop was slimmed into the resident kernel — select the loaded icon/font set again.

## Why not "rewrite the kernel in C" (measured)
- Resident region `#8000`–`~#A67B` = 9851 bytes; kernel was **9676** (~175 free).
- The parser is **673 bytes** of Z80 (~140 in asm) → cannot be resident.

So it is a **paged bank module** called via the app-load path — not a resident rewrite. After adding the boot glue the kernel is **9839 bytes**, ~12 under the ceiling: hard proof that further migration must move logic *out* to modules, not add resident asm.

## How it is wired
- `kernel/kc/kcfg.{c,h}` — the parser (no globals; `_DATA`/`_INITIALIZER` = 0).
- `kernel/kc/kcfg_mod.c` + `tools/build_cfgmod.sh` — built (crt0 first → `_start` at `#4000`) into `build/GBCFG.RAW`, packaged as `GBCFG.BIN`, loaded into a bank page and `call`ed like an app.
- **No inter-bank arg ABI**: the module reads/writes a fixed resident transfer area in low RAM (`#1000` text / `#1200` len / `#1202` ICONS / `#120C` FONT), which stays main RAM under banking, so `crt0` just `call _main`s.
- `kernel/gbkern.asm`: `cfg_boot` seeds DEFAULT + loads `GEOBENCH.CFG`; `run_cfgmod` pages the module in and calls it; `font_init`/`icon_init` build `<FONT>.FNT`/`<ICONS>.IST` from the parsed stems via `name_from_stem`.

## Verification
Host parity tests (`kernel/kc/run_tests.sh`) — **14/14**, every asm behavior.
Boot in 1984 `--memory=128`, three ways:
- no cfg → defaults → clean desktop (new path works);
- `ICONS=DEFAULT`/`FONT=DEFAULT` → identical (cfg load + parse + filename build all correct);
- `ICONS=NONE` → icons fail to load (the parsed value really drives the filename).

## Follow-ups
- DEFAULT fallback when a configured `.FNT`/`.IST` is missing (costs resident bytes we lack → pairs with trimming the nucleus).
- Retire the now-orphaned `lib/config.asm`.
- Next subsystem (directory parsing) follows the same module pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)