### PR TITLE
Typed-message + callback API, funded by shrinking the kernel (#32)

### DIFF
--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -97,11 +97,28 @@ static void drop(void)
     paint();
 }
 
+/* on_event: kernel callback (issue #32). Fires when the user clicks the
+   kernel-owned top bar; proves the kernel->app round-trip by showing the
+   message payload (the clicked column) in the hint line. */
+static void on_event(void)
+{
+    static char msg[] = "Top-bar click @ col 00";
+    unsigned char c;
+    if (gb_msg.type != GB_MSG_MENU) return;
+    c = gb_msg.p0;
+    msg[20] = "0123456789ABCDEF"[c >> 4];
+    msg[21] = "0123456789ABCDEF"[c & 15];
+    gb_curhide();
+    gb_text(1, 10, msg);
+    gb_curshow();
+}
+
 void main(void)
 {
     unsigned char flags, mx, my, held, icon;
 
     paint();
+    gb_on_event(on_event);                     /* top-bar clicks -> on_event */
     drag_active = 0;
     dc_timer = 0;
     held_prev = 0;

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -21,8 +21,14 @@
 ; module, then reads the parsed ICONS=/FONT= stems back. See kernel/kc/.
 KCFG_TEXT       equ   #1000        ; GEOBENCH.CFG contents (<=512 bytes)
 KCFG_LEN        equ   #1200        ; word: cfg-text byte count (0 = no file)
-KCFG_ICONS      equ   #1202        ; 9 bytes: parsed icon-set stem (NUL-term)
-KCFG_FONT       equ   #120C        ; 9 bytes: parsed font-set stem (NUL-term)
+KCFG_ICONNAME   equ   #1202        ; 11-byte 8.3 icon filename, built by the module
+KCFG_FONTNAME   equ   #120D        ; 11-byte 8.3 font filename, built by the module
+
+; Callback API (issue #32) - kernel->app event delivery, state in low RAM so it
+; costs no resident image bytes (low RAM stays main RAM under banking).
+APP_HANDLER     equ   #1300        ; word: registered app event handler (0 = none)
+GB_MSG          equ   #1302        ; message record: type, p0, p1, p2 (4 bytes)
+GB_MSG_MENU     equ   1            ; message type: top-bar click, p0 = byte column
 
                 org   GB_KERNEL
 ; --- fixed API jump table (order is the ABI; see lib/gbapp.inc) -----------
@@ -51,6 +57,7 @@ KCFG_FONT       equ   #120C        ; 9 bytes: parsed font-set stem (NUL-term)
                 jp    k_fssave               ; GB_FSSAVE      #8042
                 jp    k_getkey               ; GB_GETKEY      #8045
                 jp    k_vsync                ; GB_VSYNC       #8048
+                jp    k_onevent              ; GB_ONEVENT     #804B
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -176,6 +183,7 @@ gp_noquit
                 jr    z,gp_nohold
                 set   2,d
 gp_nohold
+                call  menu_dispatch          ; kernel-owned top-bar click -> app
                 ld    a,(poll_byte)
                 ld    b,a
                 ld    a,(poll_line)
@@ -341,13 +349,8 @@ gf_pen          db    0
 k_cls
                 ld    a,1
                 jp    SCR_SET_MODE            ; mode 1 clears; returns to caller
-k_print
-                ld    a,(hl)
-                or    a
-                ret   z
-                call  TXT_OUTPUT
-                inc   hl
-                jr    k_print
+k_print                                        ; GB_PRINT: stub (unused early debug
+                ret                            ; print; no binding). Slot kept fixed.
 k_quit
                 ret                            ; (skeleton: app RETs anyway)
 
@@ -693,16 +696,8 @@ name_geobench   db    "GEOBENCH"
 ; GBCFG C module (paged into a bank) to parse it into KCFG_ICONS / KCFG_FONT.
 ; Absent file -> length 0 -> the parser is a no-op and the defaults stand.
 cfg_boot
-                ld    hl,cfg_default         ; KCFG_ICONS = "DEFAULT"
-                ld    de,KCFG_ICONS
-                ld    bc,9
-                ldir
-                ld    hl,cfg_default         ; KCFG_FONT  = "DEFAULT"
-                ld    de,KCFG_FONT
-                ld    bc,9
-                ldir
-                ld    hl,0                    ; default: no config text
-                ld    (KCFG_LEN),hl
+                ld    hl,0                    ; default: no config text (module then
+                ld    (KCFG_LEN),hl           ; emits the DEFAULT names itself)
                 ld    hl,cfg_fname           ; fs_req_name = "GEOBENCH.CFG"
                 ld    de,fs_req_name
                 ld    bc,11
@@ -717,7 +712,6 @@ cfg_boot
                 ld    (KCFG_LEN),hl
 cfgb_run
                 jp    run_cfgmod
-cfg_default     db    "DEFAULT",0,0          ; 9 bytes
 cfg_fname       db    "GEOBENCHCFG"          ; "GEOBENCH.CFG" (8.3)
 
 ; run_cfgmod: load GBCFG.BIN into PAGE_APP0 and CALL it (it parses the transfer
@@ -747,46 +741,17 @@ rcm_done
                 ret
 cfgmod_name     db    "GBCFG   BIN"          ; 8.3, space-padded
 
-; name_from_stem: HL = NUL-terminated stem (<=8 chars), DE = 3-char extension.
-; Builds fs_req_name as an 8.3 name (8 chars space-padded + the extension), so a
-; config stem like "CLASSIC" becomes "CLASSIC FNT".
-name_from_stem
-                ld    (nfs_ext),de
-                ld    de,fs_req_name
-                ld    b,8
-nfs_name
-                ld    a,(hl)
-                or    a
-                jr    z,nfs_pad
-                ld    (de),a
-                inc   hl
-                inc   de
-                djnz  nfs_name
-                jr    nfs_doext
-nfs_pad
-                ld    a,' '
-nfs_padl
-                ld    (de),a
-                inc   de
-                djnz  nfs_padl
-nfs_doext
-                ld    hl,(nfs_ext)
-                ld    bc,3
-                ldir
-                ret
-nfs_ext         dw    0
-ext_fnt         db    "FNT"
-ext_ist         db    "IST"
-
 ; --- font in PAGE_DATA ----------------------------------------------------
 ; font_init: page PAGE_DATA in, load <FONT>.FNT into it, cache the geometry.
+; The 8.3 filename was built by the GBCFG module (KCFG_FONTNAME); just copy it.
 font_init
                 di
                 ld    a,PAGE_DATA
                 call  bank_set
-                ld    hl,KCFG_FONT           ; fs_req_name = "<FONT>.FNT" (config)
-                ld    de,ext_fnt
-                call  name_from_stem
+                ld    hl,KCFG_FONTNAME       ; fs_req_name = the config font name
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
                 ld    hl,#1000               ; font fits easily
                 ld    (fs_load_max),hl
                 ld    hl,DATA_FONT           ; load into PAGE_DATA
@@ -803,9 +768,10 @@ icon_init
                 di
                 ld    a,PAGE_DATA
                 call  bank_set
-                ld    hl,KCFG_ICONS          ; fs_req_name = "<ICONS>.IST" (config)
-                ld    de,ext_ist
-                call  name_from_stem
+                ld    hl,KCFG_ICONNAME       ; fs_req_name = the config icon name
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
                 ld    hl,#0C00               ; .IST <= 3K
                 ld    (fs_load_max),hl
                 ld    hl,DATA_ICONS
@@ -831,6 +797,10 @@ launch_app
                 ld    c,a
                 ld    a,(bank_cur)           ; save caller's page (per depth) on stack
                 push  af
+                ld    hl,(APP_HANDLER)       ; save the parent's event handler and clear
+                push  hl                       ; it, so a top-bar click during the child
+                ld    hl,0                     ; cannot call the parent's handler (whose
+                ld    (APP_HANDLER),hl        ; page is not mapped while the child runs)
                 ld    hl,launch_depth
                 inc   (hl)
                 di
@@ -848,6 +818,8 @@ launch_app
 la_done
                 ld    hl,launch_depth
                 dec   (hl)
+                pop   hl                       ; restore the parent's event handler
+                ld    (APP_HANDLER),hl
                 pop   af                       ; caller's page
                 call  bank_set
                 call  draw_topbar             ; the app may have wiped it (e.g. a C
@@ -935,6 +907,38 @@ k_vsync
                 ret   z
                 inc   a
                 ret
+
+; k_onevent (GB_ONEVENT): register the calling app's event handler. HL = handler
+; address (a void(void) C function in the app's page), 0 to unregister. The
+; kernel calls it from menu_dispatch with a message in GB_MSG.
+k_onevent
+                ld    (APP_HANDLER),hl
+                ret
+
+; menu_dispatch: called from k_poll. If a fresh click (D bit0) landed in the
+; kernel-owned top bar and the app registered a handler, deliver a GB_MSG_MENU
+; message (p0 = byte column) and consume the click. The app's page is mapped
+; (it called GB_POLL), so the handler is a direct CALL - no bank trampoline.
+menu_dispatch
+                bit   0,d                     ; fresh click this frame?
+                ret   z
+                ld    a,(poll_line)
+                cp    8                        ; inside the 8px top bar (rows 0..7)?
+                ret   nc
+                ld    hl,(APP_HANDLER)        ; handler registered?
+                ld    a,h
+                or    l
+                ret   z
+                res   0,d                      ; consume the click (the app's poll
+                ld    a,GB_MSG_MENU            ; loop won't also see it)
+                ld    (GB_MSG),a
+                ld    a,(poll_byte)
+                ld    (GB_MSG+1),a            ; p0 = clicked byte column
+                push  de                       ; preserve the poll flags across the
+                call  md_call                  ; C handler (call (hl))
+                pop   de
+                ret
+md_call         jp    (hl)
 
 ; app_for_ext: HL = the app for fs_ent_name's type. Walks app_table: each entry
 ; is a 3-char extension + an 11-char 8.3 app name; a 0 ends the table -> default.
@@ -1040,105 +1044,19 @@ kf_pen          db    0
 ; screen rectangle to/from a caller buffer. B=x C=y D=w E=h HL=buffer (w*h
 ; bytes). The buffer lives in the caller's page (mapped during the call); the
 ; screen is resident, so no page swap is needed.
+; k_saverect / k_restorerect (GB_SAVERECT / GB_RESTORERECT): stubs. No app uses
+; them and there is no gb_saverect/gb_restorerect binding; bodies removed to
+; reclaim resident space. Slots kept so addresses are fixed. (save_block /
+; restore_block remain - the cursor save-under still uses them.)
 k_saverect
-                call  set_sb
-                jp    save_block
 k_restorerect
-                call  set_sb
-                jp    restore_block
-set_sb
-                ld    a,b
-                ld    (sb_x),a
-                ld    a,c
-                ld    (sb_y),a
-                ld    a,d
-                ld    (sb_w),a
-                ld    a,e
-                ld    (sb_h),a
-                ld    (sb_buf),hl
                 ret
 
-; k_xorframe (GB_XORFRAME): XOR a 1px rectangle outline into the screen. B=x
-; C=y D=w E=h. Self-erasing rubber-band: call again at the same spot to undo.
+; k_xorframe (GB_XORFRAME): stub. The rubber-band XOR frame was never wired up
+; (no app uses it, no gb_xorframe binding); body removed to reclaim resident
+; space for the callback API. The jump-table slot stays so addresses are fixed.
 k_xorframe
-                ld    a,b
-                ld    (xf_x),a
-                ld    a,c
-                ld    (xf_y),a
-                ld    a,d
-                ld    (xf_w),a
-                ld    a,e
-                ld    (xf_h),a
-                ld    a,(xf_x)               ; top edge
-                ld    d,a
-                ld    a,(xf_y)
-                ld    e,a
-                ld    a,(xf_w)
-                ld    b,a
-                call  xf_hline
-                ld    a,(xf_x)               ; bottom edge (y+h-1)
-                ld    d,a
-                ld    a,(xf_y)
-                ld    b,a
-                ld    a,(xf_h)
-                add   a,b
-                dec   a
-                ld    e,a
-                ld    a,(xf_w)
-                ld    b,a
-                call  xf_hline
-                ld    a,(xf_x)               ; left edge
-                ld    d,a
-                ld    a,(xf_y)
-                ld    e,a
-                ld    a,(xf_h)
-                ld    b,a
-                call  xf_vline
-                ld    a,(xf_x)               ; right edge (x+w-1)
-                ld    b,a
-                ld    a,(xf_w)
-                add   a,b
-                dec   a
-                ld    d,a
-                ld    a,(xf_y)
-                ld    e,a
-                ld    a,(xf_h)
-                ld    b,a
-                jp    xf_vline
-xf_hline                                       ; D=x E=y B=count -> XOR a row of bytes
-                ld    a,b
-                ld    (xf_cnt),a
-                call  scr_addr
-                ld    a,(xf_cnt)
-                ld    b,a
-xfh_loop
-                ld    a,(hl)
-                xor   #FF
-                ld    (hl),a
-                inc   hl
-                djnz  xfh_loop
                 ret
-xf_vline                                       ; D=x E=y B=rows -> XOR a column
-                ld    a,b
-                ld    (xf_cnt),a
-xfv_loop
-                push  de
-                call  scr_addr
-                ld    a,(hl)
-                xor   #FF
-                ld    (hl),a
-                pop   de
-                inc   e
-                ld    a,(xf_cnt)
-                dec   a
-                ld    (xf_cnt),a
-                jr    nz,xfv_loop
-                ret
-xf_x            db    0
-xf_y            db    0
-xf_w            db    0
-xf_h            db    0
-xf_cnt          db    0
 
 ; ===========================================================================
 ; Top bar (kernel-owned): total RAM (left) + clock (right) on lines 0-7. The

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -756,12 +756,28 @@ font_init
                 ld    (fs_load_max),hl
                 ld    hl,DATA_FONT           ; load into PAGE_DATA
                 ld    (fs_load_dst),hl
-                call  fs_load_file
+                ld    hl,def_fnt             ; fall back to DEFAULT.FNT if missing
+                call  load_or_default
                 ld    hl,DATA_FONT           ; cache geometry (font_glyphs -> PAGE_DATA)
                 call  font_apply_header
                 call  bank_normal
                 ei
                 ret
+def_fnt         db    "DEFAULT FNT"
+def_ist         db    "DEFAULT IST"
+
+; load_or_default: fs_req_name holds the wanted 8.3 name and fs_load_dst/max are
+; set. Try it; if the file is missing (a bad ICONS=/FONT= value), retry with the
+; 11-byte default name at HL so a typo can't leave the screen drawing garbage.
+load_or_default                                ; HL = default 8.3 name (11 bytes)
+                push  hl
+                call  fs_load_file
+                pop   hl
+                ret   c                         ; wanted file loaded
+                ld    de,fs_req_name           ; missing -> use the default name
+                ld    bc,11
+                ldir
+                jp    fs_load_file              ; (dst/max unchanged by the miss)
 
 ; icon_init: load <ICONS>.IST into PAGE_DATA at DATA_ICONS.
 icon_init
@@ -776,7 +792,8 @@ icon_init
                 ld    (fs_load_max),hl
                 ld    hl,DATA_ICONS
                 ld    (fs_load_dst),hl
-                call  fs_load_file
+                ld    hl,def_ist             ; fall back to DEFAULT.IST if missing
+                call  load_or_default
                 call  bank_normal
                 ei
                 ret

--- a/kernel/kc/kcfg.c
+++ b/kernel/kc/kcfg.c
@@ -52,6 +52,20 @@ static void copy_val(const char *p, const char *e, char *dst, unsigned char max)
     dst[n] = 0;
 }
 
+void gb_make_83(const char *stem, const char *ext, char *dst)
+{
+    unsigned char i = 0;
+    while (i < 8 && stem[i]) {       /* copy the stem, up to 8 chars */
+        dst[i] = stem[i];
+        ++i;
+    }
+    while (i < 8)                     /* space-pad the name field */
+        dst[i++] = ' ';
+    dst[8]  = ext[0];                 /* 3-char extension */
+    dst[9]  = ext[1];
+    dst[10] = ext[2];
+}
+
 void gb_cfg_parse(const char *buf, unsigned int len,
                   char *icons_out, char *font_out)
 {

--- a/kernel/kc/kcfg.h
+++ b/kernel/kc/kcfg.h
@@ -23,4 +23,10 @@
 void gb_cfg_parse(const char *buf, unsigned int len,
                   char *icons_out, char *font_out);
 
+/* gb_make_83: write an 11-byte AMSDOS 8.3 name into dst (8 chars space-padded +
+ * the 3-char extension) from a NUL-terminated stem (<=8 chars used) and ext.
+ * e.g. stem "CLASSIC", ext "FNT" -> "CLASSIC FNT". This moves the filename
+ * building off the (full) resident kernel and into the paged C module. */
+void gb_make_83(const char *stem, const char *ext, char *dst);
+
 #endif /* GB_KCFG_H */

--- a/kernel/kc/kcfg_mod.c
+++ b/kernel/kc/kcfg_mod.c
@@ -6,23 +6,38 @@
  * I/O is through a fixed transfer area in low RAM that stays main RAM under
  * banking (so it is reachable while this code is paged into the window).
  *
- * The kernel fills the area before the call and reads it after:
+ * The module owns the whole config-to-filename job (defaults, parse, 8.3 build),
+ * so the resident kernel only has to `ldir` the finished names. The kernel fills
+ * the input before the call and reads the outputs after:
  *   #1000  cfg text (<=512 bytes, the GEOBENCH.CFG contents)
  *   #1200  length   (word: number of cfg-text bytes; 0 = no file)
- *   #1202  ICONS out (9 bytes, seeded with the default, NUL-terminated)
- *   #120C  FONT  out (9 bytes, seeded with the default, NUL-terminated)
+ *   #1202  ICONS filename out (11-byte 8.3, e.g. "DEFAULT IST")
+ *   #120D  FONT  filename out (11-byte 8.3, e.g. "DEFAULT FNT")
  *
  * Using fixed addresses (not function args) means crt0 can enter with a plain
  * `call _main` - no inter-bank argument-passing ABI to hand-roll in asm.
  */
 #include "kcfg.h"
 
-#define KCFG_TEXT   ((const char *)0x1000)
-#define KCFG_LEN    (*(unsigned int *)0x1200)
-#define KCFG_ICONS  ((char *)0x1202)
-#define KCFG_FONT   ((char *)0x120C)
+#define KCFG_TEXT      ((const char *)0x1000)
+#define KCFG_LEN       (*(unsigned int *)0x1200)
+#define KCFG_ICONNAME  ((char *)0x1202)
+#define KCFG_FONTNAME  ((char *)0x120D)
+
+static void set_default(char *stem)     /* "DEFAULT" + NUL */
+{
+    stem[0] = 'D'; stem[1] = 'E'; stem[2] = 'F'; stem[3] = 'A';
+    stem[4] = 'U'; stem[5] = 'L'; stem[6] = 'T'; stem[7] = 0;
+}
 
 void main(void)
 {
-    gb_cfg_parse(KCFG_TEXT, KCFG_LEN, KCFG_ICONS, KCFG_FONT);
+    char icons[9];
+    char font[9];
+
+    set_default(icons);                 /* absent keys keep the default */
+    set_default(font);
+    gb_cfg_parse(KCFG_TEXT, KCFG_LEN, icons, font);
+    gb_make_83(icons, "IST", KCFG_ICONNAME);
+    gb_make_83(font,  "FNT", KCFG_FONTNAME);
 }

--- a/kernel/kc/test_kcfg.c
+++ b/kernel/kc/test_kcfg.c
@@ -32,6 +32,21 @@ static void check(const char *name, const char *cfg, unsigned int len,
 
 #define CHECK(name, lit, wi, wf) check((name), (lit), (unsigned)sizeof(lit) - 1, (wi), (wf))
 
+/* gb_make_83 builds an 11-byte 8.3 name; compare against an explicit literal
+ * (which includes the space padding). */
+static void check83(const char *name, const char *stem, const char *ext,
+                    const char *want11)
+{
+    char dst[11];
+    gb_make_83(stem, ext, dst);
+    if (memcmp(dst, want11, 11) != 0) {
+        printf("FAIL %-28s got=\"%.11s\" want=\"%.11s\"\n", name, dst, want11);
+        ++failures;
+    } else {
+        printf("ok   %-28s \"%.11s\"\n", name, dst);
+    }
+}
+
 int main(void)
 {
     CHECK("empty",                 "",                              "DEFAULT", "DEFAULT");
@@ -48,6 +63,11 @@ int main(void)
     CHECK("repeated key last wins","ICONS=A\r\nICONS=B\r\n",        "B",       "DEFAULT");
     CHECK("font then icons",       "FONT=F1\r\nICONS=I1\r\n",       "I1",      "F1");
     CHECK("crlf mixed with lf",    "ICONS=AA\nFONT=BB\r\n",         "AA",      "BB");
+
+    check83("make83 default",  "DEFAULT", "FNT", "DEFAULT FNT");
+    check83("make83 short",    "AA",      "IST", "AA      IST");
+    check83("make83 full 8",   "ABCDEFGH","FNT", "ABCDEFGHFNT");
+    check83("make83 empty",    "",        "IST", "        IST");
 
     if (failures) {
         printf("\n%d test(s) FAILED\n", failures);

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -39,4 +39,19 @@ unsigned char gb_fs_save(char *buf, unsigned int len);   /* save opened file -> 
                                                          /* 1 ok / 0 fail         */
 unsigned char gb_getkey(void);        /* typed char from the keyboard, 0 if none  */
 unsigned char gb_vsync(void);         /* wait one frame -> 1 if ESC held, else 0  */
+
+/* Event callback (issue #32): the kernel calls a registered handler when an
+ * event it owns occurs - currently a click in the top bar (GB_MSG_MENU). The
+ * handler is invoked during gb_poll (so call gb_poll in your loop), reads the
+ * message from gb_msg, and must return promptly (do not call gb_poll from it).
+ * The message lives at a fixed low-RAM address shared with the kernel. */
+typedef struct {
+    unsigned char type;   /* GB_MSG_* */
+    unsigned char p0;     /* menu: clicked byte column */
+    unsigned char p1;
+    unsigned char p2;
+} gb_msg_t;
+#define GB_MSG_MENU 1
+#define gb_msg (*(volatile gb_msg_t *)0x1302)
+void gb_on_event(void (*handler)(void));   /* register handler, 0 to clear */
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -28,6 +28,7 @@
         .globl  _gb_fs_save
         .globl  _gb_getkey
         .globl  _gb_vsync
+        .globl  _gb_on_event
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -188,3 +189,7 @@ _gb_getkey:
 ;; void gb_vsync(void);   wait one frame (50 Hz), no pointer/clock side effects
 _gb_vsync:
         jp      0x8048          ; GB_VSYNC
+
+;; void gb_on_event(void (*handler)(void));   handler ptr in HL -> kernel stores it
+_gb_on_event:
+        jp      0x804B          ; GB_ONEVENT

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -86,3 +86,10 @@ GB_VSYNC        equ   GB_KERNEL+72 ; #8048  wait for the frame flyback (50 Hz pa
                                    ;        no pointer/clock) -> A = 1 if ESC is held
                                    ;        else 0. For keyboard apps that drive
                                    ;        their own loop instead of GB_POLL.
+GB_ONEVENT      equ   GB_KERNEL+75 ; #804B  register an event handler: HL = address
+                                   ;        of a void(void) function in the app, 0 to
+                                   ;        clear. The kernel CALLs it during GB_POLL
+                                   ;        when a top-bar click occurs, with a typed
+                                   ;        message at GB_MSG (#1302): type, p0, p1,
+                                   ;        p2. type GB_MSG_MENU(1) -> p0 = byte col.
+                                   ;        Handler must return promptly (no GB_POLL).


### PR DESCRIPTION
Implements #32: kernel→app event delivery (the missing up-call direction), funded by shrinking the resident kernel — which was at **~12 bytes free** under HIMEM.

## Why a callback API (not a bus)
GEOBENCH is cooperative and single-app-at-a-time (apps nest synchronously). There's no concurrency to carry, so this is a **callback API**, shaped so a queue/bus could grow from it later. Menu dispatch (`gb_menu_set`) is the driver.

## Shrink (~244 bytes) — the funding
- **Stub three verified-dead routines** to a bare `ret`, keeping their jump-table slots so every API address stays fixed (zero ABI risk): `k_xorframe` (+ `xf_*` helpers/data), `k_saverect`/`k_restorerect` (+ `set_sb`), `k_print`. None had a libgb binding or any caller.
- **Move 8.3-filename building** out of the kernel (`name_from_stem`) into the GBCFG C module — it now emits the full `"DEFAULT FNT"`/`"DEFAULT IST"` names (new `gb_make_83`, host-tested), so `font_init`/`icon_init` just `ldir` the finished name. On-thesis (logic → C module).

## Callback API
- New jump-table entry **`GB_ONEVENT` (#804B)**: an app registers a `void(void)` handler.
- **`menu_dispatch`** (in `k_poll`): on a fresh click in the kernel-owned top bar (rows 0–7) with a handler registered, write a typed message (`gb_msg` at `#1302`: `type,p0,p1,p2`) and `call` the handler. The app's page is already mapped during `GB_POLL`, so it's a direct call — **no bank trampoline**. The click is consumed.
- **Nesting**: `launch_app` saves/clears/restores the handler around a child, so a parent's handler is never called while the child's page is mapped.
- All new state in **low RAM (`#1300+`)** → zero resident image bytes.
- **libgb**: `gb.h` gains `gb_msg_t` + `gb_msg` + `gb_on_event`; `gblib.s` the trampoline; `gbapp.inc` documents the entry.
- **Demo**: the desktop registers a handler that, on a top-bar click, shows the clicked column — proving the round-trip + payload.

## DEFAULT fallback (option 1)
Also in this PR: `load_or_default` — `font_init`/`icon_init` try the configured 8.3 name and, on a miss, retry with the built-in `DEFAULT` name before drawing. A typo'd `ICONS=`/`FONT=` (or a deleted set) can no longer leave the screen rendering garbage. Verified: a disk with `ICONS=NONE`/`FONT=NONE` now boots to the normal desktop (was garbage before).

## Result
Resident kernel **9839 → 9654 bytes** — *smaller than before* despite adding the API, now ~197 bytes under `#A67B` (was ~12).

## Verification
- Host parity tests `kernel/kc/run_tests.sh` — **18/18** (config parse + `gb_make_83`).
- `tools/build_kernel.sh` green; headless boot `--memory=128` at frame 900 — default desktop unchanged (text/icons via the module-built `DEFAULT.FNT`/`DEFAULT.IST`).
- **Interactive (pending user click-test)**: click the top bar → desktop hint line becomes `Top-bar click @ col XX`; clicking the icon area does not fire it; launching FILEMGR and returning leaves the desktop handler working (nesting).

## Follow-ups
More message types (tick/focus/redraw); the dropdown menu UI on top of this callback; a real queue/bus only if concurrent/background apps are adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
