### PR TITLE
SymbiFace II mouse support (joystick fallback) (#36)

### DIFF
--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -78,6 +78,7 @@ kernel_main
                                               ; gb_getkey (the keyboard is the joystick)
                 call  set_palette            ; GEOBENCH 4-pen palette
                 call  fs_init                ; pick storage backend (floppy here)
+                call  input_init             ; enable the SymbiFace mouse if present
                 di                            ; probe RAM BEFORE PAGE_DATA is filled
                 call  mem_detect             ; (it pokes every bank's #4000)
                 ei
@@ -172,7 +173,7 @@ k_curshow
 ; fresh click (fire just pressed), bit1 = quit (ESC). Interrupts must be on so
 ; the firmware scans the keyboard.
 k_poll
-                call  input_poll             ; in_dirs / in_fire / in_quit
+                call  input_poll             ; in_dx/in_dy + in_fire/in_quit
                 call  poll_move              ; -> DE = new x, HL = new y (clamped)
                 call  MC_WAIT_FLYBACK        ; pace to 50 Hz; do the move in the blank
                 call  cursor_move_to         ; erases+redraws ONLY if the position
@@ -229,72 +230,23 @@ poll_lastfire   db    0
 poll_byte       db    0
 poll_line       db    0
 
-; poll_move: compute the new cursor position from the held directions (in_dirs),
-; clamped. Returns DE = new x, HL = new y. Does NOT write cursor_x/y - that is
-; left to cursor_move_to, which only redraws when the position actually changes.
+; poll_move: apply the per-frame pointer delta (in_dx/in_dy, from input_poll -
+; joystick step and/or SymbiFace mouse) to the cursor, clamped to the screen.
+; Returns DE = new x, HL = new y. Does NOT write cursor_x/y - cursor_move_to does
+; that, redrawing only when the position actually changes.
 poll_move
-                ld    a,(in_dirs)            ; acceleration: a held direction steps
-                or    a                       ; finely for the first few frames (so a
-                jr    nz,pm_held              ; tap nudges ~1px) then faster when held
-                ld    (pm_accel),a           ; nothing held -> reset the ramp
-                jr    pm_setstep
-pm_held
-                ld    a,(pm_accel)
-                inc   a
-                cp    40
-                jr    c,pm_accsave
-                ld    a,39                    ; cap the ramp counter
-pm_accsave
-                ld    (pm_accel),a
-pm_setstep
-                ld    a,(pm_accel)
-                cp    7
-                ld    a,2                     ; 2 units (~1px): precise
-                jr    c,pm_havestep
-                ld    a,12                    ; held a while -> 12 units (~6px): fast
-pm_havestep
-                ld    (pm_step),a
-                ld    a,(in_dirs)
-                ld    c,a
                 ld    hl,(cursor_x)
-                bit   2,c                     ; DIR_LEFT
-                jr    z,pm_right
-                call  pm_sub
-pm_right
-                bit   3,c                     ; DIR_RIGHT
-                jr    z,pm_xclamp
-                call  pm_add
-pm_xclamp
+                ld    de,(in_dx)             ; signed delta this frame
+                add   hl,de
                 call  clamp638
                 ld    (pm_newx),hl
                 ld    hl,(cursor_y)
-                bit   0,c                     ; DIR_UP -> +y (screen up)
-                jr    z,pm_down
-                call  pm_add
-pm_down
-                bit   1,c                     ; DIR_DOWN -> -y
-                jr    z,pm_yclamp
-                call  pm_sub
-pm_yclamp
-                call  clamp398               ; HL = new y
-                ld    de,(pm_newx)           ; DE = new x
-                ret
-pm_add                                         ; HL += pm_step
-                ld    a,(pm_step)
-                ld    e,a
-                ld    d,0
+                ld    de,(in_dy)
                 add   hl,de
-                ret
-pm_sub                                         ; HL -= pm_step
-                ld    a,(pm_step)
-                ld    e,a
-                ld    d,0
-                or    a
-                sbc   hl,de
+                call  clamp398
+                ld    de,(pm_newx)
                 ret
 pm_newx         dw    0
-pm_step         db    0
-pm_accel        db    0
 clamp638
                 ld    de,638
                 jr    clamp_hl

--- a/lib/input.asm
+++ b/lib/input.asm
@@ -1,73 +1,84 @@
 ; ---------------------------------------------------------------------------
 ; lib/input.asm - GEOBENCH input layer
 ;
-; Polls the input devices and reports an abstract result, so the rest of the
-; system never reads hardware directly. The pointer is driven by the joystick
-; port only (an AMX-style mouse / gamepad presents as the joystick); the cursor
-; keys and Space are deliberately NOT read, so the whole keyboard is free for
-; Notepad text entry. ESC is the one keyboard key kept here, as a universal quit
-; (it is never a text character, so it does not clash with typing). A SYMBiFACE
-; PS/2 mouse will be added here behind the same interface.
+; Polls the pointer devices and reports an abstract per-frame result, so the
+; rest of the system never reads hardware directly. Two sources are COMBINED
+; every frame, so the joystick is always a working fallback:
+;   - joystick port (KM_GET_JOYSTICK; an AMX-style mouse/gamepad presents as the
+;     joystick). Held directions -> a stepped delta, with an acceleration ramp.
+;   - SYMBiFACE II PS/2 mouse (port #FD10), polled only when a SymbiFace is
+;     detected. #FD10 returns 0x00 both when idle AND when no mouse is fitted, so
+;     a mouse cannot be sensed at rest - we just read its packets when they come.
+;     The port floats on a board with no SymbiFace, so it is gated behind a
+;     presence probe (the SymbiFace IDE controller answering fs_ide_present).
+; Both feed a signed per-frame delta (in_dx/in_dy, cursor units); the kernel's
+; poll_move applies it. ESC is the one keyboard key read here (universal quit;
+; never a text char, so it does not clash with Notepad typing).
 ;
-; Requires lib/firmware.inc (KM_TEST_KEY, KM_GET_JOYSTICK). Assembled into the
-; consumer; no org.
+; Requires lib/firmware.inc (KM_TEST_KEY, KM_GET_JOYSTICK) and fs_ide_present
+; (lib/fs.asm). Assembled into the consumer; no org.
 ;
 ; Interface:
-;   call input_poll   -> in_dirs : bitmask of held directions (DIR_*)
-;                        in_fire : non-zero if select/fire is held
-;                        in_quit : non-zero if the user asked to quit
+;   call input_init   -> probe for a SymbiFace; enable the mouse if present
+;   call input_poll   -> in_dx/in_dy : signed pointer delta this frame
+;                        in_fire      : non-zero if select/click is held
+;                        in_quit      : non-zero if the user asked to quit
 ; ---------------------------------------------------------------------------
 
-; --- CPC key numbers -----------------------------------------------------
-KEY_UP          equ   0
-KEY_RIGHT       equ   1
-KEY_DOWN        equ   2
-KEY_LEFT        equ   8
-KEY_SPACE       equ   47
-KEY_ESC         equ   66
+KEY_ESC          equ   66
 
-; --- Direction bitmask returned in in_dirs -------------------------------
-; These deliberately match the low nibble of the CPC joystick byte (bit 0 up,
-; 1 down, 2 left, 3 right) so a joystick read drops straight into in_dirs.
-DIR_UP          equ   1
-DIR_DOWN        equ   2
-DIR_LEFT        equ   4
-DIR_RIGHT       equ   8
+; --- Direction bits (low nibble of the CPC joystick byte) ---------------
+DIR_UP           equ   1
+DIR_DOWN         equ   2
+DIR_LEFT         equ   4
+DIR_RIGHT        equ   8
 
-; --- Joystick byte bits (KM_GET_JOYSTICK) --------------------------------
-JOY_FIRE2       equ   4           ; bit 4
-JOY_FIRE1       equ   5           ; bit 5
+JOY_FIRE2        equ   4           ; KM_GET_JOYSTICK bit 4
+JOY_FIRE1        equ   5           ; bit 5
+
+FS_MOUSE         equ   #FD10       ; SYMBiFACE II PS/2 mouse status port
+MOUSE_SHIFT      equ   1           ; delta scale: << this (1 = x2, ~1 px per unit)
+MOUSE_MAXPKT     equ   8           ; burst-read safety cap (protocol emits <=4)
+
+; ---------------------------------------------------------------------------
+; input_init: enable the mouse only if a SymbiFace is present. Its IDE controller
+; answers fs_ide_present; the mouse port floats on a board without one, which
+; would otherwise inject noise. Joystick-only when absent.
+input_init
+                xor   a
+                ld    (mouse_enabled),a
+                ld    (mouse_btn_state),a
+                call  fs_ide_present
+                ret   nc
+                ld    a,1
+                ld    (mouse_enabled),a
+                ret
 
 ; ---------------------------------------------------------------------------
 input_poll
+                ld    hl,0
+                ld    (in_dx),hl
+                ld    (in_dy),hl
                 xor   a
-                ld    (in_dirs),a
-                ld    (in_joy_dirs),a
                 ld    (in_fire),a
                 ld    (in_quit),a
-                call  read_joystick          ; mouse/joystick -> directions + fire
-                ld    a,(in_joy_dirs)        ; the pointer follows the joystick only
-                ld    (in_dirs),a
-                ld    a,KEY_ESC              ; ESC quits (not a text key, so it never
-                call  KM_TEST_KEY            ; clashes with Notepad typing)
+                ld    (in_joy_dirs),a
+                call  read_joystick          ; -> in_joy_dirs, in_fire, in_quit
+                call  joy_to_delta           ; held dirs (+ accel) -> in_dx/in_dy
+                call  read_mouse             ; SymbiFace mouse -> in_dx/in_dy + buttons
+                ld    a,KEY_ESC              ; ESC quits (never a text key)
+                call  KM_TEST_KEY
                 ret   z
                 ld    a,1
                 ld    (in_quit),a
                 ret
 
-; ---------------------------------------------------------------------------
-; Joystick 0: directions OR straight into in_dirs (matching bit layout);
-; fire 1 = select, fire 2 = quit.
+; read_joystick: directions -> in_joy_dirs; fire 1 = select, fire 2 = quit.
 read_joystick
-                call  KM_GET_JOYSTICK       ; A = joystick 0 state
-                ld    c,a                   ; keep the raw byte in C
-
-                and   #0F                   ; bits 0..3 == DIR_* directions
-                ld    b,a
-                ld    a,(in_joy_dirs)
-                or    b
+                call  KM_GET_JOYSTICK
+                ld    c,a
+                and   #0F                     ; bits 0..3 = DIR_* directions
                 ld    (in_joy_dirs),a
-
                 bit   JOY_FIRE1,c
                 jr    z,rj_fire2
                 ld    a,1
@@ -79,8 +90,161 @@ rj_fire2
                 ld    (in_quit),a
                 ret
 
+; joy_to_delta: held directions -> a per-frame delta, with the acceleration ramp
+; (a tap nudges ~1px; held a while moves faster).
+joy_to_delta
+                ld    a,(in_joy_dirs)
+                or    a
+                jr    nz,jd_held
+                ld    (in_accel),a            ; nothing held -> reset the ramp
+                jr    jd_step
+jd_held
+                ld    a,(in_accel)
+                inc   a
+                cp    40
+                jr    c,jd_accsave
+                ld    a,39                     ; cap the ramp counter
+jd_accsave
+                ld    (in_accel),a
+jd_step
+                ld    a,(in_accel)
+                cp    7
+                ld    a,2                      ; 2 units (~1px): precise
+                jr    c,jd_havestep
+                ld    a,12                     ; held a while -> 12 units (~6px): fast
+jd_havestep
+                ld    (in_step),a
+                ld    a,(in_joy_dirs)
+                ld    c,a
+                bit   2,c                      ; LEFT -> dx -= step
+                jr    z,jd_right
+                ld    hl,in_dx
+                call  jd_substep
+jd_right
+                bit   3,c                      ; RIGHT -> dx += step
+                jr    z,jd_up
+                ld    hl,in_dx
+                call  jd_addstep
+jd_up
+                bit   0,c                      ; UP -> dy += step (screen up = +cursor_y)
+                jr    z,jd_down
+                ld    hl,in_dy
+                call  jd_addstep
+jd_down
+                bit   1,c                      ; DOWN -> dy -= step
+                ret   z
+                ld    hl,in_dy
+                jr    jd_substep
+jd_addstep                                     ; (HL) += in_step  [HL -> word]
+                ld    a,(in_step)
+                ld    e,a
+                ld    d,0
+                jp    add_de_to
+jd_substep                                     ; (HL) -= in_step
+                ld    a,(in_step)
+                neg
+                ld    e,a
+                ld    d,#FF
+                jp    add_de_to
+
+; ---------------------------------------------------------------------------
+; read_mouse: burst-read #FD10, accumulating X/Y deltas (scaled) into in_dx/in_dy
+; and the latest button state. Button packets only arrive on a change, so the
+; held state is kept in mouse_btn_state and applied every frame.
+read_mouse
+                ld    a,(mouse_enabled)
+                or    a
+                ret   z
+                ld    a,MOUSE_MAXPKT
+                ld    (rm_count),a
+rm_loop
+                ld    bc,FS_MOUSE
+                in    a,(c)
+                or    a
+                jr    z,rm_apply              ; 0x00 = no more data
+                ld    e,a                      ; keep the raw packet
+                bit   7,a
+                jr    nz,rm_hi
+                ld    a,e                      ; m=01 -> X offset (+ = right)
+                call  mouse_sext6
+                call  mouse_scale
+                ld    hl,in_dx
+                call  add_de_to
+                jr    rm_next
+rm_hi
+                bit   6,a
+                jr    nz,rm_btnscroll
+                ld    a,e                      ; m=10 -> Y offset (+ = up = +cursor_y)
+                call  mouse_sext6
+                call  mouse_scale
+                ld    hl,in_dy
+                call  add_de_to
+                jr    rm_next
+rm_btnscroll
+                bit   5,a                      ; m=11: D5 0=buttons, 1=scroll
+                jr    nz,rm_next               ; scroll -> ignored for now
+                ld    a,e
+                and   #1F                       ; buttons (b0=L b1=R b2=M ...)
+                ld    (mouse_btn_state),a
+rm_next
+                ld    a,(rm_count)
+                dec   a
+                ld    (rm_count),a
+                jr    nz,rm_loop
+rm_apply
+                ld    a,(mouse_btn_state)      ; held left button -> select/click
+                bit   0,a
+                jr    z,rm_noL
+                ld    a,1
+                ld    (in_fire),a
+rm_noL
+                ld    a,(mouse_btn_state)      ; held right button -> quit
+                bit   1,a
+                ret   z
+                ld    a,1
+                ld    (in_quit),a
+                ret
+
+; mouse_sext6: A = packet -> DE = sign-extended 6-bit data (bit5 = sign).
+mouse_sext6
+                and   #3F
+                ld    e,a
+                ld    d,0
+                bit   5,e
+                ret   z
+                ld    a,e
+                or    #C0
+                ld    e,a
+                ld    d,#FF
+                ret
+
+; mouse_scale: DE <<= MOUSE_SHIFT.
+mouse_scale
+                ld    b,MOUSE_SHIFT
+ms_shl          sla   e
+                rl    d
+                djnz  ms_shl
+                ret
+
+; add_de_to: (HL) += DE (signed 16-bit); HL -> word variable.
+add_de_to
+                ld    a,(hl)
+                add   a,e
+                ld    (hl),a
+                inc   hl
+                ld    a,(hl)
+                adc   a,d
+                ld    (hl),a
+                ret
+
 ; --- State ---------------------------------------------------------------
-in_dirs         db    0            ; held directions (DIR_*), from the joystick
-in_joy_dirs     db    0            ; joystick/mouse directions (scratch)
-in_fire         db    0
-in_quit         db    0
+in_dx           dw    0            ; signed pointer delta this frame (cursor units)
+in_dy           dw    0
+in_fire         db    0            ; select/click held
+in_quit         db    0            ; quit requested
+in_joy_dirs     db    0            ; joystick directions (scratch)
+in_accel        db    0            ; joystick acceleration ramp counter
+in_step         db    0            ; joystick step this frame
+mouse_enabled   db    0            ; 1 = a SymbiFace is present, poll the mouse
+mouse_btn_state db    0            ; latest mouse button bits (persists across frames)
+rm_count        db    0            ; mouse burst-read counter


### PR DESCRIPTION
Closes #36.

Adds **SymbiFace II PS/2 mouse** support as the GEOBENCH pointer, with the **joystick always available as a fallback**. Tested interactively under UniDOS (mouse moves the pointer, left-click selects; joystick still works).

## What changed

The pointer layer (`lib/input.asm`) now combines two sources every frame into a signed per-frame delta (`in_dx`/`in_dy`) that the kernel's `poll_move` applies:

- **Joystick** (`KM_GET_JOYSTICK`): held directions → a stepped delta with the existing acceleration ramp. Always polled, so it is the universal fallback.
- **SymbiFace mouse** (port **#FD10**): burst-read until `0x00`, decoding X/Y offsets (scaled), buttons (left = select, right = quit); scroll ignored for now.

`poll_move` is simplified to just apply the delta (the per-direction stepping moved into `input.asm`).

## Detection / fallback

`#FD10` returns `0x00` both when idle **and** when no mouse is fitted, so a mouse can't be sensed at rest — we just consume packets when they arrive. Polling both sources every frame is what makes the joystick a zero-cost fallback. Mouse polling is gated on SymbiFace presence (`input_init` reuses `fs_ide_present`; #FD10 floats on a board without one).

## Notes

- The kernel grew ~180 bytes (kern_end #A229, ~95 bytes under the UniDOS stack ceiling); verified stable under UniDOS. If future growth tightens this, page the FAT32 write path out of the resident kernel to reclaim ~1KB.
- A stack relocation to low RAM was tried and reverted — low RAM (#0000–#3FFF) is shadowed by the lower ROM during firmware calls, so a stack there reads ROM, not RAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
