### PR TITLE
File lifecycle: menus, Notepad save/load, FAT16 floppy + FAT32 IDE read/write (#34)

### DIFF
--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -97,6 +97,9 @@ static void drop(void)
     paint();
 }
 
+/* a single "Disk" menu title at byte column 10 (clear of mem and the clock) */
+static const unsigned char dt_menu[] = { 1, 10, 'D','i','s','k',0,0,0,0 };
+
 /* on_event: kernel callback (issue #32). Fires when the user clicks the
    kernel-owned top bar; proves the kernel->app round-trip by showing the
    message payload (the clicked column) in the hint line. */
@@ -119,6 +122,7 @@ void main(void)
 
     paint();
     gb_on_event(on_event);                     /* top-bar clicks -> on_event */
+    gb_menu(dt_menu);                          /* draw the desktop menu title */
     drag_active = 0;
     dc_timer = 0;
     held_prev = 0;

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -41,6 +41,7 @@ static unsigned char view_first;         /* first visible display row */
 static unsigned char dirty, status;      /* 0 none, 1 saved, 2 failed */
 static unsigned char want_menu, modal, close_menu; /* File clicked / modal / close it */
 static unsigned char keycool;            /* frames to flush keys after a click or fire */
+static unsigned char prev_total;         /* display-row count at the last full draw */
 
 /* the kernel-drawn top-bar menu: one title "File" at MENU_COL */
 static const unsigned char file_menu[] = { 1, MENU_COL, 'F','i','l','e',0,0,0,0 };
@@ -86,26 +87,53 @@ static void status_line(void)
                           "Click text to place caret. Ctrl-Q=quit");
 }
 
-/* draw: full repaint - window, the visible rows (scrolled to keep the caret in
-   view), status line, and the caret. */
-static void draw(void)
+/* count_lines: index of the last display row (newlines + wraps). */
+static unsigned char count_lines(void)
+{
+    unsigned int i;
+    unsigned char col = 0, n = 0, ch;
+    for (i = 0; i < len; i++) {
+        ch = buf[i];
+        if (ch == '\n') { n++; col = 0; }
+        else if (ch >= 32) { if (++col == WRAP) { n++; col = 0; } }
+    }
+    return n;
+}
+
+/* scroll_to_caret: adjust view_first so the caret's row is on screen. */
+static void scroll_to_caret(void)
+{
+    unsigned char r, c;
+    pos_of(cur, &r, &c);
+    if (r < view_first) view_first = r;
+    else if (r >= view_first + MAX_LINES) view_first = r - MAX_LINES + 1;
+}
+
+/* render: paint the text using the current view_first. only==0xFF -> full (frame,
+   status, every visible row); otherwise repaint just that screen row (clearing it
+   first) - used for a single-line edit so typing doesn't flash the whole window.
+   Always (re)draws the caret. */
+static void render(unsigned char only)
 {
     unsigned int i;
     unsigned char col = 0, row = 0, scr, currow, curcol;
 
-    pos_of(cur, &currow, &curcol);               /* scroll to show the caret */
-    if (currow < view_first) view_first = currow;
-    else if (currow >= view_first + MAX_LINES) view_first = currow - MAX_LINES + 1;
-
-    gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, dirty ? "NOTEPAD *" : "NOTEPAD");
-    status_line();
-
+    pos_of(cur, &currow, &curcol);
+    if (only == 0xFF) {
+        gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, dirty ? "NOTEPAD *" : "NOTEPAD");
+        status_line();
+    }
     for (i = 0; i <= len; i++) {                  /* <= len: flush the last line */
         if (i == len || buf[i] == '\n' ||
             (buf[i] >= 32 && col == WRAP)) {
             if (row >= view_first && row - view_first < MAX_LINES) {
-                line[col] = 0;
-                gb_text(TX_COL, TX_Y0 + (row - view_first) * LINE_H, line);
+                scr = row - view_first;
+                if (only == 0xFF || scr == only) {
+                    line[col] = 0;
+                    if (only != 0xFF)             /* clear just this line first */
+                        gb_fill(WIN_X + 1, TX_Y0 + scr * LINE_H, WIN_W - 2, LINE_H, 0);
+                    gb_text(TX_COL, TX_Y0 + scr * LINE_H, line);
+                }
             }
             if (i == len) break;
             if (buf[i] == '\n') { row++; col = 0; continue; }
@@ -118,6 +146,14 @@ static void draw(void)
     }
     scr = currow - view_first;
     cursor_at(curcol, scr);
+}
+
+/* draw: full repaint (scroll to the caret, then render everything). */
+static void draw(void)
+{
+    scroll_to_caret();
+    render(0xFF);
+    prev_total = count_lines();
 }
 
 /* insert one char at the caret; grow the buffer right. */
@@ -190,12 +226,14 @@ static unsigned char popup(unsigned char x, unsigned char y,
         break;                                         /* clicked elsewhere -> cancel */
     }
     modal = 0;
-    gb_curhide();
+    if (esc) while (gb_poll() & GB_QUIT) ;         /* swallow ESC (gb_poll keeps the
+                                                      cursor's save-under consistent) */
+    gb_curhide();                                   /* erase the cursor cleanly */
     gb_fill(x, y, 18, n * LINE_H + 4, 0);          /* erase the popup box */
-    gb_curshow();
-    if (esc) while (gb_poll() & GB_QUIT) ;         /* swallow ESC so it doesn't quit */
     keycool = 4;                                    /* flush the click's buffered chars */
-    return sel;
+    return sel;                                     /* returns with the cursor hidden;
+                                                      the caller's draw + gb_curshow
+                                                      re-shows it exactly once */
 }
 
 static const char *const file_items[] = { "New", "Load", "Save" };
@@ -303,9 +341,17 @@ void main(void)
             else if (c >= 32 && c < 127) { ins((char)c); edited = 1; }
             /* other keys (arrows etc.) are ignored - no redraw */
         }
-        if (edited) {                                /* redraw only on an actual edit */
+        if (edited) {
+            unsigned char t = count_lines(), oldvf = view_first, cr, cc;
             gb_curhide();
-            draw();
+            scroll_to_caret();
+            pos_of(cur, &cr, &cc);
+            if (t != prev_total || view_first != oldvf) {
+                render(0xFF);                        /* line count or scroll changed */
+                prev_total = t;
+            } else {
+                render(cr - view_first);             /* just the caret's line */
+            }
             gb_curshow();
         }
     }

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -1,24 +1,18 @@
-/* notepad - the GEOBENCH text editor (C), and the first app that writes to disk.
+/* notepad - the GEOBENCH text editor (C), pointer-driven (#34).
  *
- * Launched by the file manager when a .TXT is double-clicked. Loads the file
- * (gb_fs_load), shows it word-wrapped with a red underline cursor, and edits it
- * from the keyboard (gb_getkey):
+ * The top bar shows a "File" menu (New / Load / Save) drawn by the kernel; click
+ * it to drop the menu down. Click in the text to place the insertion point, then
+ * type to insert there (Backspace deletes before it). On the CPC the pointer is
+ * the arrow keys, so positioning the caret is by clicking, not by cursor keys.
  *
- *   printable keys   append a character
- *   Enter            newline
- *   Delete/Backspace remove the last character
- *   Ctrl-S           save (overwrites in place; the status line reports the result)
- *   ESC              quit back to the file manager
+ *   File > New     empty buffer, name UNTITLED.TXT
+ *   File > Load     pick a file from a list and open it
+ *   File > Save     write the buffer (creates / grows the file via the new
+ *                   AMSDOS write layer)
+ *   Ctrl-Q          quit back to the file manager
  *
- * The view scrolls so the end of the text (where editing happens) stays visible.
- * Typing within a line repaints only that line; the whole window is redrawn only
- * on a newline, a scroll, or a save. It paces with gb_vsync (no pointer), reads
- * only the keyboard, and quits when gb_vsync reports ESC held - so the desktop's
- * pointer/joystick never disturb it.
- *
- * v1 edits at the end (append / backspace); mid-text cursor movement is a
- * follow-up. Save overwrites in place, so the text must fit the file's current
- * disk allocation. */
+ * Input is GB_POLL (pointer + click + the menu callback) plus GB_GETKEY for
+ * typing. The view scrolls to keep the caret visible. */
 #include "gb.h"
 
 #define NP_MAX    1024
@@ -33,36 +27,49 @@
 #define WRAP      44
 
 #define K_ENTER   0x0D
-#define K_DEL     0x7F
 #define K_BS      0x08
-#define K_SAVE    0x13   /* Ctrl-S */
-#define K_QUIT    0x11   /* Ctrl-Q */
+#define K_DEL     0x7F
+#define K_QUIT    0x11           /* Ctrl-Q */
+
+#define MENU_COL  10             /* "File" title column in the top bar */
+#define MENU_END  16
 
 static char buf[NP_MAX];
 static char line[WRAP + 2];
-static unsigned int len;
-static unsigned char dirty;
-static unsigned char status;       /* 0 none, 1 saved, 2 save failed */
-static unsigned char prev_total;   /* line count at the last full draw */
+static unsigned int len, cur;            /* text length, insertion index */
+static unsigned char view_first;         /* first visible display row */
+static unsigned char dirty, status;      /* 0 none, 1 saved, 2 failed */
+static unsigned char want_menu, modal;   /* File clicked; in a modal loop */
 
-static unsigned char count_lines(void)
+/* the kernel-drawn top-bar menu: one title "File" at MENU_COL */
+static const unsigned char file_menu[] = { 1, MENU_COL, 'F','i','l','e',0,0,0,0 };
+
+/* pos_of: display (row,col) of buffer index idx (wrap + newlines). */
+static void pos_of(unsigned int idx, unsigned char *prow, unsigned char *pcol)
 {
     unsigned int i;
-    unsigned char col = 0, n = 0, ch;
-    for (i = 0; i < len; i++) {
+    unsigned char col = 0, row = 0, ch;
+    for (i = 0; i < idx; i++) {
         ch = buf[i];
-        if (ch == '\n') { n++; col = 0; }
-        else if (ch >= 32) { if (++col == WRAP) { n++; col = 0; } }
+        if (ch == '\n') { row++; col = 0; }
+        else if (ch >= 32) { if (++col == WRAP) { row++; col = 0; } }
     }
-    return n;
+    *prow = row; *pcol = col;
 }
 
-static void status_line(void)
+/* idx_of: buffer index nearest the display position (trow,tcol). */
+static unsigned int idx_of(unsigned char trow, unsigned char tcol)
 {
-    gb_text(TX_COL, WIN_Y + WIN_H - 11,
-            status == 1 ? "saved" :
-            status == 2 ? "SAVE FAILED - too big to fit" :
-                          "Ctrl-S=save  Ctrl-Q=quit");
+    unsigned int i;
+    unsigned char col = 0, row = 0, ch;
+    for (i = 0; i < len; i++) {
+        if (row == trow && col >= tcol) return i;
+        ch = buf[i];
+        if (ch == '\n') { if (row == trow) return i; row++; col = 0; }
+        else if (ch >= 32) { if (++col == WRAP) { row++; col = 0; } }
+        if (row > trow) return i;
+    }
+    return len;
 }
 
 static void cursor_at(unsigned char col, unsigned char row)
@@ -70,109 +77,215 @@ static void cursor_at(unsigned char col, unsigned char row)
     gb_fill(TX_COL + (col * 3) / 2, TX_Y0 + row * LINE_H + 7, 2, 2, 3);
 }
 
-/* draw: full repaint - window, the last screenful of text, status, cursor. */
+static void status_line(void)
+{
+    gb_text(TX_COL, WIN_Y + WIN_H - 11,
+            status == 1 ? "saved" :
+            status == 2 ? "SAVE FAILED" :
+                          "Click text to place caret. Ctrl-Q=quit");
+}
+
+/* draw: full repaint - window, the visible rows (scrolled to keep the caret in
+   view), status line, and the caret. */
 static void draw(void)
 {
     unsigned int i;
-    unsigned char ch, col = 0, lineno = 0, row = 0, first, total;
-    unsigned char curcol = 0, currow = 0;
+    unsigned char col = 0, row = 0, scr, currow, curcol;
 
-    total = count_lines();
-    prev_total = total;
-    first = (total >= MAX_LINES) ? (total - MAX_LINES + 1) : 0;
+    pos_of(cur, &currow, &curcol);               /* scroll to show the caret */
+    if (currow < view_first) view_first = currow;
+    else if (currow >= view_first + MAX_LINES) view_first = currow - MAX_LINES + 1;
 
     gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, dirty ? "NOTEPAD *" : "NOTEPAD");
     status_line();
 
-    for (i = 0; i < len; i++) {
-        ch = buf[i];
-        if (ch == '\n') {
-            if (lineno >= first && row < MAX_LINES) {
+    for (i = 0; i <= len; i++) {                  /* <= len: flush the last line */
+        if (i == len || buf[i] == '\n' ||
+            (buf[i] >= 32 && col == WRAP)) {
+            if (row >= view_first && row - view_first < MAX_LINES) {
                 line[col] = 0;
-                gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
-                row++;
+                gb_text(TX_COL, TX_Y0 + (row - view_first) * LINE_H, line);
             }
-            col = 0; lineno++;
-        } else if (ch >= 32) {
-            if (lineno >= first) line[col] = ch;
-            if (++col == WRAP) {
-                if (lineno >= first && row < MAX_LINES) {
-                    line[col] = 0;
-                    gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
-                    row++;
-                }
-                col = 0; lineno++;
-            }
+            if (i == len) break;
+            if (buf[i] == '\n') { row++; col = 0; continue; }
+            row++; col = 0;                        /* wrap: fall through to place buf[i] */
+        }
+        if (buf[i] >= 32) {
+            if (row >= view_first && col < WRAP) line[col] = buf[i];
+            col++;
         }
     }
-    if (lineno >= first && row < MAX_LINES) {
-        line[col] = 0;
-        gb_text(TX_COL, TX_Y0 + row * LINE_H, line);
-        curcol = col; currow = row;
-    }
-    cursor_at(curcol, currow);
+    scr = currow - view_first;
+    cursor_at(curcol, scr);
 }
 
-/* draw_tail: repaint just the current (last) line - used when an append/backspace
-   doesn't change the line count, so the whole window needn't flicker. */
-static void draw_tail(void)
+/* insert one char at the caret; grow the buffer right. */
+static void ins(char c)
 {
-    unsigned int i, ls = 0;
-    unsigned char ch, col = 0, lineno = 0, first, currow;
+    unsigned int i;
+    if (len >= NP_MAX) return;
+    for (i = len; i > cur; i--) buf[i] = buf[i - 1];
+    buf[cur] = c;
+    len++; cur++;
+    dirty = 1; status = 0;
+}
 
-    for (i = 0; i < len; i++) {
-        ch = buf[i];
-        if (ch == '\n') { lineno++; col = 0; ls = i + 1; }
-        else if (ch >= 32) { if (++col == WRAP) { lineno++; col = 0; ls = i + 1; } }
+static void del_back(void)
+{
+    unsigned int i;
+    if (cur == 0) return;
+    for (i = cur; i < len; i++) buf[i - 1] = buf[i];
+    len--; cur--;
+    dirty = 1; status = 0;
+}
+
+/* 8.3 helpers: turn a "NAME.EXT" string (from gb_dir*) into an 11-byte name. */
+static char name83[11];
+static void to_83(const char *s)
+{
+    unsigned char i = 0, j;
+    for (j = 0; j < 11; j++) name83[j] = ' ';
+    while (s[i] && s[i] != '.' && i < 8) { name83[i] = s[i]; i++; }
+    while (s[i] && s[i] != '.') i++;
+    if (s[i] == '.') {
+        i++;
+        for (j = 0; j < 3 && s[i]; j++, i++) name83[8 + j] = s[i];
     }
-    first = (lineno >= MAX_LINES) ? (lineno - MAX_LINES + 1) : 0;
-    currow = lineno - first;
+}
 
-    col = 0;
-    for (i = ls; i < len; i++) { ch = buf[i]; if (ch >= 32) line[col++] = ch; }
-    line[col] = 0;
+/* on_menu: kernel callback on a top-bar click. If it hit the File title, ask the
+   main loop to drop the menu (not while another modal popup is up). */
+static void on_menu(void)
+{
+    if (modal) return;
+    if (gb_msg.type == GB_MSG_MENU &&
+        gb_msg.p0 >= MENU_COL && gb_msg.p0 < MENU_END)
+        want_menu = 1;
+}
 
-    gb_fill(WIN_X + 1, TX_Y0 + currow * LINE_H, WIN_W - 2, LINE_H, 0); /* clear line */
-    gb_text(TX_COL, TX_Y0 + currow * LINE_H, line);
-    cursor_at(col, currow);
-    status_line();
+/* popup: draw a framed list at (x,y), n items from labels[], and run a pointer
+   loop until the user clicks one (-> its index) or clicks away (-> 0xFF). */
+static unsigned char popup(unsigned char x, unsigned char y,
+                           const char *const *labels, unsigned char n)
+{
+    unsigned char i, flags, row, sel = 0xFF;
+    modal = 1;
+    gb_curhide();
+    gb_fill(x, y, 18, n * LINE_H + 4, 1);         /* white box + black frame */
+    gb_frame(x, y, 18, n * LINE_H + 4, 2);
+    for (i = 0; i < n; i++)
+        gb_text(x + 1, y + 2 + i * LINE_H, labels[i]);
+    gb_curshow();
+    for (;;) {
+        flags = gb_poll();
+        if (!(flags & GB_CLICK)) continue;
+        if (gb_my() >= y + 2 && gb_my() < y + 2 + n * LINE_H &&
+            gb_mx() >= x && gb_mx() < x + 18) {
+            row = (gb_my() - (y + 2)) / LINE_H;
+            if (row < n) { sel = row; break; }
+        }
+        break;                                     /* clicked outside -> cancel */
+    }
+    modal = 0;
+    return sel;
+}
+
+static const char *const file_items[] = { "New", "Load", "Save" };
+
+static void do_save(void)
+{
+    status = gb_fs_save(buf, len) ? 1 : 2;
+    if (status == 1) dirty = 0;
+}
+
+static void do_new(void)
+{
+    len = 0; cur = 0; view_first = 0; dirty = 0; status = 0;
+    gb_set_name("UNTITLEDTXT");
+}
+
+/* do_load: list directory entries in a popup; open the one clicked. */
+static void do_load(void)
+{
+    const char *names[MAX_LINES];
+    static char store[MAX_LINES][14];
+    char *p;
+    unsigned char n = 0, i, sel;
+
+    p = gb_dir1();
+    while (p && n < MAX_LINES) {
+        for (i = 0; i < 13 && p[i]; i++) store[n][i] = p[i];
+        store[n][i] = 0;
+        names[n] = store[n];
+        n++;
+        p = gb_dirn();
+    }
+    if (!n) return;
+    sel = popup(WIN_X + 6, TX_Y0, names, n);
+    if (sel == 0xFF) return;
+    to_83(store[sel]);
+    gb_set_name(name83);
+    len = gb_fs_load(buf, NP_MAX);
+    cur = 0; view_first = 0; dirty = 0; status = 0;
+}
+
+/* run_menu: drop the File menu and dispatch the chosen item. */
+static void run_menu(void)
+{
+    unsigned char sel = popup(MENU_COL, 8, file_items, 3);
+    if (sel == 0) do_new();
+    else if (sel == 1) do_load();
+    else if (sel == 2) do_save();
 }
 
 void main(void)
 {
-    unsigned char c, n, edited, need_full, t;
+    unsigned char flags, c, n;
 
-    gb_curhide();
     len = gb_fs_load(buf, NP_MAX);
-    dirty = 0; status = 0;
-    for (n = 64; n; n--)               /* drop keys buffered while navigating here */
-        if (!gb_getkey()) break;
+    cur = len; view_first = 0; dirty = 0; status = 0;
+    want_menu = 0; modal = 0;
+    for (n = 64; n; n--) if (!gb_getkey()) break;   /* drop buffered keys */
+
+    gb_on_event(on_menu);
+    gb_menu(file_menu);
     draw();
+    gb_curshow();
 
     for (;;) {
-        gb_vsync();                    /* pace one frame (50 Hz) */
-        edited = 0; need_full = 0;
-        for (n = 32; n; n--) {
+        flags = gb_poll();
+
+        if (want_menu) {                            /* File title was clicked */
+            want_menu = 0;
+            run_menu();
+            draw();
+            gb_curshow();
+            continue;
+        }
+
+        if (flags & GB_CLICK) {                     /* click in text -> caret */
+            unsigned char my = gb_my(), mx = gb_mx();
+            if (my >= TX_Y0 && my < TX_Y0 + MAX_LINES * LINE_H && mx >= TX_COL) {
+                unsigned char row = view_first + (my - TX_Y0) / LINE_H;
+                unsigned char col = ((mx - TX_COL) * 2) / 3;
+                gb_curhide();
+                cur = idx_of(row, col);
+                draw();
+                gb_curshow();
+            }
+        }
+
+        n = 8;                                       /* drain typed keys */
+        while (n--) {
             c = gb_getkey();
             if (!c) break;
-            if (c == K_QUIT) return;   /* Ctrl-Q -> quit (ESC is a no-op now) */
-            if (c == K_SAVE) {
-                status = gb_fs_save(buf, len) ? 1 : 2;
-                if (status == 1) dirty = 0;
-                edited = 1; need_full = 1;
-            } else if (c == K_DEL || c == K_BS) {
-                if (len) { len--; dirty = 1; status = 0; edited = 1; }
-            } else if (c == K_ENTER) {
-                if (len < NP_MAX) { buf[len++] = '\n'; dirty = 1; status = 0; edited = 1; need_full = 1; }
-            } else if (c >= 32 && c < 127) {
-                if (len < NP_MAX) { buf[len++] = (char)c; dirty = 1; status = 0; edited = 1; }
-            }
-            /* other keys (cursor, etc.) are ignored - no redraw */
-        }
-        if (edited) {
-            t = count_lines();
-            if (need_full || t != prev_total) draw();   /* draw() updates prev_total */
-            else draw_tail();
+            if (c == K_QUIT) return;
+            gb_curhide();
+            if (c == K_BS || c == K_DEL) del_back();
+            else if (c == K_ENTER) ins('\n');
+            else if (c >= 32 && c < 127) ins((char)c);
+            draw();
+            gb_curshow();
         }
     }
 }

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -240,7 +240,7 @@ static void run_menu(void)
 
 void main(void)
 {
-    unsigned char flags, c, n;
+    unsigned char flags, c, n, edited;
 
     len = gb_fs_load(buf, NP_MAX);
     cur = len; view_first = 0; dirty = 0; status = 0;
@@ -254,6 +254,7 @@ void main(void)
 
     for (;;) {
         flags = gb_poll();
+        if (flags & GB_QUIT) return;                /* ESC quits */
 
         if (want_menu) {                            /* File title was clicked */
             want_menu = 0;
@@ -275,15 +276,19 @@ void main(void)
             }
         }
 
-        n = 8;                                       /* drain typed keys */
+        edited = 0;                                  /* drain typed keys */
+        n = 8;
         while (n--) {
             c = gb_getkey();
             if (!c) break;
             if (c == K_QUIT) return;
+            if (c == K_BS || c == K_DEL) { del_back(); edited = 1; }
+            else if (c == K_ENTER) { ins('\n'); edited = 1; }
+            else if (c >= 32 && c < 127) { ins((char)c); edited = 1; }
+            /* other keys (arrows etc.) are ignored - no redraw */
+        }
+        if (edited) {                                /* redraw only on an actual edit */
             gb_curhide();
-            if (c == K_BS || c == K_DEL) del_back();
-            else if (c == K_ENTER) ins('\n');
-            else if (c >= 32 && c < 127) ins((char)c);
             draw();
             gb_curshow();
         }

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -39,7 +39,8 @@ static char line[WRAP + 2];
 static unsigned int len, cur;            /* text length, insertion index */
 static unsigned char view_first;         /* first visible display row */
 static unsigned char dirty, status;      /* 0 none, 1 saved, 2 failed */
-static unsigned char want_menu, modal;   /* File clicked; in a modal loop */
+static unsigned char want_menu, modal, close_menu; /* File clicked / modal / close it */
+static unsigned char keycool;            /* frames to flush keys after a click or fire */
 
 /* the kernel-drawn top-bar menu: one title "File" at MENU_COL */
 static const unsigned char file_menu[] = { 1, MENU_COL, 'F','i','l','e',0,0,0,0 };
@@ -157,10 +158,10 @@ static void to_83(const char *s)
    main loop to drop the menu (not while another modal popup is up). */
 static void on_menu(void)
 {
-    if (modal) return;
-    if (gb_msg.type == GB_MSG_MENU &&
-        gb_msg.p0 >= MENU_COL && gb_msg.p0 < MENU_END)
-        want_menu = 1;
+    if (gb_msg.type != GB_MSG_MENU) return;
+    if (gb_msg.p0 < MENU_COL || gb_msg.p0 >= MENU_END) return;
+    if (modal) close_menu = 1;   /* clicking File again while open -> close it */
+    else       want_menu = 1;
 }
 
 /* popup: draw a framed list at (x,y), n items from labels[], and run a pointer
@@ -168,8 +169,8 @@ static void on_menu(void)
 static unsigned char popup(unsigned char x, unsigned char y,
                            const char *const *labels, unsigned char n)
 {
-    unsigned char i, flags, row, sel = 0xFF;
-    modal = 1;
+    unsigned char i, flags, row, sel = 0xFF, esc = 0;
+    modal = 1; close_menu = 0;
     gb_curhide();
     gb_fill(x, y, 18, n * LINE_H + 4, 1);         /* white box + black frame */
     gb_frame(x, y, 18, n * LINE_H + 4, 2);
@@ -178,15 +179,22 @@ static unsigned char popup(unsigned char x, unsigned char y,
     gb_curshow();
     for (;;) {
         flags = gb_poll();
+        if (flags & GB_QUIT) { esc = 1; break; }      /* ESC closes the menu */
+        if (close_menu) break;                         /* clicked File again -> close */
         if (!(flags & GB_CLICK)) continue;
         if (gb_my() >= y + 2 && gb_my() < y + 2 + n * LINE_H &&
             gb_mx() >= x && gb_mx() < x + 18) {
             row = (gb_my() - (y + 2)) / LINE_H;
             if (row < n) { sel = row; break; }
         }
-        break;                                     /* clicked outside -> cancel */
+        break;                                         /* clicked elsewhere -> cancel */
     }
     modal = 0;
+    gb_curhide();
+    gb_fill(x, y, 18, n * LINE_H + 4, 0);          /* erase the popup box */
+    gb_curshow();
+    if (esc) while (gb_poll() & GB_QUIT) ;         /* swallow ESC so it doesn't quit */
+    keycool = 4;                                    /* flush the click's buffered chars */
     return sel;
 }
 
@@ -264,16 +272,24 @@ void main(void)
             continue;
         }
 
+        if (flags & GB_FIRE) keycool = 4;           /* fire held -> flush its 'Z'/'X' */
         if (flags & GB_CLICK) {                     /* click in text -> caret */
             unsigned char my = gb_my(), mx = gb_mx();
+            keycool = 4;
             if (my >= TX_Y0 && my < TX_Y0 + MAX_LINES * LINE_H && mx >= TX_COL) {
-                unsigned char row = view_first + (my - TX_Y0) / LINE_H;
-                unsigned char col = ((mx - TX_COL) * 2) / 3;
-                gb_curhide();
-                cur = idx_of(row, col);
-                draw();
-                gb_curshow();
+                unsigned int nc = idx_of(view_first + (my - TX_Y0) / LINE_H,
+                                         ((mx - TX_COL) * 2) / 3);
+                if (nc != cur) {                     /* redraw only if the caret moved */
+                    cur = nc;
+                    gb_curhide(); draw(); gb_curshow();
+                }
             }
+        }
+
+        if (keycool) {                               /* after a click/fire: drop the */
+            keycool--;                                /* buffered fire/direction chars */
+            while (gb_getkey()) ;
+            continue;
         }
 
         edited = 0;                                  /* drain typed keys */

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -284,6 +284,50 @@ static void run_menu(void)
     else if (sel == 2) do_save();
 }
 
+/* confirm: "Save changes?" dialog -> 1 = YES, 0 = NO, 0xFF = cancelled (ESC). */
+static unsigned char confirm(void)
+{
+    unsigned char flags, sel = 0xFF;
+    unsigned char x = 28, y = 86, w = 26, h = 44;
+    modal = 1;
+    gb_curhide();
+    gb_fill(x, y, w, h, 1);                       /* white box + black frame */
+    gb_frame(x, y, w, h, 2);
+    gb_text(x + 1, y + 4,  "Save changes?");
+    gb_text(x + 3, y + 20, "YES");
+    gb_text(x + 3, y + 32, "NO");
+    gb_curshow();
+    for (;;) {
+        flags = gb_poll();
+        if (flags & GB_QUIT) break;                       /* ESC -> cancel */
+        if (!(flags & GB_CLICK)) continue;
+        if (gb_mx() >= x && gb_mx() < x + w) {
+            if (gb_my() >= y + 20 && gb_my() < y + 30) { sel = 1; break; }  /* YES */
+            if (gb_my() >= y + 32 && gb_my() < y + 42) { sel = 0; break; }  /* NO  */
+        }
+        /* clicks elsewhere keep the dialog open */
+    }
+    modal = 0;
+    if (sel == 0xFF) while (gb_poll() & GB_QUIT) ;   /* swallow ESC */
+    gb_curhide();
+    gb_fill(x, y, w, h, 0);                          /* erase the dialog */
+    keycool = 4;
+    return sel;
+}
+
+/* try_close: handle a click on the window close gadget. -> 1 if Notepad should
+   quit, 0 to stay open. Prompts to save when there are unsaved edits. */
+static unsigned char try_close(void)
+{
+    unsigned char ans;
+    if (!dirty) return 1;                /* nothing changed -> just close */
+    ans = confirm();
+    if (ans == 0xFF) return 0;           /* cancelled -> stay open */
+    if (ans == 0) return 1;              /* NO -> discard and close */
+    do_save();                            /* YES -> save; close only if it worked */
+    return (unsigned char)(status == 1);
+}
+
 void main(void)
 {
     unsigned char flags, c, n, edited;
@@ -311,9 +355,15 @@ void main(void)
         }
 
         if (flags & GB_FIRE) keycool = 4;           /* fire held -> flush its 'Z'/'X' */
-        if (flags & GB_CLICK) {                     /* click in text -> caret */
+        if (flags & GB_CLICK) {
             unsigned char my = gb_my(), mx = gb_mx();
             keycool = 4;
+            if (my >= WIN_Y && my < WIN_Y + 14 &&   /* close gadget (title-bar left) */
+                mx >= WIN_X && mx < WIN_X + 5) {
+                if (try_close()) return;             /* quit back to the file manager */
+                draw(); gb_curshow();                /* cancelled -> repaint */
+                continue;
+            }
             if (my >= TX_Y0 && my < TX_Y0 + MAX_LINES * LINE_H && mx >= TX_COL) {
                 unsigned int nc = idx_of(view_first + (my - TX_Y0) / LINE_H,
                                          ((mx - TX_COL) * 2) / 3);

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -1606,15 +1606,16 @@ md_last         dw    0
                 include "../lib/fs_amsdos.asm"
                 include "../lib/bank.asm"
 kern_end                                        ; GBKERN.BIN = #8000..kern_end only.
-; --- scratch buffers: above the loaded image, uninitialised RAM at runtime -----
-; Keeping these 2.5KB out of GBKERN.BIN shrinks the load so it fits under the
-; UniDOS+FatFS HIMEM (&A288) on an IDE machine, not just AMSDOS (&A67B). fs_secbuf
-; is first (used by the IDE backend, stays below the lower IDE HIMEM); fsam_buf
-; (floppy only) follows and is never touched on an IDE machine.
-fs_secbuf       defs  512            ; IDE sector buffer / aliased AMSDOS write sector
-fsam_buf        defs  2048           ; floppy whole-directory buffer
+; --- scratch buffers live in LOW RAM (always the main bank, below the stack) -----
+; They used to sit just above kern_end, but as the kernel grew they landed in the
+; UniDOS stack's path: HIMEM &A288 grows DOWN toward kern_end, so a 512-byte sector
+; write during a deep call (a Notepad save) smashed the return stack and the IDE
+; loop ran away. Low RAM #1800+ (the retired GBFAT transfer area) is clear of both
+; the descending stack and the resident image. Fixed addresses, not loaded data.
+fs_secbuf       equ   #1800            ; IDE sector buffer / aliased AMSDOS write sector
+fsam_buf        equ   #1A00            ; floppy whole-directory buffer
                                                 ; The packaging incbins below live
-                                                ; above all of this - never loaded at
+                                                ; above kern_end - never loaded at
                                                 ; runtime, only read by `save`.
 dtp_img         incbin "../build/DESKTOP.RAW"   ; packaged on the disk as DESKTOP.BIN
 dtp_imgend

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -967,20 +967,25 @@ k_getkey
                 ; keyboard app (Notepad redrawing on every move). While any pointing
                 ; direction is physically held, the "char" is the pointer, not
                 ; typing: drop it. KM_TEST_KEY preserves B/DE/HL.
-                ld    e,a                     ; save the char
-                ld    hl,kgk_dirkeys
+                ld    (kgk_char),a           ; save char in memory (KM_TEST_KEY may
+                ld    hl,kgk_dirkeys         ; corrupt HL/BC, so don't trust regs)
                 ld    b,(hl)
 kgk_test
                 inc   hl
                 ld    a,(hl)
+                push  hl
+                push  bc
                 call  KM_TEST_KEY
+                pop   bc
+                pop   hl
                 jr    nz,kgk_none            ; a direction held -> discard the char
                 djnz  kgk_test
-                ld    a,e                     ; a genuine typed character
+                ld    a,(kgk_char)           ; a genuine typed character
                 ret
 kgk_none
                 xor   a
                 ret
+kgk_char        db    0
 kgk_dirkeys     db    8, 0,1,2,8, 72,73,74,75  ; cursor keys + joystick directions
 
 ; k_vsync (GB_VSYNC): wait for the frame flyback (50 Hz pace, no pointer/clock),

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -1590,10 +1590,17 @@ md_last         dw    0
                 include "../lib/fs_ide_fat.asm"
                 include "../lib/fs_amsdos.asm"
                 include "../lib/bank.asm"
-kern_end                                        ; GBKERN.BIN is CODE ONLY (must end
-                                                ; below HIMEM ~#A67B). The packaging
-                                                ; incbins live above it - never loaded
-                                                ; at runtime, only read by `save`.
+kern_end                                        ; GBKERN.BIN = #8000..kern_end only.
+; --- scratch buffers: above the loaded image, uninitialised RAM at runtime -----
+; Keeping these 2.5KB out of GBKERN.BIN shrinks the load so it fits under the
+; UniDOS+FatFS HIMEM (&A288) on an IDE machine, not just AMSDOS (&A67B). fs_secbuf
+; is first (used by the IDE backend, stays below the lower IDE HIMEM); fsam_buf
+; (floppy only) follows and is never touched on an IDE machine.
+fs_secbuf       defs  512            ; IDE sector buffer / aliased AMSDOS write sector
+fsam_buf        defs  2048           ; floppy whole-directory buffer
+                                                ; The packaging incbins below live
+                                                ; above all of this - never loaded at
+                                                ; runtime, only read by `save`.
 dtp_img         incbin "../build/DESKTOP.RAW"   ; packaged on the disk as DESKTOP.BIN
 dtp_imgend
 app_img         incbin "../build/FILEMGR.RAW"   ; packaged on the disk as FILEMGR.BIN

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -986,7 +986,9 @@ kgk_none
                 xor   a
                 ret
 kgk_char        db    0
-kgk_dirkeys     db    8, 0,1,2,8, 72,73,74,75  ; cursor keys + joystick directions
+kgk_dirkeys     db    10, 0,1,2,8, 72,73,74,75, 76,77 ; cursor + joystick dirs + fire
+                                              ; (fire = the click; it also buffers a
+                                              ; char, e.g. 'Z' - drop it while held)
 
 ; k_vsync (GB_VSYNC): wait for the frame flyback (50 Hz pace, no pointer/clock),
 ; then report whether ESC is held -> A = 1 if so, 0 otherwise. Lets a keyboard app

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -29,6 +29,7 @@ KCFG_FONTNAME   equ   #120D        ; 11-byte 8.3 font filename, built by the mod
 APP_HANDLER     equ   #1300        ; word: registered app event handler (0 = none)
 GB_MSG          equ   #1302        ; message record: type, p0, p1, p2 (4 bytes)
 GB_MSG_MENU     equ   1            ; message type: top-bar click, p0 = byte column
+MENU_DEF        equ   #1310        ; app menu: count, then {col, 8-byte label} *count
 
                 org   GB_KERNEL
 ; --- fixed API jump table (order is the ABI; see lib/gbapp.inc) -----------
@@ -58,6 +59,7 @@ GB_MSG_MENU     equ   1            ; message type: top-bar click, p0 = byte colu
                 jp    k_getkey               ; GB_GETKEY      #8045
                 jp    k_vsync                ; GB_VSYNC       #8048
                 jp    k_onevent              ; GB_ONEVENT     #804B
+                jp    k_menu                 ; GB_MENU        #804E
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -818,6 +820,10 @@ launch_app
                 push  hl                       ; it, so a top-bar click during the child
                 ld    hl,0                     ; cannot call the parent's handler (whose
                 ld    (APP_HANDLER),hl        ; page is not mapped while the child runs)
+                ld    a,(MENU_DEF)           ; save & clear the parent's menu so the
+                push  af                       ; child starts with a clean top bar
+                xor   a
+                ld    (MENU_DEF),a
                 ld    hl,launch_depth
                 inc   (hl)
                 di
@@ -835,6 +841,8 @@ launch_app
 la_done
                 ld    hl,launch_depth
                 dec   (hl)
+                pop   af                       ; restore the parent's menu count
+                ld    (MENU_DEF),a
                 pop   hl                       ; restore the parent's event handler
                 ld    (APP_HANDLER),hl
                 pop   af                       ; caller's page
@@ -956,6 +964,52 @@ menu_dispatch
                 pop   de
                 ret
 md_call         jp    (hl)
+
+; k_menu (GB_MENU): register the calling app's top-bar menu. HL = a blob in the
+; app page: count, then per title { col (byte), 8-byte NUL/space-padded label }.
+; Copied into resident MENU_DEF so draw_topbar can render it across clock ticks
+; and app switches; redraws the bar. launch_app clears it for a child app.
+k_menu
+                ld    a,(hl)                  ; count
+                cp    5
+                ret   nc                       ; > 4 titles unsupported -> ignore
+                ld    e,a                       ; len = count*9 + 1
+                add   a,a
+                add   a,a
+                add   a,a
+                add   a,e
+                inc   a
+                ld    c,a
+                ld    b,0
+                ld    de,MENU_DEF
+                ldir
+                jp    draw_topbar
+
+; draw_menu_titles: render the registered menu titles in the top bar. Called from
+; draw_topbar with PAGE_DATA mapped (the font is there) and the bar text pens set.
+draw_menu_titles
+                ld    a,(MENU_DEF)
+                or    a
+                ret   z
+                ld    b,a
+                ld    ix,MENU_DEF+1
+dmt_loop
+                push  bc
+                push  ix
+                ld    a,(ix+0)                ; title column
+                ld    (tc_x),a
+                xor   a
+                ld    (tc_y),a
+                push  ix
+                pop   hl
+                inc   hl                       ; label = entry + 1
+                call  draw_text
+                pop   ix
+                pop   bc
+                ld    de,9
+                add   ix,de
+                djnz  dmt_loop
+                ret
 
 ; app_for_ext: HL = the app for fs_ent_name's type. Walks app_table: each entry
 ; is a 3-char extension + an 11-char 8.3 app name; a 0 ends the table -> default.
@@ -1109,6 +1163,7 @@ draw_topbar
                 ld    (tc_y),a
                 ld    hl,mem_str
                 call  draw_text
+                call  draw_menu_titles       ; the focused app's menu titles
                 ld    a,CLK_COL
                 ld    (tc_x),a
                 xor   a

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -60,6 +60,7 @@ MENU_DEF        equ   #1310        ; app menu: count, then {col, 8-byte label} *
                 jp    k_vsync                ; GB_VSYNC       #8048
                 jp    k_onevent              ; GB_ONEVENT     #804B
                 jp    k_menu                 ; GB_MENU        #804E
+                jp    k_setname              ; GB_SETNAME     #8051
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -874,6 +875,15 @@ k_launch
 ; k_getarg (GB_GETARG): HL = the launch arg (the 8.3 file name the app opened).
 k_getarg
                 ld    hl,launch_arg
+                ret
+
+; k_setname (GB_SETNAME): set the current file name (the launch arg) so a later
+; GB_FSLOAD/GB_FSSAVE targets it - this is how an app does New / Save As / open a
+; picked file. HL = an 11-byte 8.3 name in the caller's page.
+k_setname
+                ld    de,launch_arg
+                ld    bc,11
+                ldir
                 ret
 
 ; k_fsload (GB_FSLOAD): load the file the app was opened with (launch_arg) into a

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -73,6 +73,9 @@ kernel_main
                 ld    (#BDEE),a               ; KM TEST BREAK indirection to RET (that's
                                               ; what actually resets on ESC; disarm alone
                                               ; doesn't touch it)
+                call  disarm_joy_keys        ; joystick keys must not feed the char
+                                              ; buffer, or moving the pointer floods
+                                              ; gb_getkey (the keyboard is the joystick)
                 call  set_palette            ; GEOBENCH 4-pen palette
                 call  fs_init                ; pick storage backend (floppy here)
                 di                            ; probe RAM BEFORE PAGE_DATA is filled
@@ -102,6 +105,36 @@ kernel_main
                 call  SCR_SET_MODE
                 ret
 name_desktop    db    "DESKTOP BIN"
+
+; disarm_joy_keys: the CPC joystick is keyboard matrix row 9 (key numbers 72..77 =
+; up/down/left/right/fire1/fire2). By default those keys translate to characters,
+; so moving the pointer (= the joystick) floods the firmware key buffer and any
+; app that calls gb_getkey (Notepad) redraws on every move. Set their normal /
+; shift / control translation to &FF (no character). KM_GET_JOYSTICK / KM_TEST_KEY
+; read the matrix directly and are unaffected, so the pointer still works.
+disarm_joy_keys
+                ld    c,72
+djk_loop
+                ld    a,c
+                ld    b,#FF
+                push  bc
+                call  KM_SET_TRANSLATE
+                pop   bc
+                ld    a,c
+                ld    b,#FF
+                push  bc
+                call  KM_SET_SHIFT
+                pop   bc
+                ld    a,c
+                ld    b,#FF
+                push  bc
+                call  KM_SET_CONTROL
+                pop   bc
+                inc   c
+                ld    a,c
+                cp    78
+                jr    c,djk_loop
+                ret
 
 ; --- palette -------------------------------------------------------------
 INK_DESKTOP     equ   1            ; blue  -> pen 0 (paper / backdrop)

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -960,9 +960,28 @@ k_fssave
 ; none is waiting. Non-blocking (the firmware's IRQ scan fills the buffer).
 k_getkey
                 call  KM_READ_CHAR           ; CF + A = char, or NC = none. (Apps frame
-                ret   c                       ; on IY now, so KM_READ_CHAR clobbering IX
-                xor   a                       ; is harmless - see build_capp.sh.)
+                jr    nc,kgk_none            ; on IY now, so KM_READ_CHAR clobbering IX
+                                              ; is harmless - see build_capp.sh.)
+                ; The pointer is the joystick/cursor keys, and the firmware also
+                ; buffers those as characters - so moving the pointer would flood a
+                ; keyboard app (Notepad redrawing on every move). While any pointing
+                ; direction is physically held, the "char" is the pointer, not
+                ; typing: drop it. KM_TEST_KEY preserves B/DE/HL.
+                ld    e,a                     ; save the char
+                ld    hl,kgk_dirkeys
+                ld    b,(hl)
+kgk_test
+                inc   hl
+                ld    a,(hl)
+                call  KM_TEST_KEY
+                jr    nz,kgk_none            ; a direction held -> discard the char
+                djnz  kgk_test
+                ld    a,e                     ; a genuine typed character
                 ret
+kgk_none
+                xor   a
+                ret
+kgk_dirkeys     db    8, 0,1,2,8, 72,73,74,75  ; cursor keys + joystick directions
 
 ; k_vsync (GB_VSYNC): wait for the frame flyback (50 Hz pace, no pointer/clock),
 ; then report whether ESC is held -> A = 1 if so, 0 otherwise. Lets a keyboard app

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -1606,6 +1606,8 @@ chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELL
 chl_imgend
 cfg_img         incbin "../build/GBCFG.RAW"     ; config-parser C module, as GBCFG.BIN
 cfg_imgend
+fat_img         incbin "../build/GBFAT.RAW"     ; FAT16/IDE write module, as GBFAT.BIN
+fat_imgend
 font_img        incbin "../build/DEFAULT.FNT"   ; packaged on the disk as DEFAULT.FNT
 font_imgend
 icon_img        incbin "../build/DEFAULT.IST"   ; packaged on the disk as DEFAULT.IST
@@ -1619,6 +1621,7 @@ wel_imgend
                 save  "NOTEPAD.BIN",npd_img,npd_imgend-npd_img,DSK,"build/gbkern.dsk"
                 save  "CHELLO.BIN",chl_img,chl_imgend-chl_img,DSK,"build/gbkern.dsk"
                 save  "GBCFG.BIN",cfg_img,cfg_imgend-cfg_img,DSK,"build/gbkern.dsk"
+                save  "GBFAT.BIN",fat_img,fat_imgend-fat_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.FNT",font_img,font_imgend-font_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.IST",icon_img,icon_imgend-icon_img,DSK,"build/gbkern.dsk"
                 save  "WELCOME.TXT",wel_img,wel_imgend-wel_img,DSK,"build/gbkern.dsk"

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -1336,13 +1336,27 @@ read_time                                      ; -> time_str "HH:MM"
                 ld    a,(have_rtc)
                 or    a
                 jr    z,rt_soft
+                ld    a,#0B                    ; register B bit2 (DM): 1 = binary
+                call  read_rtc_reg            ; (the SymbiFace/SymbOS world runs the
+                and   #04                      ;  RTC in binary; HDCPM/SymbOS set this)
+                ld    (rt_binmode),a
                 ld    a,#04
                 call  read_rtc_reg
+                and   #3F                      ; drop 12/24h + PM flags -> hours 0..23
+                call  rt_cvt                   ; binary -> BCD if in binary mode
                 ld    (rt_h),a
                 ld    a,#02
                 call  read_rtc_reg
+                call  rt_cvt
                 ld    (rt_m),a
                 jr    rt_fmt
+rt_cvt                                          ; A = raw reg; -> BCD for put_bcd2
+                ld    b,a
+                ld    a,(rt_binmode)
+                or    a
+                ld    a,b
+                ret   z                         ; BCD mode: use the register as-is
+                jp    bin_to_bcd                ; binary mode: convert to packed BCD
 rt_soft
                 ld    a,(sw_hour)
                 call  bin_to_bcd
@@ -1575,6 +1589,7 @@ sw_min          db    0
 sw_hour         db    0
 clk_frames      db    0
 have_rtc        db    0
+rt_binmode      db    0            ; RTC register B bit2 (DM): 0 = BCD, !=0 = binary
 rt_h            db    0
 rt_m            db    0
 md_save         dw    0

--- a/kernel/modules/gbfat.asm
+++ b/kernel/modules/gbfat.asm
@@ -1,0 +1,686 @@
+; ---------------------------------------------------------------------------
+; kernel/modules/gbfat.asm - FAT16/IDE write, as a paged kernel module.
+;
+; The resident kernel keeps the FAT16 *read* path; this is the *write* path,
+; which is large and IDE-only, so it lives in a module loaded on demand into the
+; free upper part of PAGE_DATA (above the font/icons) and CALLed at GBFAT_ORG.
+; Self-contained: it mounts the volume, does its own sector I/O over the IDE
+; ports, and has its own 512-byte sector buffer - so it never needs the resident
+; kernel's data, only the inputs the resident stub leaves in low RAM (resident,
+; still reachable while this code is paged into the #4000-#7FFF window):
+;
+;   GBFAT_LEN  (#1400, word)   bytes to write
+;   GBFAT_NAME (#1402, 11)     8.3 name
+;   GBFAT_RES  (#140D, byte)   result: 1 = saved, 0 = failed
+;   GBFAT_DATA (#1800, <=8KB)  the data, copied out of the app's page by the stub
+;
+; Build: tools/build_fatmod.sh -> build/GBFAT.RAW, packaged on the disk as
+; GBFAT.BIN (and copied onto the IDE volume).
+; ---------------------------------------------------------------------------
+
+GBFAT_ORG       equ   #5000
+GBFAT_LEN       equ   #1400
+GBFAT_NAME      equ   #1402
+GBFAT_RES       equ   #140D
+GBFAT_DATA      equ   #1800
+
+FS_IDE_SCNT     equ   #FD0A
+FS_IDE_LBAL     equ   #FD0B
+FS_IDE_LBAM     equ   #FD0C
+FS_IDE_LBAH     equ   #FD0D
+FS_IDE_DEV      equ   #FD0E
+FS_IDE_CMD      equ   #FD0F
+FS_IDE_STAT     equ   #FD0F
+FS_IDE_DATA     equ   #FD08
+
+                org   GBFAT_ORG
+
+; entry: run the save, store the result byte, return to the kernel.
+                call  gbfat_save
+                ld    a,1
+                jr    c,gf_setres
+                xor   a
+gf_setres
+                ld    (GBFAT_RES),a
+                ret
+
+; ---------------------------------------------------------------------------
+; gbfat_save: write GBFAT_LEN bytes from GBFAT_DATA to GBFAT_NAME. CF set = saved.
+gbfat_save
+                call  gf_mount               ; geometry from the BPB
+                ld    hl,(GBFAT_LEN)         ; sectors = ceil(len / 512)
+                ld    de,511
+                add   hl,de
+                ld    b,9
+gf_shs          srl   h
+                rr    l
+                djnz  gf_shs
+                ld    (gf_secs),hl
+                ld    a,(gf_spc)             ; clusters = ceil(secs / spc)
+                dec   a
+                ld    e,a
+                ld    d,0
+                ld    hl,(gf_secs)
+                add   hl,de
+                call  gf_div_spc
+                ld    (gf_nclus),hl
+                call  gf_find                ; entry / free slot
+                ret   nc                      ; root directory full
+                call  gf_free_old            ; overwrite -> release old chain
+                ld    hl,0
+                ld    (gf_first),hl
+                ld    hl,(gf_nclus)
+                ld    a,h
+                or    l
+                jr    z,gf_putdir            ; zero-length file
+                call  gf_alloc_chain
+                ret   nc                      ; disk full
+                call  gf_write_data
+gf_putdir
+                call  gf_put_entry
+                scf
+                ret
+
+; ---------------------------------------------------------------------------
+; gf_mount: read the BPB and compute root_lba, root_secs, spc, fat_lba, data_lba.
+gf_mount
+                ld    hl,0
+                call  gf_read_sector
+                ld    hl,0                    ; root_lba = reserved + fats*spf
+                ld    a,(gf_secbuf+#10)
+                ld    b,a
+                ld    de,(gf_secbuf+#16)      ; sectors per FAT
+                ld    (gf_spf),de
+gf_mfat
+                add   hl,de
+                djnz  gf_mfat
+                ld    de,(gf_secbuf+#0E)
+                add   hl,de
+                ld    (gf_root_lba),hl
+                ld    hl,(gf_secbuf+#11)      ; root entries / 16 = sectors
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                ld    a,l
+                or    a
+                jr    nz,gf_mrs
+                inc   a
+gf_mrs
+                ld    (gf_root_secs),a
+                ld    a,(gf_secbuf+#0D)
+                ld    (gf_spc),a
+                ld    hl,(gf_secbuf+#0E)
+                ld    (gf_fat_lba),hl
+                ld    hl,(gf_root_lba)
+                ld    a,(gf_root_secs)
+                ld    e,a
+                ld    d,0
+                add   hl,de
+                ld    (gf_data_lba),hl
+                ret
+
+; gf_div_spc: HL /= gf_spc (power of two).
+gf_div_spc
+                ld    a,(gf_spc)
+gf_dsp          srl   a
+                ret   z
+                srl   h
+                rr    l
+                jr    gf_dsp
+
+; gf_mul_spc: HL *= gf_spc (power of two). Clobbers A,B.
+gf_mul_spc
+                ld    a,(gf_spc)
+                ld    b,0
+gf_log          srl   a
+                jr    z,gf_ms_do
+                inc   b
+                jr    gf_log
+gf_ms_do        inc   b
+gf_ms_dec       dec   b
+                ret   z
+                add   hl,hl
+                jr    gf_ms_dec
+
+; gf_clus_lba: HL = cluster -> HL = first sector LBA.
+gf_clus_lba
+                dec   hl
+                dec   hl
+                call  gf_mul_spc
+                ld    de,(gf_data_lba)
+                add   hl,de
+                ret
+
+; gf_fat_get: HL = cluster -> HL = FAT[cluster].
+gf_fat_get
+                ld    (gf_fclo),hl
+                ld    a,h
+                ld    l,a
+                ld    h,0
+                ld    de,(gf_fat_lba)
+                add   hl,de
+                call  gf_read_sector
+                ld    a,(gf_fclo)
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                ld    de,gf_secbuf
+                add   hl,de
+                ld    a,(hl)
+                ld    e,a
+                inc   hl
+                ld    d,(hl)
+                ex    de,hl
+                ret
+
+; gf_fat_set: HL = cluster, DE = value -> FAT[cluster] = value.
+gf_fat_set
+                ld    (gf_fval),de
+                ld    (gf_fclo),hl
+                ld    a,h
+                ld    l,a
+                ld    h,0
+                ld    de,(gf_fat_lba)
+                add   hl,de
+                ld    (gf_flba),hl
+                call  gf_read_sector
+                ld    a,(gf_fclo)
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                ld    de,gf_secbuf
+                add   hl,de
+                ld    de,(gf_fval)
+                ld    (hl),e
+                inc   hl
+                ld    (hl),d
+                ld    hl,(gf_flba)
+                jp    gf_write_sector
+
+; gf_clus_valid: HL = cluster -> CF set if 2 <= cluster < 0xFFF8.
+gf_clus_valid
+                ld    a,h
+                cp    #FF
+                jr    nz,gf_cv_lo
+                ld    a,l
+                cp    #F8
+                jr    nc,gf_cv_no
+gf_cv_lo        ld    a,h
+                or    a
+                jr    nz,gf_cv_yes
+                ld    a,l
+                cp    2
+                jr    c,gf_cv_no
+gf_cv_yes       scf
+                ret
+gf_cv_no        or    a
+                ret
+
+; gf_free_old: walk the old chain (if overwriting) and zero each FAT entry.
+gf_free_old
+                ld    a,(gf_found)
+                or    a
+                ret   z
+                ld    hl,(gf_old_clus)
+gf_fo_loop
+                call  gf_clus_valid
+                ret   nc
+                ld    (gf_fclus),hl
+                call  gf_fat_get
+                ld    (gf_fnext),hl
+                ld    hl,(gf_fclus)
+                ld    de,0
+                call  gf_fat_set
+                ld    hl,(gf_fnext)
+                jr    gf_fo_loop
+
+; gf_alloc_chain: allocate gf_nclus clusters, chain them, set gf_first.
+gf_alloc_chain
+                ld    hl,0
+                ld    (gf_prev),hl
+                ld    hl,(gf_nclus)
+                ld    (gf_acnt),hl
+gf_ac_loop
+                ld    hl,(gf_acnt)
+                ld    a,h
+                or    l
+                jr    z,gf_ac_ok
+                call  gf_alloc_one
+                ret   nc
+                ld    (gf_fclus),hl
+                ld    de,#FFFF
+                call  gf_fat_set
+                ld    hl,(gf_prev)
+                ld    a,h
+                or    l
+                jr    nz,gf_ac_link
+                ld    hl,(gf_fclus)
+                ld    (gf_first),hl
+                jr    gf_ac_step
+gf_ac_link
+                ld    hl,(gf_prev)
+                ld    de,(gf_fclus)
+                call  gf_fat_set
+gf_ac_step
+                ld    hl,(gf_fclus)
+                ld    (gf_prev),hl
+                ld    hl,(gf_acnt)
+                dec   hl
+                ld    (gf_acnt),hl
+                jr    gf_ac_loop
+gf_ac_ok        scf
+                ret
+
+; gf_alloc_one: scan the FAT for a free entry -> HL = cluster, CF; NC = full.
+gf_alloc_one
+                ld    hl,0
+                ld    (gf_ascan),hl
+gf_ao_sec
+                ld    hl,(gf_ascan)
+                ld    de,(gf_spf)
+                or    a
+                sbc   hl,de
+                jr    nc,gf_ao_full
+                ld    hl,(gf_fat_lba)
+                ld    de,(gf_ascan)
+                add   hl,de
+                call  gf_read_sector
+                ld    hl,gf_secbuf
+                ld    c,0
+                ld    b,0
+gf_ao_ent
+                ld    a,(gf_ascan)
+                or    a
+                jr    nz,gf_ao_chk
+                ld    a,(gf_ascan+1)
+                or    a
+                jr    nz,gf_ao_chk
+                ld    a,c
+                cp    2
+                jr    c,gf_ao_skip
+gf_ao_chk
+                ld    a,(hl)
+                inc   hl
+                or    (hl)
+                dec   hl
+                jr    z,gf_ao_found
+gf_ao_skip
+                inc   hl
+                inc   hl
+                inc   c
+                djnz  gf_ao_ent
+                ld    hl,(gf_ascan)
+                inc   hl
+                ld    (gf_ascan),hl
+                jr    gf_ao_sec
+gf_ao_found
+                ld    a,(gf_ascan)
+                ld    h,a
+                ld    l,c
+                scf
+                ret
+gf_ao_full
+                or    a
+                ret
+
+; gf_write_data: write GBFAT_LEN bytes across the allocated chain.
+gf_write_data
+                ld    hl,GBFAT_DATA
+                ld    (gf_dptr),hl
+                ld    hl,(GBFAT_LEN)
+                ld    (gf_drem),hl
+                ld    hl,(gf_first)
+                ld    (gf_fclus),hl
+                xor   a
+                ld    (gf_sic),a
+gf_wd_loop
+                ld    hl,(gf_secs)
+                ld    a,h
+                or    l
+                ret   z
+                call  gf_fill_sector
+                ld    hl,(gf_fclus)
+                call  gf_clus_lba
+                ld    a,(gf_sic)
+                ld    e,a
+                ld    d,0
+                add   hl,de
+                call  gf_write_sector
+                ld    hl,(gf_secs)
+                dec   hl
+                ld    (gf_secs),hl
+                ld    a,(gf_sic)
+                inc   a
+                ld    b,a
+                ld    a,(gf_spc)
+                cp    b
+                jr    nz,gf_wd_keep
+                ld    hl,(gf_fclus)
+                call  gf_fat_get
+                ld    (gf_fclus),hl
+                xor   a
+                ld    (gf_sic),a
+                jr    gf_wd_loop
+gf_wd_keep
+                ld    a,b
+                ld    (gf_sic),a
+                jr    gf_wd_loop
+
+; gf_fill_sector: up to 512 bytes from gf_dptr into gf_secbuf, zero-padded.
+gf_fill_sector
+                ld    hl,gf_secbuf
+                ld    de,512
+gf_fs_loop
+                ld    a,d
+                or    e
+                ret   z
+                push  hl
+                ld    hl,(gf_drem)
+                ld    a,h
+                or    l
+                pop   hl
+                jr    z,gf_fs_pad
+                push  de
+                ld    de,(gf_dptr)
+                ld    a,(de)
+                inc   de
+                ld    (gf_dptr),de
+                pop   de
+                ld    (hl),a
+                push  hl
+                ld    hl,(gf_drem)
+                dec   hl
+                ld    (gf_drem),hl
+                pop   hl
+                inc   hl
+                dec   de
+                jr    gf_fs_loop
+gf_fs_pad
+                ld    (hl),0
+                inc   hl
+                dec   de
+                jr    gf_fs_loop
+
+; gf_put_entry: write the directory entry (name, attr, start cluster, size).
+gf_put_entry
+                ld    hl,(gf_dir_lba)
+                call  gf_read_sector
+                ld    hl,(gf_dir_off)
+                ld    de,gf_secbuf
+                add   hl,de
+                ld    (gf_eptr),hl
+                push  hl
+                pop   de
+                inc   de
+                ld    (hl),0
+                ld    bc,31
+                ldir
+                ld    hl,GBFAT_NAME
+                ld    de,(gf_eptr)
+                ld    bc,11
+                ldir
+                ld    a,#20
+                ld    (de),a
+                ld    hl,(gf_eptr)
+                ld    de,#1A
+                add   hl,de
+                ld    de,(gf_first)
+                ld    (hl),e
+                inc   hl
+                ld    (hl),d
+                ld    hl,(gf_eptr)
+                ld    de,#1C
+                add   hl,de
+                ld    de,(GBFAT_LEN)
+                ld    (hl),e
+                inc   hl
+                ld    (hl),d
+                inc   hl
+                ld    (hl),0
+                inc   hl
+                ld    (hl),0
+                ld    hl,(gf_dir_lba)
+                jp    gf_write_sector
+
+; gf_find: scan the root dir for GBFAT_NAME or a free slot.
+gf_find
+                xor   a
+                ld    (gf_found),a
+                ld    (gf_havefree),a
+                ld    (gf_sec),a
+gf_fd_sec
+                ld    a,(gf_sec)
+                ld    b,a
+                ld    a,(gf_root_secs)
+                cp    b
+                jr    z,gf_fd_done
+                jr    c,gf_fd_done
+                ld    hl,(gf_root_lba)
+                ld    a,(gf_sec)
+                ld    e,a
+                ld    d,0
+                add   hl,de
+                ld    (gf_cur_lba),hl
+                call  gf_read_sector
+                ld    ix,gf_secbuf
+                ld    b,16
+                ld    c,0
+gf_fd_ent
+                ld    a,(ix+0)
+                or    a
+                jr    z,gf_fd_end0
+                cp    #E5
+                jr    z,gf_fd_free
+                push  bc
+                call  gf_cmpname
+                pop   bc
+                jr    z,gf_fd_match
+                jr    gf_fd_next
+gf_fd_free
+                call  gf_fd_remember
+                jr    gf_fd_next
+gf_fd_match
+                ld    a,1
+                ld    (gf_found),a
+                ld    hl,(gf_cur_lba)
+                ld    (gf_dir_lba),hl
+                call  gf_fd_setoff
+                ld    l,(ix+#1A)
+                ld    h,(ix+#1B)
+                ld    (gf_old_clus),hl
+                scf
+                ret
+gf_fd_next
+                push  bc
+                ld    de,32
+                add   ix,de
+                pop   bc
+                inc   c
+                djnz  gf_fd_ent
+                ld    hl,gf_sec
+                inc   (hl)
+                jr    gf_fd_sec
+gf_fd_end0
+                call  gf_fd_remember
+gf_fd_done
+                ld    a,(gf_havefree)
+                or    a
+                jr    z,gf_fd_full
+                ld    hl,(gf_free_lba)
+                ld    (gf_dir_lba),hl
+                ld    hl,(gf_free_off)
+                ld    (gf_dir_off),hl
+                ld    hl,0
+                ld    (gf_old_clus),hl
+                scf
+                ret
+gf_fd_full
+                or    a
+                ret
+gf_fd_remember
+                ld    a,(gf_havefree)
+                or    a
+                ret   nz
+                ld    a,1
+                ld    (gf_havefree),a
+                ld    hl,(gf_cur_lba)
+                ld    (gf_free_lba),hl
+                call  gf_off_c
+                ld    (gf_free_off),hl
+                ret
+gf_fd_setoff
+                call  gf_off_c
+                ld    (gf_dir_off),hl
+                ret
+gf_off_c                                       ; HL = c * 32
+                ld    a,c
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                ret
+gf_cmpname                                     ; Z if IX 11-byte name == GBFAT_NAME
+                push  ix
+                pop   hl
+                ld    de,GBFAT_NAME
+                ld    b,11
+gf_cn
+                ld    a,(de)
+                cp    (hl)
+                jr    nz,gf_cn_no
+                inc   hl
+                inc   de
+                djnz  gf_cn
+                xor   a
+                ret
+gf_cn_no        or    1
+                ret
+
+; ---------------------------------------------------------------------------
+; gf_read_sector / gf_write_sector: 512 bytes, LBA in HL (16-bit), via gf_secbuf.
+gf_read_sector
+                push  hl
+                ld    a,#E0
+                ld    bc,FS_IDE_DEV
+                out   (c),a
+                ld    a,1
+                ld    bc,FS_IDE_SCNT
+                out   (c),a
+                pop   hl
+                ld    a,l
+                ld    bc,FS_IDE_LBAL
+                out   (c),a
+                ld    a,h
+                ld    bc,FS_IDE_LBAM
+                out   (c),a
+                xor   a
+                ld    bc,FS_IDE_LBAH
+                out   (c),a
+                ld    a,#20
+                ld    bc,FS_IDE_CMD
+                out   (c),a
+gf_rs_poll
+                ld    bc,FS_IDE_STAT
+                in    a,(c)
+                bit   3,a
+                jr    z,gf_rs_poll
+                ld    hl,gf_secbuf
+                ld    de,512
+                ld    bc,FS_IDE_DATA
+gf_rs_rd
+                in    a,(c)
+                ld    (hl),a
+                inc   hl
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,gf_rs_rd
+                ret
+
+gf_write_sector
+                push  hl
+                ld    a,#E0
+                ld    bc,FS_IDE_DEV
+                out   (c),a
+                ld    a,1
+                ld    bc,FS_IDE_SCNT
+                out   (c),a
+                pop   hl
+                ld    a,l
+                ld    bc,FS_IDE_LBAL
+                out   (c),a
+                ld    a,h
+                ld    bc,FS_IDE_LBAM
+                out   (c),a
+                xor   a
+                ld    bc,FS_IDE_LBAH
+                out   (c),a
+                ld    a,#30
+                ld    bc,FS_IDE_CMD
+                out   (c),a
+gf_ws_drq
+                ld    bc,FS_IDE_STAT
+                in    a,(c)
+                bit   3,a
+                jr    z,gf_ws_drq
+                ld    hl,gf_secbuf
+                ld    de,512
+                ld    bc,FS_IDE_DATA
+gf_ws_wr
+                ld    a,(hl)
+                out   (c),a
+                inc   hl
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,gf_ws_wr
+gf_ws_busy
+                ld    bc,FS_IDE_STAT
+                in    a,(c)
+                bit   7,a
+                jr    nz,gf_ws_busy
+                ret
+
+; --- state ---------------------------------------------------------------
+gf_root_lba     defw  0
+gf_root_secs    defb  0
+gf_spc          defb  0
+gf_fat_lba      defw  0
+gf_data_lba     defw  0
+gf_spf          defw  0
+gf_secs         defw  0
+gf_nclus        defw  0
+gf_first        defw  0
+gf_found        defb  0
+gf_old_clus     defw  0
+gf_havefree     defb  0
+gf_dir_lba      defw  0
+gf_dir_off      defw  0
+gf_free_lba     defw  0
+gf_free_off     defw  0
+gf_sec          defb  0
+gf_cur_lba      defw  0
+gf_eptr         defw  0
+gf_fclus        defw  0
+gf_fnext        defw  0
+gf_prev         defw  0
+gf_acnt         defw  0
+gf_ascan        defw  0
+gf_fclo         defw  0
+gf_fval         defw  0
+gf_flba         defw  0
+gf_sic          defb  0
+gf_dptr         defw  0
+gf_drem         defw  0
+gf_secbuf       defs  512
+gbfat_end
+
+                save  "build/GBFAT.RAW",GBFAT_ORG,gbfat_end-GBFAT_ORG

--- a/lib/firmware.inc
+++ b/lib/firmware.inc
@@ -28,6 +28,9 @@ KM_READ_CHAR    equ   #BB09       ; -> CF + A = char from the buffer, or NC = no
 KM_DISARM_BREAK equ   #BB48       ; disable the ESC->BREAK (reset) mechanism
 KM_TEST_KEY     equ   #BB1E       ; A = key number; exit NZ if pressed
 KM_GET_JOYSTICK equ   #BB24       ; A = joystick 0 state, H = joystick 1
+KM_SET_TRANSLATE equ  #BB39       ; A = key number, B = char it returns (&FF = none)
+KM_SET_SHIFT    equ   #BB3C       ; ... when Shift is held
+KM_SET_CONTROL  equ   #BB3F       ; ... when Control is held
 
 ; --- Machine pack --------------------------------------------------------
 MC_WAIT_FLYBACK equ   #BD19       ; wait for frame flyback

--- a/lib/fs.asm
+++ b/lib/fs.asm
@@ -51,8 +51,10 @@ fs_dir_next
 fs_load_file
                 ld    hl,(fs_p_load)
                 jp    (hl)
-; fs_save_file: save fs_save_len bytes from (fs_save_src) to fs_req_name (must
-; exist; overwrite in place). CF set = saved, NC = failed.
+; fs_save_file: save fs_save_len bytes from (fs_save_src) to fs_req_name. The
+; AMSDOS backend creates the file if absent and allocates/frees 1KB blocks as the
+; size changes (single extent, <=16KB). CF set = saved, NC = failed (disk/dir
+; full, too big, or - FAT16 - not yet implemented).
 fs_save_file
                 ld    hl,(fs_p_save)
                 jp    (hl)

--- a/lib/fs_amsdos.asm
+++ b/lib/fs_amsdos.asm
@@ -1009,9 +1009,8 @@ fsv_dptr        defw  0            ; save: pointer into the source data
 fsv_drem        defw  0            ; save: source bytes left
 fsv_nblk        defb  0            ; save: 1KB blocks the file needs
 fsv_cand        defb  0            ; alloc: candidate block being tested
-fsam_buf        defs  2048
-; save: one assembled 512-byte sector. Aliased onto the IDE backend's sector
-; buffer (fs_secbuf) - fs_init picks exactly one backend, so the two are never
-; live at once. Saves 512 resident bytes (the kernel is right at the AMSDOS load
-; ceiling ~#A67B).
+; fsam_buf (the 2KB whole-directory buffer) is defined after kern_end in
+; gbkern.asm so it is scratch RAM, not part of the loaded GBKERN.BIN image.
+; fsam_wbuf (the write sector) is aliased onto the IDE backend's fs_secbuf -
+; fs_init picks exactly one backend, so the two are never live at once.
 fsam_wbuf       equ   fs_secbuf

--- a/lib/fs_amsdos.asm
+++ b/lib/fs_amsdos.asm
@@ -1010,4 +1010,8 @@ fsv_drem        defw  0            ; save: source bytes left
 fsv_nblk        defb  0            ; save: 1KB blocks the file needs
 fsv_cand        defb  0            ; alloc: candidate block being tested
 fsam_buf        defs  2048
-fsam_wbuf       defs  512          ; save: one assembled 512-byte sector
+; save: one assembled 512-byte sector. Aliased onto the IDE backend's sector
+; buffer (fs_secbuf) - fs_init picks exactly one backend, so the two are never
+; live at once. Saves 512 resident bytes (the kernel is right at the AMSDOS load
+; ceiling ~#A67B).
+fsam_wbuf       equ   fs_secbuf

--- a/lib/fs_amsdos.asm
+++ b/lib/fs_amsdos.asm
@@ -584,6 +584,26 @@ fwr_res_loop
 fsam_save_file
                 call  fsam_motor_on
                 call  fsam_read_dir                  ; directory -> fsam_buf
+                ld    hl,(fs_save_len)                ; Rc = ceil((128+len)/128)
+                ld    de,128
+                add   hl,de
+                ld    de,127
+                add   hl,de
+                ld    a,h
+                add   a,a
+                ld    d,a
+                ld    a,l
+                rlca
+                and   1
+                add   a,d
+                ld    (fsam_rc),a
+                add   a,7                              ; nblk = ceil(Rc/8) 1KB blocks
+                srl   a
+                srl   a
+                srl   a
+                ld    (fsv_nblk),a
+                cp    17
+                jr    nc,fsv_fail                      ; > 16 blocks -> single extent only
                 ld    ix,fsam_buf                    ; find the Ex=0 entry by name
                 ld    b,64
 fsv_scan
@@ -594,54 +614,37 @@ fsv_scan
                 or    a
                 jr    nz,fsv_next
                 call  fsam_namematch
-                jr    z,fsv_found
+                jr    z,fsv_have                       ; existing file -> reuse the entry
 fsv_next
                 push  bc
                 ld    de,32
                 add   ix,de
                 pop   bc
                 djnz  fsv_scan
+                call  fsv_find_free_entry             ; not found -> create in a free slot
+                jr    nc,fsv_fail                      ; directory full
+                push  ix                              ; init it: user 0, name, the rest 0
+                pop   hl
+                ld    (hl),0
+                push  ix
+                pop   de
+                inc   de
+                ld    bc,31
+                ldir
+                ld    hl,fs_req_name
+                push  ix
+                pop   de
+                inc   de
+                ld    bc,11
+                ldir
+                jr    fsv_have
 fsv_fail
                 call  fsam_motor_off
                 or    a                               ; NC
                 ret
-fsv_found
-                ld    hl,(fs_save_len)                ; total = 128 + len
-                ld    de,128
-                add   hl,de
-                ld    de,127                          ; Rc = ceil(total/128)
-                add   hl,de
-                ld    a,h
-                add   a,a
-                ld    d,a
-                ld    a,l
-                rlca
-                and   1
-                add   a,d
-                ld    (fsam_rc),a
-                push  ix                              ; capacity = (#blocks)*8 records
-                pop   hl
-                ld    de,16
-                add   hl,de                           ; HL = block list
-                ld    b,16
-                ld    c,0
-fsv_cnt
-                ld    a,(hl)
-                or    a
-                jr    z,fsv_cntsk
-                inc   c
-fsv_cntsk
-                inc   hl
-                djnz  fsv_cnt
-                ld    a,c
-                add   a,a
-                add   a,a
-                add   a,a                              ; blocks*8
-                ld    b,a
-                ld    a,(fsam_rc)
-                cp    b
-                jr    z,fsv_fits
-                jr    nc,fsv_fail                      ; Rc > capacity -> won't fit
+fsv_have
+                call  fsv_ensure_blocks               ; alloc/free 1KB blocks to fsv_nblk
+                jr    nc,fsv_fail                      ; disk full
 fsv_fits
                 ld    hl,fsam_wbuf                    ; build the 128-byte header
                 ld    de,fsam_wbuf+1
@@ -802,6 +805,147 @@ fsv_fdpad
                 dec   bc
                 jr    fsv_filldata
 
+; fsv_find_free_entry: IX -> first &E5 (free) directory slot. CF set, or NC if the
+; directory is full.
+fsv_find_free_entry
+                ld    ix,fsam_buf
+                ld    b,64
+ffe_loop
+                ld    a,(ix+0)
+                cp    #E5
+                jr    z,ffe_found
+                push  bc
+                ld    de,32
+                add   ix,de
+                pop   bc
+                djnz  ffe_loop
+                or    a                               ; NC = directory full
+                ret
+ffe_found
+                scf
+                ret
+
+; fsv_ensure_blocks: make the entry at IX own exactly fsv_nblk 1KB blocks. Blocks
+; are packed at the front of the 16-byte block list. Grows by allocating free
+; blocks, shrinks by zeroing the tail. CF set = ok, NC = disk full.
+fsv_ensure_blocks
+                push  ix                              ; count current blocks -> C
+                pop   hl
+                ld    de,16
+                add   hl,de
+                ld    b,16
+                ld    c,0
+eb_count
+                ld    a,(hl)
+                or    a
+                jr    z,eb_counted                     ; first zero = end (packed front)
+                inc   c
+                inc   hl
+                djnz  eb_count
+eb_counted
+                ld    a,(fsv_nblk)
+                cp    c
+                jr    z,eb_ok
+                jr    nc,eb_grow                       ; need more blocks
+                ld    a,(fsv_nblk)                    ; need fewer -> zero slots [nblk..15]
+                ld    c,a
+eb_trim
+                ld    a,c
+                cp    16
+                jr    nc,eb_ok
+                push  ix
+                pop   hl
+                ld    de,16
+                add   hl,de
+                ld    e,c
+                ld    d,0
+                add   hl,de
+                ld    (hl),0
+                inc   c
+                jr    eb_trim
+eb_grow
+                ld    a,(fsv_nblk)
+                cp    c
+                jr    z,eb_ok
+                call  fsv_alloc1                       ; -> A = free block, NC = disk full
+                ret   nc
+                push  ix
+                pop   hl
+                ld    de,16
+                add   hl,de
+                ld    e,c
+                ld    d,0
+                add   hl,de
+                ld    (hl),a                           ; store the block at slot C
+                inc   c
+                jr    eb_grow
+eb_ok
+                scf
+                ret
+
+; fsv_alloc1: find a free 1KB block (2..179; 0/1 are the directory). A new block
+; is one that no directory entry references - and because each allocation is
+; written into the entry's block list before the next call, repeats are excluded.
+; -> A = block, CF set; NC if the disk is full. Preserves BC and IX.
+fsv_alloc1
+                push  bc
+                push  ix
+                ld    a,2
+fa1_try
+                ld    (fsv_cand),a
+                call  fsv_block_used                   ; Z if some entry uses it
+                jr    nz,fa1_free
+                ld    a,(fsv_cand)
+                inc   a
+                cp    180                              ; DATA format: blocks 0..179
+                jr    c,fa1_try
+                pop   ix
+                pop   bc
+                or    a                                ; NC = disk full
+                ret
+fa1_free
+                pop   ix
+                pop   bc
+                ld    a,(fsv_cand)
+                scf
+                ret
+
+; fsv_block_used: A = block number -> Z if any directory entry references it.
+fsv_block_used
+                ld    c,a                              ; C = target block
+                ld    hl,fsam_buf
+                ld    b,64
+fbu_ent
+                ld    a,(hl)
+                cp    #E5
+                jr    z,fbu_skip
+                push  hl
+                push  bc
+                ld    de,16
+                add   hl,de                            ; -> block list
+                ld    b,16
+fbu_blk
+                ld    a,(hl)
+                cp    c
+                jr    z,fbu_hit
+                inc   hl
+                djnz  fbu_blk
+                pop   bc
+                pop   hl
+fbu_skip
+                push  bc
+                ld    de,32
+                add   hl,de
+                pop   bc
+                djnz  fbu_ent
+                or    1                                ; NZ = free
+                ret
+fbu_hit
+                pop   bc
+                pop   hl
+                xor   a                                ; Z = used
+                ret
+
 ; fsam_namematch: IX = dir entry; Z if its 8.3 name == fs_req_name (11 bytes).
 fsam_namematch
                 push  ix
@@ -863,5 +1007,7 @@ fsv_si          defb  0            ; save: sector index within the file
 fsv_curtrk      defb  0            ; save: track the head is on
 fsv_dptr        defw  0            ; save: pointer into the source data
 fsv_drem        defw  0            ; save: source bytes left
+fsv_nblk        defb  0            ; save: 1KB blocks the file needs
+fsv_cand        defb  0            ; alloc: candidate block being tested
 fsam_buf        defs  2048
 fsam_wbuf       defs  512          ; save: one assembled 512-byte sector

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -409,4 +409,7 @@ fs_data_lba     defw  0            ; data region start LBA
 flf_secs        defw  0            ; load: sectors remaining
 flf_clus        defw  0            ; load: current cluster
 flf_sic         defb  0            ; load: sector within the cluster
-fs_secbuf       defs  512
+; fs_secbuf (the 512-byte sector buffer) is defined after kern_end in gbkern.asm
+; so it is NOT part of the loaded GBKERN.BIN image - it is scratch RAM filled at
+; runtime. Keeping it (and the 2KB fsam_buf) out of the image shrinks the load by
+; 2.5KB, so the kernel fits under UniDOS+FatFS HIMEM (&A288) on an IDE machine.

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -23,6 +23,15 @@ FS_IDE_CMD      equ   #FD0F
 FS_IDE_STAT     equ   #FD0F
 FS_IDE_DATA     equ   #FD08
 
+; FAT16 write happens in a paged module (kernel/modules/gbfat.asm), loaded into
+; the free top of PAGE_DATA on demand. The resident stub marshals the data + name
+; into this low-RAM transfer area (resident, reachable from the paged module):
+GBFAT_LEN       equ   #1400        ; bytes to write (word)
+GBFAT_NAME      equ   #1402        ; 8.3 name (11 bytes)
+GBFAT_RES       equ   #140D        ; result: 1 = saved, 0 = failed
+GBFAT_DATA      equ   #1800        ; staged data (<= 8KB)
+GBFAT_LOAD      equ   #5000        ; module load address (above the font/icons)
+
 ; ---------------------------------------------------------------------------
 ; fside_dir_first: mount the volume (read BPB, locate the root directory) and
 ; return the first valid entry.
@@ -168,11 +177,59 @@ fdn_end
                 ret
 
 ; ---------------------------------------------------------------------------
-; fside_save_file: not yet implemented for the IDE/FAT16 backend. NC = failed.
-; (The floppy/AMSDOS backend has the write path; FAT16 write is a follow-up.)
+; fside_save_file: save fs_save_len bytes from (fs_save_src) to fs_req_name via
+; the paged FAT16-write module (GBFAT.BIN). The write path is too large to keep
+; resident, so the data + name are copied into the low-RAM transfer area (while
+; the app's page is still mapped), the module is loaded into the free top of
+; PAGE_DATA and CALLed, and it does the FAT16 write over the IDE ports. CF set =
+; saved. Files larger than the 8KB staging buffer are refused.
 fside_save_file
+                ld    hl,(fs_save_len)        ; refuse > 8KB (low-RAM staging buffer)
+                ld    de,#2000
+                or    a
+                sbc   hl,de
+                jr    nc,fsv_mod_fail
+                ld    hl,(fs_save_src)        ; copy the data out of the app page
+                ld    de,GBFAT_DATA           ; into low RAM (app page mapped now)
+                ld    bc,(fs_save_len)
+                ld    a,b
+                or    c
+                jr    z,fsv_mod_nlen
+                ldir
+fsv_mod_nlen
+                ld    hl,fs_req_name          ; name + length -> the transfer area
+                ld    de,GBFAT_NAME
+                ld    bc,11
+                ldir
+                ld    hl,(fs_save_len)
+                ld    (GBFAT_LEN),hl
+                ld    a,(bank_cur)            ; page in PAGE_DATA, load + run the module
+                push  af
+                ld    a,PAGE_DATA
+                call  bank_set
+                ld    hl,gbfat_modname        ; fs_req_name = "GBFAT   BIN"
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    hl,#2000
+                ld    (fs_load_max),hl
+                ld    hl,GBFAT_LOAD
+                ld    (fs_load_dst),hl
+                call  fs_load_file            ; load GBFAT.BIN -> #5000 (above the icons)
+                jr    nc,fsv_mod_unload        ; module missing -> fail
+                call  GBFAT_LOAD              ; run it (reads low RAM, writes the IDE)
+fsv_mod_unload
+                pop   af
+                call  bank_set
+                ld    a,(GBFAT_RES)          ; result byte -> CF
+                or    a
+                ret   z
+                scf
+                ret
+fsv_mod_fail
                 or    a
                 ret
+gbfat_modname   db    "GBFAT   BIN"          ; 8.3, space-padded
 
 ; ---------------------------------------------------------------------------
 ; fside_load_file: load the file named in fs_req_name (11-byte 8.3) into the

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -483,15 +483,16 @@ dfs_cmp
                 ld    (sav_found),a
                 pop   de                          ; DE = offset within sector
                 ld    (sav_ent_off),de
-                call  dfs_store_lba
-                ld    bc,#1A                      ; old start cluster: low @0x1A hi @0x14
-                add   hl,bc
+                call  dfs_store_lba               ; (clobbers HL/BC - recompute below)
+                ld    hl,fs_secbuf+#1A            ; old start cluster: low word @0x1A
+                ld    de,(sav_ent_off)
+                add   hl,de
                 ld    a,(hl)
                 ld    (sav_old_clus),a
                 inc   hl
                 ld    a,(hl)
                 ld    (sav_old_clus+1),a
-                ld    hl,fs_secbuf+#14
+                ld    hl,fs_secbuf+#14            ; high word @0x14
                 ld    de,(sav_ent_off)
                 add   hl,de
                 ld    a,(hl)

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -1,17 +1,28 @@
 ; ---------------------------------------------------------------------------
-; lib/fs_ide_fat.asm - storage backend: FAT16 over the SYMBiFACE II / Cyboard
-; IDE interface. Reads the root directory straight off the IDE controller, with
-; no AMSDOS/UniDOS involvement. Selected by lib/fs.asm when an IDE is present.
+; lib/fs_ide_fat.asm - storage backend: FAT32 over the SYMBiFACE II / Cyboard
+; IDE interface. Reads the volume straight off the IDE controller, with no
+; AMSDOS/UniDOS involvement. Selected by lib/fs.asm when an IDE is present.
+;
+; The real-world target is a large FAT32 disk (e.g. a 1 GB CF card shared with
+; UniDOS/SymbOS), so this backend speaks FAT32 with 32-bit cluster numbers and
+; issues 24-bit LBA reads (files land high on a near-full disk, well past the
+; 16-bit LBA range). An MBR partition table is honoured; a superfloppy (FAT BPB
+; directly at LBA 0) is treated as partition base 0.
 ;
 ; Backend entry points (the floppy backend exposes the matching fsam_* names so
 ; the dispatcher in lib/fs.asm can route to either):
 ;   fside_dir_first -> CF set = first entry ready in fs_ent_*, NC = empty
 ;   fside_dir_next  -> CF set = next entry ready,              NC = end of dir
+;   fside_load_file -> CF set = loaded (fs_ent_size bytes),    NC = not found
+;   fside_save_file -> CF set = saved (create or overwrite),   NC = failed
+; The save path allocates clusters, writes both FAT copies, and the directory
+; entry directly over the IDE ports (FSInfo free-count is left untouched - it is
+; advisory and FatFs/fsck tolerate drift).
 ; Per-entry output fields fs_ent_name/attr/size live in lib/fs.asm (shared).
 ;
 ; IDE port map (from 1984 src/ide.c; port = &FD00 | reg):
 ;   &FD0A scnt  &FD0B lbaL  &FD0C lbaM  &FD0D lbaH  &FD0E dev  &FD0F cmd/status
-;   &FD08 data (1 byte per IN).  READ SECTORS = &20, DRQ = status bit 3.
+;   &FD08 data (1 byte per IN).  READ SECTORS = &20, status: 7=BSY 3=DRQ 0=ERR.
 ; ---------------------------------------------------------------------------
 
 FS_IDE_SCNT     equ   #FD0A
@@ -23,88 +34,72 @@ FS_IDE_CMD      equ   #FD0F
 FS_IDE_STAT     equ   #FD0F
 FS_IDE_DATA     equ   #FD08
 
-; FAT16 write happens in a paged module (kernel/modules/gbfat.asm), loaded into
-; the free top of PAGE_DATA on demand. The resident stub marshals the data + name
-; into this low-RAM transfer area (resident, reachable from the paged module):
-GBFAT_LEN       equ   #1400        ; bytes to write (word)
-GBFAT_NAME      equ   #1402        ; 8.3 name (11 bytes)
-GBFAT_RES       equ   #140D        ; result: 1 = saved, 0 = failed
-GBFAT_DATA      equ   #1800        ; staged data (<= 8KB)
-GBFAT_LOAD      equ   #5000        ; module load address (above the font/icons)
-
 ; ---------------------------------------------------------------------------
-; fside_dir_first: mount the volume (read BPB, locate the root directory) and
-; return the first valid entry.
+; fside_dir_first: mount the volume (MBR/partition probe + FAT32 BPB) and return
+; the first valid directory entry.
 fside_dir_first
-                ld    hl,0                    ; BPB lives at LBA 0
-                call  fs_read_sector
-
-                ld    hl,0                    ; root_lba = reserved + fats*spf
-                ld    a,(fs_secbuf+#10)       ; number of FATs
-                ld    b,a
-                ld    de,(fs_secbuf+#16)      ; sectors per FAT
-ffr_mul
-                add   hl,de
-                djnz  ffr_mul
-                ld    de,(fs_secbuf+#0E)      ; reserved sectors
-                add   hl,de
-                ld    (fs_root_lba),hl
-
-                ld    hl,(fs_secbuf+#11)      ; root entry count / 16 = sectors
-                srl   h
-                rr    l
-                srl   h
-                rr    l
-                srl   h
-                rr    l
-                srl   h
-                rr    l
-                ld    a,l
-                or    a
-                jr    nz,ffr_secok
-                inc   a                        ; at least one sector
-ffr_secok
-                ld    (fs_root_secs),a
-
-                ld    a,(fs_secbuf+#0D)       ; geometry for file reads (BPB still
-                ld    (fs_spc),a               ; in secbuf): sectors per cluster,
-                ld    hl,(fs_secbuf+#0E)      ; FAT start (= reserved),
-                ld    (fs_fat_lba),hl
-                ld    hl,(fs_root_lba)        ; data start = root_lba + root_secs
-                ld    a,(fs_root_secs)
-                ld    e,a
-                ld    d,0
-                add   hl,de
-                ld    (fs_data_lba),hl
-
-                xor   a
-                ld    (fs_cur_sec),a
-                ld    (fs_ent_idx),a
-                ld    hl,(fs_root_lba)        ; load the first root-dir sector
-                call  fs_read_sector
+                call  fs_mount
+                call  fs_dir_rewind           ; load the first root-dir sector
                 jp    fdn_loop                 ; scan for the first valid entry
 
+; fs_mount: MBR/partition probe + FAT32 BPB -> fs_fat_lba, fs_data_lba, fs_spc,
+; fs_clshift, fs_dir_clus (root cluster). No directory scan.
+fs_mount
+                call  clear_part_lba          ; probe the MBR at ABSOLUTE LBA 0
+                call  clear_lba_tmp
+                call  fs_read_sector
+                call  fs_detect_part          ; -> fs_part_lba (0 = superfloppy)
+
+                ld    hl,fs_part_lba          ; read the FAT32 BPB at the volume base
+                call  lbatmp_from_var
+                call  fs_read_sector
+
+                ld    a,(fs_secbuf+#0D)       ; sectors per cluster + its log2
+                ld    (fs_spc),a
+                ld    b,0
+fdf_log         srl   a
+                jr    z,fdf_logd
+                inc   b
+                jr    fdf_log
+fdf_logd        ld    a,b
+                ld    (fs_clshift),a
+
+                ld    hl,fs_part_lba          ; fat_lba = part_base + reserved sectors
+                call  acc_load
+                ld    de,(fs_secbuf+#0E)
+                call  acc_add16
+                call  acc_store_fat
+
+                ld    hl,fs_secbuf+#24        ; sectors per FAT (FAT32, 32-bit)
+                ld    de,fatsz_tmp
+                ld    bc,4
+                ldir
+                ld    a,(fs_secbuf+#10)       ; data_lba = fat_lba + numFATs*fatsz
+                ld    (fs_numfat),a
+                ld    b,a                       ; (acc still holds fat_lba)
+fdf_dl          push  bc
+                ld    hl,fatsz_tmp
+                call  acc_add
+                pop   bc
+                djnz  fdf_dl
+                call  acc_store_data
+
+                ld    hl,fs_secbuf+#2C        ; root directory start cluster
+                ld    de,fs_dir_clus
+                ld    bc,4
+                ldir
+                ret
+
 ; ---------------------------------------------------------------------------
-; fside_dir_next: scan forward (across sectors) for the next valid 8.3 entry.
+; fside_dir_next: scan forward for the next valid 8.3 entry, walking the root
+; directory's cluster chain across sectors.
 fside_dir_next
 fdn_loop
                 ld    a,(fs_ent_idx)
                 cp    16                       ; 16 entries per 512-byte sector
                 jr    c,fdn_have
-                ld    a,(fs_cur_sec)           ; exhausted: step to next sector
-                inc   a
-                ld    (fs_cur_sec),a
-                ld    b,a
-                ld    a,(fs_root_secs)
-                cp    b
-                jp    z,fdn_end                ; past the last root-dir sector
-                jp    c,fdn_end
-                ld    hl,(fs_root_lba)
-                ld    a,(fs_cur_sec)
-                ld    e,a
-                ld    d,0
-                add   hl,de
-                call  fs_read_sector
+                call  fs_dir_step              ; advance to the next dir sector
+                jp    nc,fdn_end               ; end of directory chain
                 xor   a
                 ld    (fs_ent_idx),a
 fdn_have
@@ -136,23 +131,23 @@ fdn_have
                 jr    z,fdn_skip               ; long-file-name fragment
                 ld    a,b
                 and   #08
-                jr    nz,fdn_skip              ; volume label
+                jr    nz,fdn_skip              ; volume label / directory-as-label
 
                 push  hl                       ; valid -> copy fields out
                 ld    de,fs_ent_name
                 ld    bc,11
                 ldir
                 pop   hl
-                ld    a,b                       ; attr was saved in B
+                ld    a,b                       ; attr saved in B
                 ld    (fs_ent_attr),a
                 push  hl
-                ld    de,#1C
+                ld    de,#1C                    ; size (4 bytes @ 0x1C)
                 add   hl,de
                 ld    de,fs_ent_size
                 ld    bc,4
                 ldir
                 pop   hl
-                push  hl                       ; start cluster (word @ 0x1A)
+                push  hl                       ; cluster: low word @0x1A
                 ld    de,#1A
                 add   hl,de
                 ld    a,(hl)
@@ -160,6 +155,15 @@ fdn_have
                 inc   hl
                 ld    a,(hl)
                 ld    (fs_ent_clus+1),a
+                pop   hl
+                push  hl                       ; cluster: high word @0x14
+                ld    de,#14
+                add   hl,de
+                ld    a,(hl)
+                ld    (fs_ent_clus+2),a
+                inc   hl
+                ld    a,(hl)
+                ld    (fs_ent_clus+3),a
                 pop   hl
 
                 ld    a,(fs_ent_idx)
@@ -176,83 +180,663 @@ fdn_end
                 or    a                         ; CF clear = end of directory
                 ret
 
-; ---------------------------------------------------------------------------
-; fside_save_file: save fs_save_len bytes from (fs_save_src) to fs_req_name via
-; the paged FAT16-write module (GBFAT.BIN). The write path is too large to keep
-; resident, so the data + name are copied into the low-RAM transfer area (while
-; the app's page is still mapped), the module is loaded into the free top of
-; PAGE_DATA and CALLed, and it does the FAT16 write over the IDE ports. CF set =
-; saved. Files larger than the 8KB staging buffer are refused.
-fside_save_file
-                ld    hl,(fs_save_len)        ; refuse > 8KB (low-RAM staging buffer)
-                ld    de,#2000
-                or    a
-                sbc   hl,de
-                jr    nc,fsv_mod_fail
-                ld    hl,(fs_save_src)        ; copy the data out of the app page
-                ld    de,GBFAT_DATA           ; into low RAM (app page mapped now)
-                ld    bc,(fs_save_len)
-                ld    a,b
-                or    c
-                jr    z,fsv_mod_nlen
+; fs_dir_rewind: position at the first sector of the root directory cluster.
+fs_dir_rewind
+                xor   a
+                ld    (fs_dir_sic),a
+                ld    (fs_ent_idx),a
+                ld    hl,fs_dir_clus
+                call  clus_first_lba
+                call  save_dir_lba
+                jp    fs_read_sector
+save_dir_lba                                    ; remember the dir sector now in secbuf
+                ld    hl,lba_tmp
+                ld    de,fs_dir_cur_lba
+                ld    bc,4
                 ldir
-fsv_mod_nlen
-                ld    hl,fs_req_name          ; name + length -> the transfer area
-                ld    de,GBFAT_NAME
-                ld    bc,11
-                ldir
-                ld    hl,(fs_save_len)
-                ld    (GBFAT_LEN),hl
-                ld    a,(bank_cur)            ; page in PAGE_DATA, load + run the module
-                push  af
-                ld    a,PAGE_DATA
-                call  bank_set
-                ld    hl,gbfat_modname        ; fs_req_name = "GBFAT   BIN"
-                ld    de,fs_req_name
-                ld    bc,11
-                ldir
-                ld    hl,#2000
-                ld    (fs_load_max),hl
-                ld    hl,GBFAT_LOAD
-                ld    (fs_load_dst),hl
-                call  fs_load_file            ; load GBFAT.BIN -> #5000 (above the icons)
-                jr    nc,fsv_mod_unload        ; module missing -> fail
-                call  GBFAT_LOAD              ; run it (reads low RAM, writes the IDE)
-fsv_mod_unload
-                pop   af
-                call  bank_set
-                ld    a,(GBFAT_RES)          ; result byte -> CF
-                or    a
-                ret   z
+                ret
+
+; fs_dir_step: advance to the next directory sector (within the cluster, else
+; follow the FAT to the next cluster). CF set = sector loaded, NC = end of chain.
+fs_dir_step
+                ld    a,(fs_dir_sic)
+                inc   a
+                ld    b,a
+                ld    a,(fs_spc)
+                cp    b
+                jr    z,fds_nextclus
+                jr    c,fds_nextclus
+                ld    a,b                       ; still inside the cluster
+                ld    (fs_dir_sic),a
+                jr    fds_load
+fds_nextclus
+                ld    hl,fs_dir_clus
+                call  fs_fat_next
+                jr    nc,fds_end
+                xor   a
+                ld    (fs_dir_sic),a
+fds_load
+                ld    hl,fs_dir_clus
+                call  clus_first_lba
+                ld    a,(fs_dir_sic)
+                call  lba_add_a
+                call  save_dir_lba
+                call  fs_read_sector
                 scf
                 ret
-fsv_mod_fail
+fds_end
                 or    a
                 ret
-gbfat_modname   db    "GBFAT   BIN"          ; 8.3, space-padded
+
+; ---------------------------------------------------------------------------
+; fside_save_file: write fs_save_len bytes from (fs_save_src) to a file named
+; fs_req_name on the FAT32 volume (create or overwrite in place). The source page
+; stays mapped (k_fssave), so the data is read directly. CF set = saved.
+; Bounds: <= 32 KB (sane for the editor) to keep the cluster loop simple.
+fside_save_file
+                ld    hl,(fs_save_len)        ; refuse absurdly large saves
+                ld    de,#8000
+                or    a
+                sbc   hl,de
+                jp    nc,fes_fail
+                call  fs_mount
+
+                ld    a,(fs_clshift)          ; clbytes = 512<<clshift; nclus =
+                add   a,9                      ; ceil(len/clbytes) = (len+clbytes-1)>>(9+clshift)
+                ld    b,a                       ; B = shift count (9..)
+                ld    hl,(fs_save_len)
+                ld    de,1                      ; clbytes-1 = (1<<(9+clshift))-1
+fes_m1          sla   e
+                rl    d
+                djnz  fes_m1
+                dec   de                        ; DE = clbytes-1
+                add   hl,de                     ; HL = len + clbytes-1
+                ld    a,(fs_clshift)
+                add   a,9
+                ld    b,a
+fes_m2          srl   h
+                rr    l
+                djnz  fes_m2
+                ld    a,h                        ; nclus must be >=1 (even a 0-byte file
+                or    l                          ; gets one cluster)
+                jr    nz,fes_nc_ok
+                ld    hl,1
+fes_nc_ok       ld    (sav_nclus),hl
+
+                call  fs_dir_find_slot          ; locate existing entry or a free slot
+                jp    nc,fes_fail               ; directory full
+
+                ld    a,(sav_found)             ; overwrite? free the old cluster chain
+                or    a
+                jr    z,fes_alloc
+                ld    hl,sav_old_clus
+                call  fs_free_chain
+fes_alloc
+                ld    hl,(fs_save_src)          ; source cursor + remaining bytes
+                ld    (sav_src),hl
+                ld    hl,(fs_save_len)
+                ld    (sav_rem),hl
+                xor   a                          ; sav_prev_clus = 0 (no previous link)
+                ld    (sav_prev_clus),a
+                ld    (sav_prev_clus+1),a
+                ld    (sav_prev_clus+2),a
+                ld    (sav_prev_clus+3),a
+                ld    (sav_have_prev),a
+                ld    hl,(sav_nclus)
+                ld    (sav_left),hl
+fes_loop
+                ld    hl,(sav_left)
+                ld    a,h
+                or    l
+                jr    z,fes_dirent
+                call  fs_alloc_cluster          ; alloc_clus = a free cluster (now EOC)
+                jp    nc,fes_fail               ; disk full
+                ld    a,(sav_have_prev)         ; link prev -> this (first time: record start)
+                or    a
+                jr    nz,fes_link
+                ld    hl,alloc_clus             ; first cluster = file start
+                ld    de,sav_first_clus
+                ld    bc,4
+                ldir
+                jr    fes_setprev
+fes_link
+                ld    hl,sav_prev_clus          ; fat_set(prev, alloc_clus)
+                ld    de,fat_set_clus
+                ld    bc,4
+                ldir
+                ld    hl,alloc_clus
+                ld    de,fat_set_val
+                ld    bc,4
+                ldir
+                call  fs_fat_set
+fes_setprev
+                ld    hl,alloc_clus             ; prev = this
+                ld    de,sav_prev_clus
+                ld    bc,4
+                ldir
+                ld    a,1
+                ld    (sav_have_prev),a
+                call  sav_write_cluster_data    ; write spc sectors from the source
+                ld    hl,(sav_left)
+                dec   hl
+                ld    (sav_left),hl
+                jr    fes_loop
+fes_dirent
+                call  sav_write_dirent          ; commit the directory entry
+                scf
+                ret
+fes_fail
+                or    a
+                ret
+
+; sav_write_cluster_data: write fs_spc sectors of cluster alloc_clus, pulling from
+; (sav_src)/sav_rem, zero-padding the tail.
+sav_write_cluster_data
+                ld    hl,alloc_clus
+                call  clus_first_lba            ; lba_tmp = first sector of the cluster
+                ld    a,(fs_spc)
+                ld    (swc_left),a
+swc_loop
+                ld    hl,fs_secbuf              ; build one sector: up to 512 src bytes
+                ld    de,512
+swc_fill
+                ld    a,d                        ; 512 bytes per sector
+                or    e
+                jr    z,swc_full
+                push  de
+                ld    de,(sav_rem)              ; any source bytes left?
+                ld    a,d
+                or    e
+                pop   de
+                jr    z,swc_pad
+                ld    a,(sav_src)               ; *src -> sector (advance src, dec rem)
+                push  hl
+                ld    hl,(sav_src)
+                ld    a,(hl)
+                inc   hl
+                ld    (sav_src),hl
+                pop   hl
+                ld    (hl),a
+                ld    bc,(sav_rem)
+                dec   bc
+                ld    (sav_rem),bc
+                jr    swc_next
+swc_pad
+                xor   a
+                ld    (hl),a
+swc_next
+                inc   hl
+                dec   de
+                jr    swc_fill
+swc_full
+                call  fs_write_sector           ; flush the sector
+                ld    hl,lba_tmp                ; next sector LBA
+                inc   (hl)
+                jr    nz,swc_noc
+                inc   hl
+                inc   (hl)
+                jr    nz,swc_noc
+                inc   hl
+                inc   (hl)
+swc_noc
+                ld    a,(swc_left)
+                dec   a
+                ld    (swc_left),a
+                jr    nz,swc_loop
+                ret
+
+; sav_write_dirent: write the 8.3 entry (name, archive attr, start cluster, size)
+; into the directory sector recorded by fs_dir_find_slot, then flush it.
+sav_write_dirent
+                ld    hl,sav_ent_lba            ; reload the directory sector
+                call  lbatmp_from_var
+                call  fs_read_sector
+                ld    hl,(sav_ent_off)          ; entry = secbuf + offset
+                ld    de,fs_secbuf
+                add   hl,de
+                push  hl
+                ex    de,hl                      ; DE -> entry
+                ld    hl,fs_req_name            ; 11-byte name
+                ld    bc,11
+                ldir
+                ld    a,#20                      ; attribute = archive
+                ld    (de),a
+                pop   hl                         ; HL -> entry base
+                ld    de,#14                      ; cluster high word @ 0x14
+                add   hl,de
+                ld    a,(sav_first_clus+2)
+                ld    (hl),a
+                inc   hl
+                ld    a,(sav_first_clus+3)
+                ld    (hl),a
+                ld    hl,(sav_ent_off)           ; cluster low word @ 0x1A
+                ld    de,fs_secbuf+#1A
+                add   hl,de
+                ld    a,(sav_first_clus)
+                ld    (hl),a
+                inc   hl
+                ld    a,(sav_first_clus+1)
+                ld    (hl),a
+                ld    hl,(sav_ent_off)           ; size (4 bytes) @ 0x1C
+                ld    de,fs_secbuf+#1C
+                add   hl,de
+                ld    de,(fs_save_len)
+                ld    (hl),e
+                inc   hl
+                ld    (hl),d
+                inc   hl
+                xor   a
+                ld    (hl),a
+                inc   hl
+                ld    (hl),a
+                jp    fs_write_sector
+
+; fs_dir_find_slot: walk the root directory. If an entry named fs_req_name exists,
+; set sav_found=1 with its location (sav_ent_lba/off) and start cluster
+; (sav_old_clus). Otherwise pick the first free slot (deleted or the 0x00 end) and
+; leave sav_found=0. CF set = a usable slot was found, NC = directory full.
+fs_dir_find_slot
+                xor   a
+                ld    (sav_found),a
+                ld    (sav_free_ok),a
+                call  fs_dir_rewind
+dfs_sec
+                ld    b,0
+dfs_ent
+                ld    a,b                        ; entry ptr = secbuf + idx*32
+                ld    l,a
+                ld    h,0
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                add   hl,hl
+                push  hl                          ; HL = offset within sector
+                ld    de,fs_secbuf
+                add   hl,de                       ; HL -> entry
+                ld    a,(hl)
+                or    a
+                jr    z,dfs_endmark               ; 0x00 = end of directory
+                cp    #E5
+                jr    z,dfs_free                  ; deleted -> free slot candidate
+                push  hl
+                ld    de,#0B
+                add   hl,de
+                ld    a,(hl)
+                pop   hl
+                and   #0F
+                cp    #0F
+                jr    z,dfs_cont                  ; LFN fragment -> not a candidate
+                push  hl                          ; compare 11-byte name
+                ld    de,fs_req_name
+                ld    c,11
+dfs_cmp
+                ld    a,(de)
+                cp    (hl)
+                jr    nz,dfs_nomatch
+                inc   hl
+                inc   de
+                dec   c
+                jr    nz,dfs_cmp
+                pop   hl                          ; MATCH -> existing entry
+                ld    a,1
+                ld    (sav_found),a
+                pop   de                          ; DE = offset within sector
+                ld    (sav_ent_off),de
+                call  dfs_store_lba
+                ld    bc,#1A                      ; old start cluster: low @0x1A hi @0x14
+                add   hl,bc
+                ld    a,(hl)
+                ld    (sav_old_clus),a
+                inc   hl
+                ld    a,(hl)
+                ld    (sav_old_clus+1),a
+                ld    hl,fs_secbuf+#14
+                ld    de,(sav_ent_off)
+                add   hl,de
+                ld    a,(hl)
+                ld    (sav_old_clus+2),a
+                inc   hl
+                ld    a,(hl)
+                ld    (sav_old_clus+3),a
+                scf
+                ret
+dfs_nomatch
+                pop   hl
+                jr    dfs_cont
+dfs_free
+                ld    a,(sav_free_ok)            ; remember the first free slot only
+                or    a
+                jr    nz,dfs_cont
+                ld    a,1
+                ld    (sav_free_ok),a
+                pop   hl                          ; HL = offset
+                ld    (sav_ent_off),hl
+                push  hl
+                call  dfs_store_lba
+                jr    dfs_cont
+dfs_endmark
+                ld    a,(sav_free_ok)            ; 0x00 end: use it if no slot yet
+                or    a
+                jr    nz,dfs_use_free
+                pop   hl                          ; HL = offset
+                ld    (sav_ent_off),hl
+                call  dfs_store_lba
+                jr    dfs_use_free2
+dfs_use_free
+                pop   hl
+dfs_use_free2
+                xor   a                            ; new entry, no existing match
+                ld    (sav_found),a
+                scf
+                ret
+dfs_cont
+                pop   hl
+                inc   b
+                ld    a,b
+                cp    16
+                jp    c,dfs_ent
+                call  fs_dir_step
+                jp    c,dfs_sec
+                ld    a,(sav_free_ok)             ; chain ended: use a recorded free slot
+                or    a
+                jr    z,dfs_full
+                xor   a
+                ld    (sav_found),a
+                scf
+                ret
+dfs_full
+                or    a
+                ret
+dfs_store_lba                                      ; sav_ent_lba = fs_dir_cur_lba
+                ld    hl,fs_dir_cur_lba
+                ld    de,sav_ent_lba
+                ld    bc,4
+                ldir
+                ret
+
+; fs_free_chain: HL -> 4-byte start cluster. Set every cluster in the chain to 0
+; (free) in the FAT. Stops at EOC or a reserved (<2) cluster.
+fs_free_chain
+                ld    de,fc_clus
+                ld    bc,4
+                ldir
+fc_loop
+                ld    a,(fc_clus+1)
+                or    a
+                jr    nz,fc_go
+                ld    a,(fc_clus+2)
+                or    a
+                jr    nz,fc_go
+                ld    a,(fc_clus+3)
+                or    a
+                jr    nz,fc_go
+                ld    a,(fc_clus)
+                cp    2
+                ret   c                            ; cluster 0/1 -> stop
+fc_go
+                ld    hl,fc_clus                   ; cur = fc_clus
+                ld    de,fc_cur
+                ld    bc,4
+                ldir
+                ld    hl,fc_clus                   ; fc_clus = next (CF) / NC = was EOC
+                call  fs_fat_next
+                push  af
+                ld    hl,fc_cur                    ; free cur: fat_set(cur, 0)
+                ld    de,fat_set_clus
+                ld    bc,4
+                ldir
+                call  clear_fat_set_val
+                call  fs_fat_set
+                pop   af
+                jr    nc,fc_done
+                jr    fc_loop
+fc_done
+                ret
+
+; fs_alloc_cluster: scan the FAT for the first free cluster (>=2), mark it EOC, and
+; leave it in alloc_clus. CF set = allocated, NC = disk full.
+fs_alloc_cluster
+                ld    hl,fs_fat_lba              ; FAT sector cursor + cluster counter
+                ld    de,alloc_seclba
+                ld    bc,4
+                ldir
+                xor   a
+                ld    (alloc_scan),a
+                ld    (alloc_scan+1),a
+                ld    (alloc_scan+2),a
+                ld    (alloc_scan+3),a
+                ld    hl,(fatsz_tmp)             ; sectors to scan (fatsz fits 16-bit)
+                ld    (alloc_secs),hl
+fac_sec
+                ld    hl,(alloc_secs)
+                ld    a,h
+                or    l
+                jp    z,fac_full
+                ld    hl,alloc_seclba
+                call  lbatmp_from_var
+                call  fs_read_sector
+                ld    ix,fs_secbuf
+                ld    b,128                       ; 128 entries per FAT sector
+fac_ent
+                ld    a,(alloc_scan+1)            ; cluster >= 2? (skip reserved 0/1)
+                or    a
+                jr    nz,fac_chk
+                ld    a,(alloc_scan+2)
+                or    a
+                jr    nz,fac_chk
+                ld    a,(alloc_scan+3)
+                or    a
+                jr    nz,fac_chk
+                ld    a,(alloc_scan)
+                cp    2
+                jr    c,fac_next
+fac_chk
+                ld    a,(ix+0)                    ; entry free? (low 28 bits all zero)
+                or    (ix+1)
+                or    (ix+2)
+                ld    c,a
+                ld    a,(ix+3)
+                and   #0F
+                or    c
+                jr    nz,fac_next
+                ld    hl,alloc_scan              ; FREE -> alloc_clus = cluster
+                ld    de,alloc_clus
+                ld    bc,4
+                ldir
+                ld    de,fat_set_clus            ; mark EOC so the chain terminates and
+                ld    bc,4                        ; the next alloc skips it
+                ld    hl,alloc_clus
+                ldir
+                ld    hl,fat_eoc
+                ld    de,fat_set_val
+                ld    bc,4
+                ldir
+                call  fs_fat_set
+                scf
+                ret
+fac_next
+                ld    hl,alloc_scan              ; cluster counter++
+                inc   (hl)
+                jr    nz,fac_n2
+                inc   hl
+                inc   (hl)
+                jr    nz,fac_n2
+                inc   hl
+                inc   (hl)
+                jr    nz,fac_n2
+                inc   hl
+                inc   (hl)
+fac_n2
+                ld    de,4                         ; next entry
+                add   ix,de
+                djnz  fac_ent
+                ld    hl,alloc_seclba             ; next FAT sector
+                inc   (hl)
+                jr    nz,fac_s2
+                inc   hl
+                inc   (hl)
+                jr    nz,fac_s2
+                inc   hl
+                inc   (hl)
+fac_s2
+                ld    hl,(alloc_secs)
+                dec   hl
+                ld    (alloc_secs),hl
+                jp    fac_sec
+fac_full
+                or    a
+                ret
+
+; fs_fat_set: write fat_set_val (32-bit, low 28 bits) into the FAT entry for
+; cluster fat_set_clus, in every FAT copy. Preserves each entry's top nibble.
+fs_fat_set
+                ld    hl,fat_set_clus
+                call  acc_load
+                call  acc_shl
+                call  acc_shl                    ; acc = cluster*4 (byte offset)
+                ld    a,(acc)
+                ld    (fn_within),a
+                ld    a,(acc+1)
+                and   1
+                ld    (fn_within+1),a
+                call  acc_shr8
+                call  acc_shr1                   ; acc = offset>>9 (sector within a FAT)
+                ld    hl,fs_fat_lba
+                call  acc_add                    ; acc = FAT copy 0 sector LBA
+                ld    a,(fs_numfat)
+                ld    b,a
+ffs_copy
+                push  bc
+                call  acc_to_lba
+                call  fs_read_sector
+                ld    hl,(fn_within)
+                ld    de,fs_secbuf
+                add   hl,de
+                ld    a,(fat_set_val)
+                ld    (hl),a
+                inc   hl
+                ld    a,(fat_set_val+1)
+                ld    (hl),a
+                inc   hl
+                ld    a,(fat_set_val+2)
+                ld    (hl),a
+                inc   hl
+                ld    a,(hl)                      ; preserve the reserved top nibble
+                and   #F0
+                ld    c,a
+                ld    a,(fat_set_val+3)
+                and   #0F
+                or    c
+                ld    (hl),a
+                call  fs_write_sector
+                ld    hl,fatsz_tmp               ; advance to the next FAT copy
+                call  acc_add
+                pop   bc
+                djnz  ffs_copy
+                ret
+clear_fat_set_val
+                xor   a
+                ld    (fat_set_val),a
+                ld    (fat_set_val+1),a
+                ld    (fat_set_val+2),a
+                ld    (fat_set_val+3),a
+                ret
+
+; fs_write_sector: write fs_secbuf to the sector at lba_tmp (24-bit LBA). Bounded
+; status waits, mirroring fs_read_sector.
+fs_write_sector
+                ld    de,0
+fxw_bsy
+                ld    bc,FS_IDE_STAT
+                in    a,(c)
+                bit   7,a
+                jr    z,fxw_bsyok
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,fxw_bsy
+                ret
+fxw_bsyok
+                ld    a,(lba_tmp+3)
+                and   #0F
+                or    #E0
+                ld    bc,FS_IDE_DEV
+                out   (c),a
+                ld    a,1
+                ld    bc,FS_IDE_SCNT
+                out   (c),a
+                ld    a,(lba_tmp)
+                ld    bc,FS_IDE_LBAL
+                out   (c),a
+                ld    a,(lba_tmp+1)
+                ld    bc,FS_IDE_LBAM
+                out   (c),a
+                ld    a,(lba_tmp+2)
+                ld    bc,FS_IDE_LBAH
+                out   (c),a
+                ld    a,#30                       ; WRITE SECTORS
+                ld    bc,FS_IDE_CMD
+                out   (c),a
+                ld    de,0
+fxw_drqw
+                ld    bc,FS_IDE_STAT
+                in    a,(c)
+                bit   0,a
+                jr    nz,fxw_done
+                bit   3,a
+                jr    nz,fxw_go
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,fxw_drqw
+                ret
+fxw_go
+                ld    hl,fs_secbuf
+                ld    de,512
+                ld    bc,FS_IDE_DATA
+fxw_wr
+                ld    a,(hl)
+                out   (c),a
+                inc   hl
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,fxw_wr
+                ld    de,0                         ; wait for the write to complete
+fxw_busy
+                ld    bc,FS_IDE_STAT
+                in    a,(c)
+                bit   7,a
+                jr    z,fxw_done
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,fxw_busy
+fxw_done
+                ret
 
 ; ---------------------------------------------------------------------------
 ; fside_load_file: load the file named in fs_req_name (11-byte 8.3) into the
-; buffer at (fs_load_dst). CF set = loaded (fs_ent_size = byte size), NC = not
-; found. Follows the FAT16 cluster chain. 16-bit LBA (files in the first 32MB).
+; buffer at (fs_load_dst). CF set = loaded (fs_ent_size set), NC = not found.
+; Follows the FAT32 cluster chain with 24-bit LBA reads.
 fside_load_file
-                call  fside_dir_first         ; also sets fs_spc/fat_lba/data_lba
+                call  fside_dir_first
 flf_find
-                jr    nc,flf_notfound         ; end of directory
-                call  flf_cmpname             ; fs_ent_name == fs_req_name?
+                jr    nc,flf_notfound
+                call  flf_cmpname
                 jr    z,flf_found
                 call  fside_dir_next
                 jr    flf_find
 flf_notfound
-flf_toobig
                 or    a
                 ret
-flf_found                                      ; fs_ent_clus + fs_ent_size set
+flf_found
                 ld    hl,(fs_load_max)        ; size > caller's buffer? refuse
                 ld    de,(fs_ent_size)
                 or    a
                 sbc   hl,de
-                jr    c,flf_toobig
+                jr    c,flf_notfound
                 ld    hl,(fs_ent_size)        ; sectors = ceil(size/512)
                 ld    de,511
                 add   hl,de
@@ -261,8 +845,10 @@ flf_sh          srl   h
                 rr    l
                 djnz  flf_sh
                 ld    (flf_secs),hl
-                ld    hl,(fs_ent_clus)
-                ld    (flf_clus),hl
+                ld    hl,fs_ent_clus          ; flf_clus = start cluster (32-bit)
+                ld    de,flf_clus
+                ld    bc,4
+                ldir
                 xor   a
                 ld    (flf_sic),a
 flf_loop
@@ -270,18 +856,12 @@ flf_loop
                 ld    a,h
                 or    l
                 jr    z,flf_done
-                ld    hl,(flf_clus)           ; LBA = data_lba+(clus-2)*spc+sic
-                dec   hl
-                dec   hl
-                call  flf_mul_spc
-                ld    de,(fs_data_lba)
-                add   hl,de
+                ld    hl,flf_clus             ; LBA = cluster base + sector-in-cluster
+                call  clus_first_lba
                 ld    a,(flf_sic)
-                ld    e,a
-                ld    d,0
-                add   hl,de
+                call  lba_add_a
                 call  fs_read_sector
-                ld    hl,fs_secbuf            ; copy sector to dst
+                ld    hl,fs_secbuf            ; copy the sector to the destination
                 ld    de,(fs_load_dst)
                 ld    bc,512
                 ldir
@@ -295,7 +875,9 @@ flf_loop
                 ld    a,(fs_spc)
                 cp    b
                 jr    nz,flf_keepsic
-                call  flf_fat_next            ; cluster boundary -> next cluster
+                ld    hl,flf_clus             ; cluster boundary -> next cluster
+                call  fs_fat_next
+                jr    nc,flf_done             ; chain ended early -> stop
                 xor   a
                 ld    (flf_sic),a
                 jr    flf_loop
@@ -321,69 +903,133 @@ flf_cn
                 xor   a
                 ret
 
-flf_mul_spc                                    ; HL *= fs_spc (power of 2)
-                ld    a,(fs_spc)
-                ld    b,0
-flf_log         srl   a
-                jr    z,flf_doshift
-                inc   b
-                jr    flf_log
-flf_doshift     inc   b
-flf_dec         dec   b
-                ret   z
-                add   hl,hl
-                jr    flf_dec
-
-flf_fat_next                                   ; flf_clus -> next cluster (FAT16)
-                ld    hl,(flf_clus)
-                ld    a,h                       ; fat_sector = fat_lba + clus/256
-                ld    l,a
-                ld    h,0
-                ld    de,(fs_fat_lba)
-                add   hl,de
+; ---------------------------------------------------------------------------
+; fs_fat_next: HL -> 4-byte cluster variable. Replace it with the next cluster
+; in the FAT32 chain. CF set = valid next cluster, NC = end-of-chain (>=EOC).
+fs_fat_next
+                ld    (fn_ptr),hl
+                call  acc_load                ; acc = cluster
+                call  acc_shl                  ; *4 -> FAT byte offset
+                call  acc_shl
+                ld    a,(acc)                  ; within = offset & 0x1FF
+                ld    (fn_within),a
+                ld    a,(acc+1)
+                and   1
+                ld    (fn_within+1),a
+                call  acc_shr8                 ; acc = offset >> 9 (FAT sector index)
+                call  acc_shr1
+                ld    hl,fs_fat_lba
+                call  acc_add                  ; acc = absolute FAT sector LBA
+                call  acc_to_lba
                 call  fs_read_sector
-                ld    a,(flf_clus)             ; within = (clus & 255) * 2
-                ld    l,a
-                ld    h,0
-                add   hl,hl
+                ld    hl,(fn_within)           ; entry = secbuf + within
                 ld    de,fs_secbuf
                 add   hl,de
                 ld    a,(hl)
-                ld    e,a
+                ld    (acc),a
                 inc   hl
                 ld    a,(hl)
-                ld    d,a
-                ld    (flf_clus),de
+                ld    (acc+1),a
+                inc   hl
+                ld    a,(hl)
+                ld    (acc+2),a
+                inc   hl
+                ld    a,(hl)
+                and   #0F                       ; FAT32 entries are 28-bit
+                ld    (acc+3),a
+                ld    a,(acc+3)                ; end-of-chain if >= 0x0FFFFFF8
+                cp    #0F
+                jr    c,fn_valid
+                ld    a,(acc+2)
+                cp    #FF
+                jr    c,fn_valid
+                ld    a,(acc+1)
+                cp    #FF
+                jr    c,fn_valid
+                ld    a,(acc)
+                cp    #F8
+                jr    c,fn_valid
+                or    a                         ; EOC -> NC
+                ret
+fn_valid
+                ld    hl,acc
+                ld    de,(fn_ptr)
+                ld    bc,4
+                ldir
+                scf
                 ret
 
+; clus_first_lba: HL -> 4-byte cluster var. lba_tmp = data_lba + (clus-2)<<clshift
+; (the first sector of the cluster; the caller adds the sector-in-cluster).
+clus_first_lba
+                call  acc_load
+                call  acc_sub2
+                ld    a,(fs_clshift)
+                or    a
+                jr    z,cfl_done
+                ld    b,a
+cfl_shl         push  bc
+                call  acc_shl
+                pop   bc
+                djnz  cfl_shl
+cfl_done
+                ld    hl,fs_data_lba
+                call  acc_add
+                jp    acc_to_lba
+
 ; ---------------------------------------------------------------------------
-; fs_read_sector: read one 512-byte sector, LBA in HL (16-bit), into fs_secbuf.
+; fs_read_sector: read one 512-byte sector at lba_tmp (24-bit LBA) into
+; fs_secbuf. Both status waits are bounded (DE down to 0) so a drive left
+; mid-operation by UniDOS/FatFS fails out instead of hanging forever; callers
+; fall back to defaults on an unfilled buffer.
 fs_read_sector
-                push  hl
-                ld    a,#E0                    ; LBA mode, master, LBA27-24 = 0
+                ld    de,0                     ; wait BSY=0 before commanding
+frs_bsy
+                ld    bc,FS_IDE_STAT
+                in    a,(c)
+                bit   7,a
+                jr    z,frs_bsyok
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,frs_bsy
+                ret                             ; timeout: buffer untouched
+frs_bsyok
+                ld    a,(lba_tmp+3)            ; LBA 27-24 in the device register
+                and   #0F
+                or    #E0                       ; LBA mode, master
                 ld    bc,FS_IDE_DEV
                 out   (c),a
                 ld    a,1
                 ld    bc,FS_IDE_SCNT
                 out   (c),a
-                pop   hl
-                ld    a,l
+                ld    a,(lba_tmp)
                 ld    bc,FS_IDE_LBAL
                 out   (c),a
-                ld    a,h
+                ld    a,(lba_tmp+1)
                 ld    bc,FS_IDE_LBAM
                 out   (c),a
-                xor   a
+                ld    a,(lba_tmp+2)
                 ld    bc,FS_IDE_LBAH
                 out   (c),a
-                ld    a,#20                    ; READ SECTORS
+                ld    a,#20                     ; READ SECTORS
                 ld    bc,FS_IDE_CMD
                 out   (c),a
+                ld    de,0                       ; wait DRQ, bail on ERR/timeout
 frs_poll
                 ld    bc,FS_IDE_STAT
                 in    a,(c)
-                bit   3,a                       ; wait for DRQ
-                jr    z,frs_poll
+                bit   0,a
+                jr    nz,frs_fail
+                bit   3,a
+                jr    nz,frs_drq
+                dec   de
+                ld    a,d
+                or    e
+                jr    nz,frs_poll
+frs_fail
+                ret                             ; error/timeout: buffer untouched
+frs_drq
                 ld    hl,fs_secbuf
                 ld    de,512
                 ld    bc,FS_IDE_DATA
@@ -397,19 +1043,207 @@ frs_read
                 jr    nz,frs_read
                 ret
 
+; fs_detect_part: fs_secbuf holds LBA 0. Set fs_part_lba (32-bit) to the first
+; MBR partition's start LBA, or 0 for a superfloppy (FAT BPB directly at LBA 0).
+; A FAT boot sector starts with a jump (0xEB); an MBR does not, ends 55 AA, and
+; has a non-zero partition type at offset 446+4.
+fs_detect_part
+                ld    a,(fs_secbuf)
+                cp    #EB
+                jr    z,fdp_none
+                ld    a,(fs_secbuf+#1FE)
+                cp    #55
+                jr    nz,fdp_none
+                ld    a,(fs_secbuf+#1FF)
+                cp    #AA
+                jr    nz,fdp_none
+                ld    a,(fs_secbuf+#1C2)       ; partition 0 type; 0 = unused
+                or    a
+                jr    z,fdp_none
+                ld    hl,fs_secbuf+#1C6        ; partition 0 start LBA (4 bytes)
+                ld    de,fs_part_lba
+                ld    bc,4
+                ldir
+                ret
+fdp_none
+                jp    clear_part_lba
+
+; --- 32-bit helpers (operate on the 4-byte little-endian accumulator acc) ----
+clear_part_lba
+                xor   a
+                ld    (fs_part_lba),a
+                ld    (fs_part_lba+1),a
+                ld    (fs_part_lba+2),a
+                ld    (fs_part_lba+3),a
+                ret
+clear_lba_tmp
+                xor   a
+                ld    (lba_tmp),a
+                ld    (lba_tmp+1),a
+                ld    (lba_tmp+2),a
+                ld    (lba_tmp+3),a
+                ret
+lbatmp_from_var                                ; HL -> 4-byte source; lba_tmp = (HL)
+                ld    de,lba_tmp
+                ld    bc,4
+                ldir
+                ret
+acc_load                                        ; HL -> 4-byte source; acc = (HL)
+                ld    de,acc
+                ld    bc,4
+                ldir
+                ret
+acc_to_lba                                      ; lba_tmp = acc
+                ld    hl,acc
+                ld    de,lba_tmp
+                ld    bc,4
+                ldir
+                ret
+acc_store_fat                                   ; fs_fat_lba = acc
+                ld    hl,acc
+                ld    de,fs_fat_lba
+                ld    bc,4
+                ldir
+                ret
+acc_store_data                                  ; fs_data_lba = acc
+                ld    hl,acc
+                ld    de,fs_data_lba
+                ld    bc,4
+                ldir
+                ret
+acc_add                                         ; acc += (HL)  [HL -> 4-byte LE]
+                ld    de,acc
+                or    a
+                ld    b,4
+acc_add_l
+                ld    a,(de)
+                adc   a,(hl)
+                ld    (de),a
+                inc   de
+                inc   hl
+                djnz  acc_add_l
+                ret
+acc_add16                                       ; acc += DE (16-bit)
+                ld    hl,acc
+                ld    a,(hl)
+                add   a,e
+                ld    (hl),a
+                inc   hl
+                ld    a,(hl)
+                adc   a,d
+                ld    (hl),a
+                inc   hl
+                ld    a,(hl)
+                adc   a,0
+                ld    (hl),a
+                inc   hl
+                ld    a,(hl)
+                adc   a,0
+                ld    (hl),a
+                ret
+acc_sub2                                        ; acc -= 2
+                ld    hl,acc
+                ld    a,(hl)
+                sub   2
+                ld    (hl),a
+                ret   nc
+asd_b
+                inc   hl
+                ld    a,(hl)
+                sub   1
+                ld    (hl),a
+                ret   nc
+                jr    asd_b
+acc_shl                                         ; acc <<= 1
+                ld    hl,acc
+                or    a
+                rl    (hl)
+                inc   hl
+                rl    (hl)
+                inc   hl
+                rl    (hl)
+                inc   hl
+                rl    (hl)
+                ret
+acc_shr8                                        ; acc >>= 8 (byte shuffle)
+                ld    hl,acc+1
+                ld    de,acc
+                ld    bc,3
+                ldir
+                xor   a
+                ld    (acc+3),a
+                ret
+acc_shr1                                        ; acc >>= 1 (logical, 32-bit)
+                ld    hl,acc+3
+                or    a
+                srl   (hl)
+                dec   hl
+                rr    (hl)
+                dec   hl
+                rr    (hl)
+                dec   hl
+                rr    (hl)
+                ret
+lba_add_a                                       ; lba_tmp += A (8-bit, carry up)
+                ld    hl,lba_tmp
+                add   a,(hl)
+                ld    (hl),a
+                ret   nc
+laa_c
+                inc   hl
+                inc   (hl)
+                ret   nz
+                jr    laa_c
+
 ; --- state (per-entry output fields fs_ent_* live in lib/fs.asm) ----------
-fs_root_lba     defw  0
-fs_root_secs    defb  0
-fs_cur_sec      defb  0
-fs_ent_idx      defb  0
-fs_ent_clus     defw  0            ; current entry's start cluster
-fs_spc          defb  0            ; sectors per cluster (file-read geometry)
-fs_fat_lba      defw  0            ; FAT start LBA
-fs_data_lba     defw  0            ; data region start LBA
+fs_part_lba     defs  4            ; partition base LBA (0 = superfloppy)
+fs_fat_lba      defs  4            ; absolute FAT start LBA
+fs_data_lba     defs  4            ; absolute data region start LBA
+fs_dir_clus     defs  4            ; current root-dir cluster
+flf_clus        defs  4            ; current file cluster
+fs_ent_clus     defs  4            ; selected entry's start cluster
+acc             defs  4            ; 32-bit work accumulator
+lba_tmp         defs  4            ; LBA staged for fs_read_sector
+fatsz_tmp       defs  4            ; sectors per FAT (geometry calc)
+fn_ptr          defw  0            ; fs_fat_next: cluster-var pointer
+fn_within       defw  0            ; fs_fat_next: FAT entry offset in sector
+fs_spc          defb  0            ; sectors per cluster
+fs_clshift      defb  0            ; log2(sectors per cluster)
+fs_dir_sic      defb  0            ; dir: sector within current cluster
+flf_sic         defb  0            ; load: sector within current cluster
+fs_ent_idx      defb  0            ; dir: entry index within current sector
 flf_secs        defw  0            ; load: sectors remaining
-flf_clus        defw  0            ; load: current cluster
-flf_sic         defb  0            ; load: sector within the cluster
+fs_numfat       defb  0            ; number of FAT copies
+fs_dir_cur_lba  defs  4            ; LBA of the dir sector currently in secbuf
+fat_eoc         defb  #FF,#FF,#FF,#0F  ; FAT32 end-of-chain marker
+; --- write path scratch ---
+alloc_clus      defs  4            ; fs_alloc_cluster result
+alloc_seclba    defs  4            ; FAT scan: current sector LBA
+alloc_scan      defs  4            ; FAT scan: current cluster number
+alloc_secs      defw  0            ; FAT scan: sectors remaining
+fat_set_clus    defs  4            ; fs_fat_set: target cluster
+fat_set_val     defs  4            ; fs_fat_set: value to store
+fc_clus         defs  4            ; fs_free_chain: walk cursor
+fc_cur          defs  4            ; fs_free_chain: cluster being freed
+sav_nclus       defw  0            ; save: clusters needed
+sav_left        defw  0            ; save: clusters remaining to write
+sav_first_clus  defs  4            ; save: file start cluster
+sav_prev_clus   defs  4            ; save: previous cluster (for linking)
+sav_have_prev   defb  0            ; save: a previous cluster exists
+sav_src         defw  0            ; save: source data cursor
+sav_rem         defw  0            ; save: source bytes remaining
+sav_found       defb  0            ; dir slot: 1 = existing entry, 0 = new
+sav_free_ok     defb  0            ; dir slot: a free slot was recorded
+sav_ent_lba     defs  4            ; dir slot: entry's sector LBA
+sav_ent_off     defw  0            ; dir slot: entry offset within the sector
+sav_old_clus    defs  4            ; dir slot: existing entry's start cluster
+swc_left        defb  0            ; sector-write loop counter
 ; fs_secbuf (the 512-byte sector buffer) is defined after kern_end in gbkern.asm
-; so it is NOT part of the loaded GBKERN.BIN image - it is scratch RAM filled at
-; runtime. Keeping it (and the 2KB fsam_buf) out of the image shrinks the load by
-; 2.5KB, so the kernel fits under UniDOS+FatFS HIMEM (&A288) on an IDE machine.
+; so it is excluded from the loaded GBKERN.BIN image - scratch RAM filled at run
+; time. The fside_save_file paged-module path (GBFAT) is retired until FAT32
+; write lands; the equates below remain for the build's module packaging.
+GBFAT_LEN       equ   #1400
+GBFAT_NAME      equ   #1402
+GBFAT_RES       equ   #140D
+GBFAT_DATA      equ   #1800
+GBFAT_LOAD      equ   #5000

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -54,4 +54,13 @@ typedef struct {
 #define GB_MSG_MENU 1
 #define gb_msg (*(volatile gb_msg_t *)0x1302)
 void gb_on_event(void (*handler)(void));   /* register handler, 0 to clear */
+
+/* Top-bar menu (issue #34). The app registers menu titles the kernel draws in
+ * the bar (persisting across clock ticks); a click on the bar arrives via the
+ * gb_on_event callback as GB_MSG_MENU with p0 = the clicked byte column, so the
+ * app maps the column to its title and draws its own dropdown. def layout:
+ *   byte 0: title count (<=4)
+ *   then per title: byte col, then an 8-byte NUL/space-padded label
+ * Cleared automatically when the app launches a child or quits. */
+void gb_menu(const void *def);
 #endif /* GB_H */

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -63,4 +63,9 @@ void gb_on_event(void (*handler)(void));   /* register handler, 0 to clear */
  *   then per title: byte col, then an 8-byte NUL/space-padded label
  * Cleared automatically when the app launches a child or quits. */
 void gb_menu(const void *def);
+
+/* gb_set_name: set the current file (an 11-byte 8.3 name, space-padded, no dot,
+ * e.g. "NOTES   TXT") so a later gb_fs_load/gb_fs_save targets it - how an app
+ * does New / Save As / open a file chosen from a picker. */
+void gb_set_name(const char *name11);
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -30,6 +30,7 @@
         .globl  _gb_vsync
         .globl  _gb_on_event
         .globl  _gb_menu
+        .globl  _gb_set_name
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -198,3 +199,7 @@ _gb_on_event:
 ;; void gb_menu(const void *def);   def ptr in HL -> kernel copies + draws the bar
 _gb_menu:
         jp      0x804E          ; GB_MENU
+
+;; void gb_set_name(const char *name11);   11-byte 8.3 name in HL -> current file
+_gb_set_name:
+        jp      0x8051          ; GB_SETNAME

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -29,6 +29,7 @@
         .globl  _gb_getkey
         .globl  _gb_vsync
         .globl  _gb_on_event
+        .globl  _gb_menu
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -193,3 +194,7 @@ _gb_vsync:
 ;; void gb_on_event(void (*handler)(void));   handler ptr in HL -> kernel stores it
 _gb_on_event:
         jp      0x804B          ; GB_ONEVENT
+
+;; void gb_menu(const void *def);   def ptr in HL -> kernel copies + draws the bar
+_gb_menu:
+        jp      0x804E          ; GB_MENU

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -98,3 +98,6 @@ GB_MENU         equ   GB_KERNEL+78 ; #804E  register the top-bar menu: HL = blob
                                    ;        title) in the caller page. Kernel copies
                                    ;        it resident and draws the titles in the
                                    ;        bar. Cleared for a child app / on quit.
+GB_SETNAME      equ   GB_KERNEL+81 ; #8051  set the current file name (launch arg):
+                                   ;        HL = 11-byte 8.3 name. For New / Save As /
+                                   ;        opening a picked file.

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -93,3 +93,8 @@ GB_ONEVENT      equ   GB_KERNEL+75 ; #804B  register an event handler: HL = addr
                                    ;        message at GB_MSG (#1302): type, p0, p1,
                                    ;        p2. type GB_MSG_MENU(1) -> p0 = byte col.
                                    ;        Handler must return promptly (no GB_POLL).
+GB_MENU         equ   GB_KERNEL+78 ; #804E  register the top-bar menu: HL = blob
+                                   ;        (count, then {col, 8-byte label} per
+                                   ;        title) in the caller page. Kernel copies
+                                   ;        it resident and draws the titles in the
+                                   ;        bar. Cleared for a child app / on quit.

--- a/lib/input.asm
+++ b/lib/input.asm
@@ -2,10 +2,12 @@
 ; lib/input.asm - GEOBENCH input layer
 ;
 ; Polls the input devices and reports an abstract result, so the rest of the
-; system never reads hardware directly. Today it reads the keyboard (cursor
-; keys + Space + ESC) and the joystick port (an AMX-style mouse presents as the
-; joystick). A SYMBiFACE PS/2 mouse will be added here behind the same
-; interface for machines that have the board.
+; system never reads hardware directly. The pointer is driven by the joystick
+; port only (an AMX-style mouse / gamepad presents as the joystick); the cursor
+; keys and Space are deliberately NOT read, so the whole keyboard is free for
+; Notepad text entry. ESC is the one keyboard key kept here, as a universal quit
+; (it is never a text character, so it does not clash with typing). A SYMBiFACE
+; PS/2 mouse will be added here behind the same interface.
 ;
 ; Requires lib/firmware.inc (KM_TEST_KEY, KM_GET_JOYSTICK). Assembled into the
 ; consumer; no org.
@@ -40,58 +42,14 @@ JOY_FIRE1       equ   5           ; bit 5
 input_poll
                 xor   a
                 ld    (in_dirs),a
-                ld    (in_kbd_dirs),a
                 ld    (in_joy_dirs),a
                 ld    (in_fire),a
                 ld    (in_quit),a
-                call  read_keyboard          ; -> in_kbd_dirs
-                call  read_joystick          ; -> in_joy_dirs
-                ld    a,(in_kbd_dirs)        ; in_dirs = keyboard OR joystick
-                ld    b,a
-                ld    a,(in_joy_dirs)
-                or    b
+                call  read_joystick          ; mouse/joystick -> directions + fire
+                ld    a,(in_joy_dirs)        ; the pointer follows the joystick only
                 ld    (in_dirs),a
-                ret
-
-; ---------------------------------------------------------------------------
-; Keyboard: cursor keys move, Space = fire/select, ESC = quit.
-read_keyboard
-                ld    a,KEY_UP
-                call  KM_TEST_KEY
-                jr    z,rk_down
-                ld    a,(in_kbd_dirs)
-                or    DIR_UP
-                ld    (in_kbd_dirs),a
-rk_down
-                ld    a,KEY_DOWN
-                call  KM_TEST_KEY
-                jr    z,rk_left
-                ld    a,(in_kbd_dirs)
-                or    DIR_DOWN
-                ld    (in_kbd_dirs),a
-rk_left
-                ld    a,KEY_LEFT
-                call  KM_TEST_KEY
-                jr    z,rk_right
-                ld    a,(in_kbd_dirs)
-                or    DIR_LEFT
-                ld    (in_kbd_dirs),a
-rk_right
-                ld    a,KEY_RIGHT
-                call  KM_TEST_KEY
-                jr    z,rk_fire
-                ld    a,(in_kbd_dirs)
-                or    DIR_RIGHT
-                ld    (in_kbd_dirs),a
-rk_fire
-                ld    a,KEY_SPACE
-                call  KM_TEST_KEY
-                jr    z,rk_quit
-                ld    a,1
-                ld    (in_fire),a
-rk_quit
-                ld    a,KEY_ESC
-                call  KM_TEST_KEY
+                ld    a,KEY_ESC              ; ESC quits (not a text key, so it never
+                call  KM_TEST_KEY            ; clashes with Notepad typing)
                 ret   z
                 ld    a,1
                 ld    (in_quit),a
@@ -122,8 +80,7 @@ rj_fire2
                 ret
 
 ; --- State ---------------------------------------------------------------
-in_dirs         db    0            ; keyboard OR joystick directions (DIR_*)
-in_kbd_dirs     db    0            ; keyboard-only directions (window list scroll)
-in_joy_dirs     db    0            ; joystick/mouse-only directions
+in_dirs         db    0            ; held directions (DIR_*), from the joystick
+in_joy_dirs     db    0            ; joystick/mouse directions (scratch)
 in_fire         db    0
 in_quit         db    0

--- a/tools/build_fatmod.sh
+++ b/tools/build_fatmod.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Assemble the FAT16/IDE write module (kernel/modules/gbfat.asm) into a raw
+# #5000 image: build/GBFAT.RAW. The kernel pages it into the free upper part of
+# PAGE_DATA and CALLs it on an IDE save (issue #34). The module's own `save`
+# directive writes the RAW; this script just runs RASM.
+#   tools/build_fatmod.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+RASM="${RASM:-rasm}"
+mkdir -p build
+"$RASM" kernel/modules/gbfat.asm -eo
+echo "Built build/GBFAT.RAW ($(stat -c%s build/GBFAT.RAW) bytes)"

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -24,5 +24,6 @@ tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VI
 tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD (C/SDCC) -> build/NOTEPAD.RAW
 tools/build_capp.sh apps/chello build/CHELLO.RAW   # C app (SDCC) -> build/CHELLO.RAW
 tools/build_cfgmod.sh build/GBCFG.RAW              # config-parser C kernel module -> build/GBCFG.RAW
+tools/build_fatmod.sh                              # FAT16/IDE write module -> build/GBFAT.RAW
 "$RASM" kernel/gbkern.asm -eo                # incbins apps + font + icons -> .dsk
 echo "Built build/gbkern.dsk (GBKERN + DESKTOP + FILEMGR + VIEWER + NOTEPAD + CHELLO + assets)"


### PR DESCRIPTION
Implements the GEOBENCH file lifecycle (issue #34): a write layer, per-app top-bar menus, Notepad New/Load/Save with a window close gadget, and storage backends for both floppy and the real Symbiface IDE disk.

## What is here

**UI / app layer**
- Per-app MacOS-style top-bar dropdown menus (`GB_MENU`, `GB_SETNAME`).
- Notepad: pointer-driven editor with a File menu (New / Load / Save), click-to-caret, per-line redraw, and a window close gadget that prompts "Save changes?" when edited.
- Pointer is joystick/mouse-only; assorted `gb_getkey` fixes (direction/fire chars no longer leak into the buffer).

**Storage**
- Floppy (AMSDOS): file create + grow (1KB block allocation) for the write layer.
- **IDE = FAT32** (`lib/fs_ide_fat.asm`): the real disk is a large FAT32 volume (UniDOS/SymbOS `C:`), so the backend speaks FAT32 with 32-bit cluster numbers and **24-bit LBA** — GEOBENCH files land high on a near-full disk, past the old 16-bit reach. MBR partitions honoured (superfloppy = base 0).
  - Read: mount + root-dir cluster-chain walk + file chain follow.
  - Write: free-cluster allocation, both FAT copies linked, data written, dir entry created/overwritten — verified against the real image, **fsck-clean**, no corruption.

**Fixes**
- Dallas RTC read in **binary** mode (SymbiFace runs the RTC binary, not BCD) — fixes garbled clock digits on hardware with an RTC.

## Verification
- FAT32 read: desktop + fonts/icons/config load from the real disk (confirmed via a CLASSIC-font discriminator and interactive `run"GBKERN`).
- FAT32 write: kernel-written test file reads back byte-perfect; fsck reports only a pre-existing artifact already present on the untouched disk.
- Floppy still boots; kernel fits under the UniDOS HIMEM ceiling (kern_end #A160, ~296 bytes spare).

## Follow-ups (not blocking)
- The paged FAT16 `GBFAT` write module is superseded by the resident FAT32 write path; left in the build, safe to retire.
- FSInfo free-cluster hint is left untouched (advisory; the disk's was already off-by-one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
