### PR TITLE
Cooperative window manager: kernel master loop + window table (#45 phase 1)

### DIFF
--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -1,9 +1,13 @@
 /* desktop - the GEOBENCH desktop, in C (the last app to leave assembly).
  *
  * Boots into PAGE_APP0. Draws the backdrop (below the kernel's top bar) and the
- * Disk / Clock / Trash icons, runs the pointer, lets you DRAG icons (hold fire,
- * a red outline follows, release to drop), and opens an icon on double-click:
- * Disk -> the file manager, Clock -> the C demo.
+ * Disk / Clock / Trash icons, lets you DRAG icons (hold fire, a red outline
+ * follows, release to drop), and opens an icon on double-click: Disk -> the file
+ * manager, Clock -> the C demo.
+ *
+ * Issue #45: the desktop no longer owns a for(;;) loop - it registers a window
+ * (gb_wm_run) and the KERNEL drives the master loop, calling on_frame each frame.
+ * It is the single, permanent root window; app windows layer on top of it.
  *
  * A press over an icon both arms a double-click and starts a drag; releasing
  * drops the icon at its new spot (no movement => it was just a click). The
@@ -116,10 +120,54 @@ static void on_event(void)
     gb_curshow();
 }
 
+/* on_frame: one frame of the desktop, called by the kernel's window-manager loop
+   (issue #45). The kernel polls before calling, so read input with gb_flags/mx/my
+   - never gb_poll here. What used to be the body of a for(;;) loop, with each
+   'continue' now a 'return' (end this frame). */
+static void on_frame(void)
+{
+    unsigned char flags = gb_flags(), mx = gb_mx(), my = gb_my(), held, icon;
+
+    if (dc_timer) dc_timer--;
+    /* the desktop is the permanent root - ESC doesn't exit GEOBENCH (you reboot
+       the CPC to leave); it only closes apps launched on top of it */
+
+    held = flags & GB_FIRE;
+    if (held_prev && !held && drag_active) {   /* fire released -> drop */
+        drop();
+        held_prev = 0;
+        return;
+    }
+    held_prev = held;
+
+    if (drag_active) {                     /* follow the pointer */
+        dragmove(mx, my);
+        return;
+    }
+
+    if (!(flags & GB_CLICK)) return;       /* a fresh press? */
+    icon = hit_icon(mx, my);
+    if (icon == NONE) return;
+
+    if (dc_timer && dc_idx == icon) {      /* second click -> open */
+        if (icon == 0)      gb_run("FILEMGR BIN");
+        else if (icon == 1) gb_run("CHELLO  BIN");
+        dc_timer = 0;
+        held_prev = 0;
+        paint();                           /* repaint after it returns */
+    } else {                               /* first click: arm + start drag */
+        dc_idx = icon;
+        dc_timer = DCLICK;
+        dragstart(icon, mx, my);
+    }
+}
+
+/* the desktop is one window covering the screen below the top bar; on_repaint is
+   the same full paint() used to restore the backdrop behind a child's window */
+static const gb_win_t deskwin = { 0, 8, 80, 192, on_frame, paint };
+
 void main(void)
 {
-    unsigned char flags, mx, my, held, icon;
-
     paint();
     gb_on_event(on_event);                     /* top-bar clicks -> on_event */
     gb_on_repaint(paint);                      /* repaint behind a child's moved window */
@@ -127,42 +175,5 @@ void main(void)
     drag_active = 0;
     dc_timer = 0;
     held_prev = 0;
-
-    for (;;) {
-        flags = gb_poll();
-        mx = gb_mx();
-        my = gb_my();
-        if (dc_timer) dc_timer--;
-        /* the desktop is the permanent root - ESC doesn't exit GEOBENCH (you reboot
-           the CPC to leave); it only closes apps launched on top of it */
-
-        held = flags & GB_FIRE;
-        if (held_prev && !held && drag_active) {   /* fire released -> drop */
-            drop();
-            held_prev = 0;
-            continue;
-        }
-        held_prev = held;
-
-        if (drag_active) {                     /* follow the pointer */
-            dragmove(mx, my);
-            continue;
-        }
-
-        if (!(flags & GB_CLICK)) continue;     /* a fresh press? */
-        icon = hit_icon(mx, my);
-        if (icon == NONE) continue;
-
-        if (dc_timer && dc_idx == icon) {      /* second click -> open */
-            if (icon == 0)      gb_run("FILEMGR BIN");
-            else if (icon == 1) gb_run("CHELLO  BIN");
-            dc_timer = 0;
-            held_prev = 0;
-            paint();                           /* repaint after it returns */
-        } else {                               /* first click: arm + start drag */
-            dc_idx = icon;
-            dc_timer = DCLICK;
-            dragstart(icon, mx, my);
-        }
-    }
+    gb_wm_run(&deskwin);                        /* hand the loop to the kernel WM (#45) */
 }

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -31,9 +31,20 @@ KCFG_MEMSTR     equ   #121A        ; "<decimal>K" top-bar string (module -> kern
 APP_HANDLER     equ   #1300        ; word: registered app event handler (0 = none)
 GB_MSG          equ   #1302        ; message record: type, p0, p1, p2 (4 bytes)
 GB_MSG_MENU     equ   1            ; message type: top-bar click, p0 = byte column
+POLL_MX         equ   #1306        ; last poll: cursor byte column (mx)
+POLL_MY         equ   #1307        ; last poll: cursor line (my)
+POLL_FLAGS      equ   #1308        ; last poll: flags (bit0 click, bit1 quit, bit2 fire)
 MENU_DEF        equ   #1310        ; app menu: count, then {col, 8-byte label} *count
 REPAINT_HDLR    equ   #1340        ; per-depth full-repaint handlers (4 words), for
                                    ; restoring the background under a moved window (#43)
+
+; Window manager (issue #45) - the kernel owns the master loop and a table of
+; windows; each app registers one with gb_wm_run and becomes callback-driven.
+; State in low RAM (0 resident image bytes). Phase 1: one window (the desktop).
+WM_NWIN         equ   #1350        ; number of registered windows
+WM_FOCUS        equ   #1351        ; index of the focused window
+WM_TABLE        equ   #1352        ; WM_ESZ-byte entries (max 4):
+WM_ESZ          equ   9            ;   page, x, y, w, h, on_frame(2), on_repaint(2)
 
                 org   GB_KERNEL
 ; --- fixed API jump table (order is the ABI; see lib/gbapp.inc) -----------
@@ -67,6 +78,7 @@ REPAINT_HDLR    equ   #1340        ; per-depth full-repaint handlers (4 words), 
                 jp    k_setname              ; GB_SETNAME     #8051
                 jp    k_onrepaint            ; GB_ONREPAINT   #8054
                 jp    k_restore_parent       ; GB_RESTPAR     #8057
+                jp    k_wm_run               ; GB_WMRUN       #805A
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -106,6 +118,8 @@ kernel_main
                 call  icon_init              ; load the icon set into PAGE_DATA
                 call  clock_init             ; RTC or software clock -> time_str
                 call  draw_topbar            ; the kernel owns the top bar
+                xor   a                       ; window table empty (gb_wm_run appends)
+                ld    (WM_NWIN),a
                 ld    hl,name_desktop        ; the desktop is the first app
                 call  launch_app             ; run DESKTOP in PAGE_APP0
                 ld    a,2                     ; desktop quit (ESC) -> back to BASIC
@@ -227,9 +241,13 @@ gp_noquit
                 set   2,d
 gp_nohold
                 call  menu_dispatch          ; kernel-owned top-bar click -> app
-                ld    a,(poll_byte)
+                ld    a,d                     ; publish the result to fixed low RAM so a
+                ld    (POLL_FLAGS),a          ; WM callback can read it without re-polling
+                ld    a,(poll_byte)           ; (gb_mx/gb_my/gb_flags read these)
+                ld    (POLL_MX),a
                 ld    b,a
                 ld    a,(poll_line)
+                ld    (POLL_MY),a
                 ld    c,a
                 ret
 poll_lastfire   db    0
@@ -1032,6 +1050,54 @@ krp_restore
                 ei
                 ret
 krp_save        db    0
+
+; k_wm_run (GB_WMRUN): the cooperative window-manager loop (issue #45). The app
+; calls this once from main() with HL = a window descriptor in its page:
+;   { u8 x, u8 y, u8 w, u8 h, void(*on_frame)(void), void(*on_repaint)(void) }
+; It registers the window in WM_TABLE (page = the caller's), makes it the focus,
+; then runs the master loop forever: poll input, then CALL the focused window's
+; on_frame. Phase 1 has a single window (the desktop), always focused and already
+; mapped, so the loop is a thin inversion of the app's old for(;;); Phase 2 will
+; hit-test the rect on a click to switch focus and bank to another window's page.
+k_wm_run
+                push  hl                          ; HL = descriptor in the app page
+                ld    a,(WM_NWIN)
+                ld    (WM_FOCUS),a               ; the new window takes focus
+                call  wm_entry                    ; HL = WM_TABLE[NWIN]
+                ld    a,(bank_cur)               ; entry.page = the caller's page
+                ld    (hl),a
+                inc   hl
+                ex    de,hl                       ; DE = entry+1 (x..on_repaint)
+                pop   hl                          ; HL = descriptor
+                ld    bc,8
+                ldir                              ; copy x,y,w,h,on_frame,on_repaint
+                ld    a,(WM_NWIN)
+                inc   a
+                ld    (WM_NWIN),a
+wm_loop
+                call  k_poll                      ; pace + cursor + clock + low-RAM result
+                ld    a,(WM_FOCUS)               ; HL = focused entry's on_frame
+                call  wm_entry
+                ld    de,5                        ; +5 = on_frame (after page,x,y,w,h)
+                add   hl,de
+                ld    a,(hl)
+                inc   hl
+                ld    h,(hl)
+                ld    l,a
+                call  md_call                     ; on_frame() in the focused page
+                jr    wm_loop
+
+; wm_entry: A = window index -> HL = WM_TABLE + A*WM_ESZ. Clobbers A,B,DE.
+wm_entry
+                ld    hl,WM_TABLE
+                or    a
+                ret   z
+                ld    b,a
+                ld    de,WM_ESZ
+we_add
+                add   hl,de
+                djnz  we_add
+                ret
 
 ; menu_dispatch: called from k_poll. If a fresh click (D bit0) landed in the
 ; kernel-owned top bar and the app registered a handler, deliver a GB_MSG_MENU

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -35,6 +35,7 @@ void gb_curhide(void);                                   /* lift the pointer    
 unsigned char gb_poll(void);          /* frame poll -> flags; caches cursor pos   */
 unsigned char gb_mx(void);            /* last poll's cursor byte column           */
 unsigned char gb_my(void);            /* last poll's cursor line                  */
+unsigned char gb_flags(void);         /* last poll's flags (for gb_wm_run apps)   */
 char *gb_dir1(void);                  /* first dir entry -> "NAME.EXT", 0 at end  */
 char *gb_dirn(void);                  /* next dir entry  -> "NAME.EXT", 0 at end  */
 void gb_launch(void);                 /* launch the current dir entry             */
@@ -82,4 +83,18 @@ void gb_set_name(const char *name11);
  * child redraws its window on top. */
 void gb_on_repaint(void (*handler)(void));   /* register full-repaint handler */
 void gb_restore_parent(void);                /* repaint ancestor apps behind us */
+
+/* Cooperative window manager (issue #45). Instead of owning a for(;;) loop, an
+ * app fills a gb_win_t and calls gb_wm_run once from main(): the KERNEL runs the
+ * master loop and calls the window's on_frame every frame (read input with
+ * gb_flags/gb_mx/gb_my - do NOT call gb_poll inside it). on_repaint redraws the
+ * whole window with no input. The rect (x,y,w,h) is the window's screen area, for
+ * click-to-focus hit-testing once multiple windows coexist. gb_wm_run does not
+ * return (Phase 1: the desktop is the single, permanent window). */
+typedef struct {
+    unsigned char x, y, w, h;       /* window rect (byte col, line, size) */
+    void (*on_frame)(void);         /* called each frame when focused      */
+    void (*on_repaint)(void);       /* redraw the whole window, no input   */
+} gb_win_t;
+void gb_wm_run(const gb_win_t *desc);
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -33,11 +33,11 @@
         .globl  _gb_set_name
         .globl  _gb_on_repaint
         .globl  _gb_restore_parent
+        .globl  _gb_flags
+        .globl  _gb_wm_run
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
-mx_v:   .ds     1               ; cursor byte col cached by the last gb_poll
-my_v:   .ds     1               ; cursor line cached by the last gb_poll
 
         .area   _CODE
 
@@ -131,21 +131,22 @@ _gb_curshow:
 _gb_curhide:
         jp      0x8024          ; GB_CURHIDE
 
-;; unsigned char gb_poll(void);   -> flags in A; caches cursor col/line
+;; unsigned char gb_poll(void);   -> flags in A. The kernel also publishes the
+;; result (mx/my/flags) to fixed low RAM, so gb_mx/gb_my/gb_flags read it without
+;; re-polling - and a window-manager callback (gb_wm_run) can too.
 _gb_poll:
-        call    0x801E          ; GB_POLL -> B=col C=line D=flags
-        ld      a, b
-        ld      (mx_v), a
-        ld      a, c
-        ld      (my_v), a
+        call    0x801E          ; GB_POLL -> D=flags (+ #1306/7/8 low RAM)
         ld      a, d
         ret
-;; unsigned char gb_mx(void); / gb_my(void);
+;; unsigned char gb_mx(void); / gb_my(void); / gb_flags(void);  read the last poll
 _gb_mx:
-        ld      a, (mx_v)
+        ld      a, (0x1306)     ; POLL_MX
         ret
 _gb_my:
-        ld      a, (my_v)
+        ld      a, (0x1307)     ; POLL_MY
+        ret
+_gb_flags:
+        ld      a, (0x1308)     ; POLL_FLAGS
         ret
 
 ;; char *gb_dir1(void); / char *gb_dirn(void);   -> name ptr in DE, 0 at end
@@ -214,3 +215,8 @@ _gb_on_repaint:
 ;; void gb_restore_parent(void);   repaint the ancestor apps behind the caller
 _gb_restore_parent:
         jp      0x8057          ; GB_RESTPAR
+
+;; void gb_wm_run(const gb_win_t *desc);   desc in HL -> kernel registers the
+;; window and enters the master loop (issue #45). Does not return (Phase 1).
+_gb_wm_run:
+        jp      0x805A          ; GB_WMRUN

--- a/lib/gbapp.inc
+++ b/lib/gbapp.inc
@@ -101,3 +101,21 @@ GB_MENU         equ   GB_KERNEL+78 ; #804E  register the top-bar menu: HL = blob
 GB_SETNAME      equ   GB_KERNEL+81 ; #8051  set the current file name (launch arg):
                                    ;        HL = 11-byte 8.3 name. For New / Save As /
                                    ;        opening a picked file.
+GB_ONREPAINT    equ   GB_KERNEL+84 ; #8054  register a full-repaint handler (#43):
+                                   ;        HL = void(void) in the app page, stored
+                                   ;        at this app's nesting slot. A child calls
+                                   ;        GB_RESTPAR to repaint it behind a window.
+GB_RESTPAR      equ   GB_KERNEL+87 ; #8057  repaint every ancestor app bottom-up
+                                   ;        (maps each page, calls its GB_ONREPAINT
+                                   ;        handler) so a moved/closed window's area
+                                   ;        shows what was under it. Restores the
+                                   ;        caller's page; caller redraws on top.
+GB_WMRUN        equ   GB_KERNEL+90 ; #805A  window-manager master loop (#45): HL = a
+                                   ;        descriptor { u8 x,y,w,h; on_frame(2);
+                                   ;        on_repaint(2) } in the app page. Registers
+                                   ;        the window (page = caller), takes focus,
+                                   ;        then loops: poll, CALL the focused
+                                   ;        window's on_frame. Does not return.
+                                   ;        on_frame reads gb_flags/gb_mx/gb_my; the
+                                   ;        poll result is published at POLL_MX #1306
+                                   ;        / POLL_MY #1307 / POLL_FLAGS #1308.


### PR DESCRIPTION
## Phase 1 of the cooperative window manager (#45)

Inverts control for the desktop: the **kernel** now owns the master loop and a window table, and the desktop is driven by callbacks instead of its own `for(;;)`. **No behaviour change** — this is the foundation for click-to-focus (Phase 2).

### Why
Apps today run nested-synchronously: each owns a `for(;;) gb_poll()` loop and only the **deepest** one runs, so nothing can route input by window. To focus a background window the kernel has to own the loop and know each window's rect.

### What changed
**Kernel (`gbkern.asm`)**
- **Window table** in low RAM (`WM_NWIN`/`WM_FOCUS`/`WM_TABLE`) — per window: page, rect, `on_frame`, `on_repaint`. 0 resident image bytes (low RAM stays main RAM under banking).
- `k_poll` **publishes its result** (mx/my/flags) to fixed low RAM (`POLL_MX` #1306 / `POLL_MY` #1307 / `POLL_FLAGS` #1308), so a callback reads input without re-polling — the hook Phase 2 uses to intercept clicks.
- New API **`GB_WMRUN` (#805A) `k_wm_run`**: register the caller's window, then run the master loop — poll, then CALL the focused window's `on_frame`. Phase 1 has one window (the desktop), always focused and already mapped.

**libgb (`gb.h` / `gblib.s`)**
- `gb_win_t` descriptor + `gb_wm_run`.
- `gb_mx`/`gb_my` now read the shared low-RAM poll result; new `gb_flags`; `gb_poll` simplified to match.

**Desktop (`apps/desktop/main.c`)**
- `main()` does setup then `gb_wm_run(&deskwin)`; the old loop body is now `on_frame` (`continue` → `return`).
- Modal `gb_run` of un-ported apps (File Manager, Clock demo) still works unchanged — backwards compatible.

**`gbapp.inc`**: documents `GB_ONEVENT`/`GB_RESTPAR` (were undocumented) and `GB_WMRUN`.

### Verification
- Builds clean; `GBKERN.RAW` 7763 bytes (+81), ~1KB headroom under HIMEM.
- Headless boot → pixel-identical desktop (top bar, icons, live cursor); interactively the icon drags / Disk → File Manager / Clock → demo behave exactly as before.

### Next (Phase 2)
Hit-test the window rects on a click so a second window can take focus — where click-to-focus actually appears.
