### PR TITLE
Migrate fmt_mem to the paged C module (#40)

### DIFF
--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -23,6 +23,8 @@ KCFG_TEXT       equ   #1000        ; GEOBENCH.CFG contents (<=512 bytes)
 KCFG_LEN        equ   #1200        ; word: cfg-text byte count (0 = no file)
 KCFG_ICONNAME   equ   #1202        ; 11-byte 8.3 icon filename, built by the module
 KCFG_FONTNAME   equ   #120D        ; 11-byte 8.3 font filename, built by the module
+KCFG_MEMKB      equ   #1218        ; word: total RAM in KB (kernel -> module)
+KCFG_MEMSTR     equ   #121A        ; "<decimal>K" top-bar string (module -> kernel)
 
 ; Callback API (issue #32) - kernel->app event delivery, state in low RAM so it
 ; costs no resident image bytes (low RAM stays main RAM under banking).
@@ -92,7 +94,7 @@ kernel_main
                 add   hl,hl
                 ld    de,64
                 add   hl,de
-                call  fmt_mem                ; -> mem_str
+                ld    (KCFG_MEMKB),hl        ; -> KCFG_MEMSTR (formatted by GBCFG)
                 call  cfg_boot               ; parse GEOBENCH.CFG (C module) ->
                                              ; KCFG_ICONS / KCFG_FONT (before the
                                              ; font/icon loaders consume them)
@@ -1182,7 +1184,7 @@ draw_topbar
                 ld    (tc_x),a
                 xor   a
                 ld    (tc_y),a
-                ld    hl,mem_str
+                ld    hl,KCFG_MEMSTR
                 call  draw_text
                 call  draw_menu_titles       ; the focused app's menu titles
                 ld    a,CLK_COL
@@ -1400,48 +1402,9 @@ ckc_loop
                 xor   a
                 ret
 
-; fmt_mem: HL = total KB -> mem_str as "<decimal>K".
-fmt_mem
-                ld    ix,mem_str
-                xor   a
-                ld    (fm_lead),a
-                ld    de,10000
-                call  fm_digit
-                ld    de,1000
-                call  fm_digit
-                ld    de,100
-                call  fm_digit
-                ld    de,10
-                call  fm_digit
-                ld    a,l
-                add   a,'0'
-                ld    (ix+0),a
-                ld    (ix+1),'K'
-                ld    (ix+2),0
-                ret
-fm_digit
-                ld    a,#FF
-fmd_loop
-                inc   a
-                or    a
-                sbc   hl,de
-                jr    nc,fmd_loop
-                add   hl,de
-                or    a
-                jr    nz,fmd_emit
-                ld    a,(fm_lead)
-                or    a
-                ret   z
-                xor   a
-fmd_emit
-                ld    b,a
-                ld    a,1
-                ld    (fm_lead),a
-                ld    a,b
-                add   a,'0'
-                ld    (ix+0),a
-                inc   ix
-                ret
+; (fmt_mem migrated to the GBCFG C module: gb_fmt_mem in kernel/kc/kcfg.c. The
+; kernel leaves the KB count in KCFG_MEMKB before cfg_boot; the module writes the
+; "<decimal>K" string to KCFG_MEMSTR, which draw_topbar renders.)
 
 ; mem_detect: count present 64K expansion banks (port &7F00 value &C4+bank*8
 ; pages a bank's block 0 into #4000-#7FFF). MUST run resident and BEFORE
@@ -1532,8 +1495,6 @@ md_update
                 ld    (md_last+1),a
                 ret
 
-mem_str         defs  8
-fm_lead         db    0
 time_str        defs  6
 clk_shown       defs  6
 sw_sec          db    0

--- a/kernel/kc/kcfg.c
+++ b/kernel/kc/kcfg.c
@@ -66,6 +66,26 @@ void gb_make_83(const char *stem, const char *ext, char *dst)
     dst[10] = ext[2];
 }
 
+void gb_fmt_mem(unsigned int kb, char *dst)
+{
+    static const unsigned int pow10[5] = { 10000, 1000, 100, 10, 1 };
+    unsigned char i, di = 0, lead = 0;
+
+    for (i = 0; i < 5; ++i) {         /* division-free: repeated subtraction */
+        unsigned char d = 0;
+        while (kb >= pow10[i]) {
+            kb -= pow10[i];
+            ++d;
+        }
+        if (d || lead || i == 4) {    /* suppress leading zeros; always emit units */
+            dst[di++] = (char)('0' + d);
+            lead = 1;
+        }
+    }
+    dst[di++] = 'K';
+    dst[di] = 0;
+}
+
 void gb_cfg_parse(const char *buf, unsigned int len,
                   char *icons_out, char *font_out)
 {

--- a/kernel/kc/kcfg.h
+++ b/kernel/kc/kcfg.h
@@ -29,4 +29,9 @@ void gb_cfg_parse(const char *buf, unsigned int len,
  * building off the (full) resident kernel and into the paged C module. */
 void gb_make_83(const char *stem, const char *ext, char *dst);
 
+/* gb_fmt_mem: write the decimal representation of `kb` followed by 'K' and a NUL
+ * into dst (>= 7 bytes); no leading zeros (0 -> "0K"). Mirrors the old asm
+ * fmt_mem; division-free, so no SDCC runtime is pulled into the module. */
+void gb_fmt_mem(unsigned int kb, char *dst);
+
 #endif /* GB_KCFG_H */

--- a/kernel/kc/kcfg_mod.c
+++ b/kernel/kc/kcfg_mod.c
@@ -23,6 +23,8 @@
 #define KCFG_LEN       (*(unsigned int *)0x1200)
 #define KCFG_ICONNAME  ((char *)0x1202)
 #define KCFG_FONTNAME  ((char *)0x120D)
+#define KCFG_MEMKB     (*(unsigned int *)0x1218)   /* in:  total RAM in KB */
+#define KCFG_MEMSTR    ((char *)0x121A)            /* out: "<decimal>K" string */
 
 static void set_default(char *stem)     /* "DEFAULT" + NUL */
 {
@@ -40,4 +42,5 @@ void main(void)
     gb_cfg_parse(KCFG_TEXT, KCFG_LEN, icons, font);
     gb_make_83(icons, "IST", KCFG_ICONNAME);
     gb_make_83(font,  "FNT", KCFG_FONTNAME);
+    gb_fmt_mem(KCFG_MEMKB, KCFG_MEMSTR);    /* top-bar RAM string */
 }

--- a/kernel/kc/test_kcfg.c
+++ b/kernel/kc/test_kcfg.c
@@ -47,6 +47,19 @@ static void check83(const char *name, const char *stem, const char *ext,
     }
 }
 
+/* gb_fmt_mem formats a KB count as "<decimal>K". */
+static void checkmem(const char *name, unsigned int kb, const char *want)
+{
+    char dst[8];
+    gb_fmt_mem(kb, dst);
+    if (strcmp(dst, want) != 0) {
+        printf("FAIL %-28s got=\"%s\" want=\"%s\"\n", name, dst, want);
+        ++failures;
+    } else {
+        printf("ok   %-28s \"%s\"\n", name, dst);
+    }
+}
+
 int main(void)
 {
     CHECK("empty",                 "",                              "DEFAULT", "DEFAULT");
@@ -68,6 +81,15 @@ int main(void)
     check83("make83 short",    "AA",      "IST", "AA      IST");
     check83("make83 full 8",   "ABCDEFGH","FNT", "ABCDEFGHFNT");
     check83("make83 empty",    "",        "IST", "        IST");
+
+    checkmem("mem 0",      0,     "0K");
+    checkmem("mem 64",     64,    "64K");
+    checkmem("mem 128",    128,   "128K");
+    checkmem("mem 256",    256,   "256K");
+    checkmem("mem 576",    576,   "576K");
+    checkmem("mem 1024",   1024,  "1024K");
+    checkmem("mem 9",      9,     "9K");
+    checkmem("mem 10000",  10000, "10000K");
 
     if (failures) {
         printf("\n%d test(s) FAILED\n", failures);


### PR DESCRIPTION
Closes #40 (follow-up to #38 item 3).

Migrates `fmt_mem` — the last boot-only, pure-logic asm helper — into the GBCFG C module that already runs at boot, continuing the kernel→C migration. (8.3-name building was already moved in #31.)

## Changes
- **`kernel/kc/kcfg.{c,h}`**: `gb_fmt_mem(kb, dst)` — decimal + `'K'`, **division-free** (repeated subtraction) so no SDCC runtime is linked into the module.
- **`kernel/kc/kcfg_mod.c`**: read `KCFG_MEMKB` (in), write `KCFG_MEMSTR` (out) alongside the existing config parse — no extra module load.
- **`kernel/gbkern.asm`**: drop `fmt_mem`/`fm_digit`/`fm_lead`/`mem_str`; stash the KB count in `KCFG_MEMKB` before `cfg_boot`; `draw_topbar` renders `KCFG_MEMSTR`.
- **`kernel/kc/test_kcfg.c`**: host parity cases (`0K`, `64K`, `128K`, `576K`, `1024K`, `10000K`, …).

## Result
`GBKERN.RAW` 7720 → **7631** bytes.

## Verified
- Host tests (`kernel/kc/run_tests.sh`) pass.
- Top bar reads the correct RAM size ("128K") on both floppy and IDE boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
