### PR TITLE
Cooperative window manager: co-resident windows + click-to-focus (#45 phase 2)

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,338 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -150,11 +150,11 @@ static void on_frame(void)
     if (icon == NONE) return;
 
     if (dc_timer && dc_idx == icon) {      /* second click -> open */
-        if (icon == 0)      gb_run("FILEMGR BIN");
-        else if (icon == 1) gb_run("CHELLO  BIN");
+        if (icon == 0)      gb_wm_open("FILEMGR BIN");  /* co-resident window  */
+        else if (icon == 1) gb_run("CHELLO  BIN");      /* modal; kernel repaints
+                                                           the windows on return */
         dc_timer = 0;
         held_prev = 0;
-        paint();                           /* repaint after it returns */
     } else {                               /* first click: arm + start drag */
         dc_idx = icon;
         dc_timer = DCLICK;
@@ -162,18 +162,17 @@ static void on_frame(void)
     }
 }
 
-/* the desktop is one window covering the screen below the top bar; on_repaint is
-   the same full paint() used to restore the backdrop behind a child's window */
-static const gb_win_t deskwin = { 0, 8, 80, 192, on_frame, paint };
+/* the desktop is the root window: full screen below the top bar, on_repaint = the
+   full paint() (restacked behind any window), on_event = the top-bar click demo.
+   Its rect spans the screen so it is the bottom catch-all for click-to-focus. */
+static const gb_win_t deskwin = { 0, 8, 80, 192, on_frame, paint, on_event };
 
 void main(void)
 {
     paint();
-    gb_on_event(on_event);                     /* top-bar clicks -> on_event */
-    gb_on_repaint(paint);                      /* repaint behind a child's moved window */
     gb_menu(dt_menu);                          /* draw the desktop menu title */
     drag_active = 0;
     dc_timer = 0;
     held_prev = 0;
-    gb_wm_run(&deskwin);                        /* hand the loop to the kernel WM (#45) */
+    gb_wm_run(&deskwin);                        /* register + run the kernel WM (#45) */
 }

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -103,6 +103,16 @@ static void on_frame(void)
         return;
     }
 
+    /* title bar (right of the close gadget) -> drag the window */
+    if (my >= win_y && my < win_y + TITLE_H
+        && mx >= win_x + 4 && mx < win_x + WIN_W) {
+        if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
+            gb_wm_setpos(win_x, win_y);   /* move our hit rect to follow */
+            gb_restore_parent();          /* repaint the stack at the new spot */
+        }
+        return;
+    }
+
     /* footer pager: left half scrolls up, right half down */
     if (my >= foot_y && my < foot_y + 10) {
         if (mx < win_x + WIN_W / 2) {
@@ -131,8 +141,9 @@ static void on_frame(void)
     }
 }
 
-/* a fixed-position co-resident window; click it to focus, the close gadget or ESC
-   to close. on_repaint = draw_list, which the kernel calls to restack us. */
+/* a co-resident window: click it to focus, drag the title bar to move it (the hit
+   rect follows via gb_wm_setpos), the close gadget or ESC to close. on_repaint =
+   draw_list, which the kernel calls to restack us. */
 static const gb_win_t fmwin = { DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, draw_list, 0 };
 
 void main(void)

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -5,14 +5,15 @@
  * icon + name per entry - and SCROLLS when the list is taller than the window
  * (a footer pager: click the left half to scroll up, the right half down). A
  * click selects a row (red frame); a double-click launches the entry's app
- * (the kernel's type->app table). The close gadget or ESC quits.
+ * (the kernel's type->app table). The close gadget or ESC closes the window.
  *
- * The window is draggable (issue #43): grab the title bar (right of the close
- * gadget) and move it. Dragging lifts the window to an outline, then redraws at
- * the dropped position - no save-under; the backdrop pen fills the vacated area. */
+ * Issue #45: a co-resident window managed by the kernel. main() registers it with
+ * gb_wm_add and returns; the kernel's WM loop calls on_frame when we are focused
+ * and draw_list (on_repaint) to restack us. Click our window to focus it; click
+ * the desktop (or another window) to focus that. */
 #include "gb.h"
 
-#define DEF_X    4            /* initial window position */
+#define DEF_X    4            /* window position */
 #define DEF_Y    26
 #define WIN_W    56
 #define WIN_H    130
@@ -22,7 +23,7 @@
 #define VIS      5            /* visible rows (the rest scroll)  */
 #define DCLICK   40           /* double-click window, frames */
 
-static unsigned char win_x = DEF_X;   /* live window position (draggable) */
+static unsigned char win_x = DEF_X;   /* window position */
 static unsigned char win_y = DEF_Y;
 static unsigned char total;   /* number of files on the disk            */
 static unsigned char top;     /* index of the first visible row (scroll) */
@@ -70,78 +71,76 @@ static void draw_list(void)
     gb_curshow();
 }
 
-/* launch: open the file at absolute index idx (position the dir cursor there,
-   then ask the kernel to launch the entry), and redraw on return. */
+/* launch: open the file at absolute index idx. The launched app runs MODALLY (it
+   owns the screen until it quits); the kernel repaints all WM windows - including
+   our draw_list - when it returns, so we just clear the selection beforehand. */
 static void launch(unsigned char idx)
 {
     unsigned char i;
     char *p = gb_dir1();
     for (i = 0; i < idx && p; i++) p = gb_dirn();
-    gb_launch();
-    gb_restore_parent();         /* repaint the desktop behind us (where the app was) */
     nsel = 0;
-    draw_list();                 /* our window on top */
+    gb_launch();
 }
+
+/* on_frame: one frame when this window is focused (kernel WM loop, issue #45).
+   Read input with gb_flags/mx/my; each old loop 'continue' is now a 'return'. */
+static void on_frame(void)
+{
+    unsigned char flags = gb_flags(), mx, my, vis, idx, foot_y;
+
+    if (dc_timer) dc_timer--;
+    if (flags & GB_QUIT) { gb_wm_close(); return; }    /* ESC closes this window */
+    if (!(flags & GB_CLICK)) return;
+
+    mx = gb_mx();
+    my = gb_my();
+    foot_y = win_y + WIN_H - 12;
+
+    /* close gadget (top-left of the title bar) */
+    if (my >= win_y && my < win_y + TITLE_H && mx >= win_x && mx < win_x + 4) {
+        gb_wm_close();
+        return;
+    }
+
+    /* footer pager: left half scrolls up, right half down */
+    if (my >= foot_y && my < foot_y + 10) {
+        if (mx < win_x + WIN_W / 2) {
+            if (top > 0) { top--; draw_list(); }
+        } else {
+            if (top + VIS < total) { top++; draw_list(); }
+        }
+        return;
+    }
+
+    /* a list row? */
+    if (my >= win_y + ROW_OFF && my < win_y + ROW_OFF + VIS * ROW_H
+        && mx >= win_x && mx < win_x + WIN_W) {
+        vis = (my - (win_y + ROW_OFF)) / ROW_H;
+        idx = top + vis;
+        if (idx >= total) return;
+        if (dc_timer && dc_row == idx) {     /* double-click -> open */
+            launch(idx);
+            dc_timer = 0;
+        } else {                              /* single click -> select */
+            nsel = idx + 1;
+            dc_row = idx;
+            dc_timer = DCLICK;
+            draw_list();
+        }
+    }
+}
+
+/* a fixed-position co-resident window; click it to focus, the close gadget or ESC
+   to close. on_repaint = draw_list, which the kernel calls to restack us. */
+static const gb_win_t fmwin = { DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, draw_list, 0 };
 
 void main(void)
 {
-    unsigned char flags, mx, my, vis, idx;
-    unsigned char foot_y;
-
+    win_x = DEF_X;
+    win_y = DEF_Y;
     total = count_files();
     top = 0; nsel = 0; dc_timer = 0;
     draw_list();
-    gb_on_repaint(draw_list);    /* repaint behind a child's (or our) moved window */
-
-    for (;;) {
-        flags = gb_poll();
-        if (dc_timer) dc_timer--;
-        if (flags & GB_QUIT) return;
-        if (!(flags & GB_CLICK)) continue;
-
-        mx = gb_mx();
-        my = gb_my();
-        foot_y = win_y + WIN_H - 12;
-
-        /* close gadget (top-left of the title bar) */
-        if (my >= win_y && my < win_y + TITLE_H && mx >= win_x && mx < win_x + 4)
-            return;
-
-        /* title bar (right of the close gadget) -> drag the window */
-        if (my >= win_y && my < win_y + TITLE_H
-            && mx >= win_x + 4 && mx < win_x + WIN_W) {
-            if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
-                gb_restore_parent();                  /* repaint what was behind us */
-                draw_list();                          /* our window on top */
-            }
-            continue;
-        }
-
-        /* footer pager: left half scrolls up, right half down */
-        if (my >= foot_y && my < foot_y + 10) {
-            if (mx < win_x + WIN_W / 2) {
-                if (top > 0) { top--; draw_list(); }
-            } else {
-                if (top + VIS < total) { top++; draw_list(); }
-            }
-            continue;
-        }
-
-        /* a list row? */
-        if (my >= win_y + ROW_OFF && my < win_y + ROW_OFF + VIS * ROW_H
-            && mx >= win_x && mx < win_x + WIN_W) {
-            vis = (my - (win_y + ROW_OFF)) / ROW_H;
-            idx = top + vis;
-            if (idx >= total) continue;
-            if (dc_timer && dc_row == idx) {     /* double-click -> open */
-                launch(idx);
-                dc_timer = 0;
-            } else {                              /* single click -> select */
-                nsel = idx + 1;
-                dc_row = idx;
-                dc_timer = DCLICK;
-                draw_list();
-            }
-        }
-    }
+    gb_wm_add(&fmwin);           /* register; the kernel WM drives us (#45) */
 }

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -39,12 +39,21 @@ REPAINT_HDLR    equ   #1340        ; per-depth full-repaint handlers (4 words), 
                                    ; restoring the background under a moved window (#43)
 
 ; Window manager (issue #45) - the kernel owns the master loop and a table of
-; windows; each app registers one with gb_wm_run and becomes callback-driven.
-; State in low RAM (0 resident image bytes). Phase 1: one window (the desktop).
-WM_NWIN         equ   #1350        ; number of registered windows
-WM_FOCUS        equ   #1351        ; index of the focused window
-WM_TABLE        equ   #1352        ; WM_ESZ-byte entries (max 4):
-WM_ESZ          equ   9            ;   page, x, y, w, h, on_frame(2), on_repaint(2)
+; co-resident windows; each app registers one and becomes callback-driven. State
+; in low RAM (0 resident image bytes). Phase 2: multiple windows + click-to-focus.
+WM_PAGES        equ   #134F        ; page-in-use bitmap: bit i = PAGE_APP0+i busy
+WM_NWIN         equ   #1350        ; number of live windows
+WM_FOCUS        equ   #1351        ; slot index of the focused window
+WM_TABLE        equ   #1352        ; WM_MAXWIN * WM_ESZ-byte entries:
+WM_ESZ          equ   12           ;   page,x,y,w,h, on_frame(2),on_repaint(2),
+WM_MAXWIN       equ   4            ;   on_event(2), flags(1: bit0 alive)
+WM_Z            equ   #1382        ; z-order: WM_NWIN slot indices, [0]=bottom
+WM_FR_PAGE      equ   1            ; entry field offsets (after +0 page):
+WM_FR_X         equ   1            ;   page,x,y,w,h, frame,repaint,event, flags
+WM_FR_FRAME     equ   5
+WM_FR_REPAINT   equ   7
+WM_FR_EVENT     equ   9
+WM_FR_FLAGS     equ   11
 
                 org   GB_KERNEL
 ; --- fixed API jump table (order is the ABI; see lib/gbapp.inc) -----------
@@ -79,6 +88,9 @@ WM_ESZ          equ   9            ;   page, x, y, w, h, on_frame(2), on_repaint
                 jp    k_onrepaint            ; GB_ONREPAINT   #8054
                 jp    k_restore_parent       ; GB_RESTPAR     #8057
                 jp    k_wm_run               ; GB_WMRUN       #805A
+                jp    k_wm_add               ; GB_WMADD       #805D
+                jp    k_wm_open              ; GB_WMOPEN      #8060
+                jp    k_wm_close             ; GB_WMCLOSE     #8063
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -118,8 +130,11 @@ kernel_main
                 call  icon_init              ; load the icon set into PAGE_DATA
                 call  clock_init             ; RTC or software clock -> time_str
                 call  draw_topbar            ; the kernel owns the top bar
-                xor   a                       ; window table empty (gb_wm_run appends)
-                ld    (WM_NWIN),a
+                ld    hl,WM_PAGES            ; clear all WM low-RAM state (pages bitmap,
+                ld    de,WM_PAGES+1          ; counts, table incl. alive flags, z-order)
+                ld    bc,WM_Z+WM_MAXWIN-WM_PAGES-1
+                ld    (hl),0
+                ldir
                 ld    hl,name_desktop        ; the desktop is the first app
                 call  launch_app             ; run DESKTOP in PAGE_APP0
                 ld    a,2                     ; desktop quit (ESC) -> back to BASIC
@@ -819,11 +834,11 @@ launch_app
                 ld    de,fs_req_name         ; name -> fs_req_name (HL in caller page)
                 ld    bc,11
                 ldir
-                ld    a,(launch_depth)       ; target page = PAGE_APP0 + depth
-                cp    3
-                ret   nc                      ; no free page (max 3 apps) -> give up
-                add   a,PAGE_APP0
-                ld    c,a
+                call  wm_alloc_page          ; grab a free bank page (not depth-based,
+                or    a                       ; so it never collides with a co-resident
+                ret   z                       ; WM window) -> A=page, 0 = none free
+                ld    c,a                      ; C = target page
+                push  bc                       ; save target page to free on return
                 ld    a,(bank_cur)           ; save caller's page (per depth) on stack
                 push  af
                 ld    hl,(APP_HANDLER)       ; save the parent's event handler and clear
@@ -857,8 +872,14 @@ la_done
                 ld    (APP_HANDLER),hl
                 pop   af                       ; caller's page
                 call  bank_set
+                pop   bc                       ; target page -> release it
+                ld    a,c
+                call  wm_free_page
                 call  draw_topbar             ; the app may have wiped it (e.g. a C
                                               ; app's gb_cls) - the bar is the kernel's
+                ld    a,(WM_NWIN)            ; if WM windows are live underneath (a modal
+                or    a                       ; app launched from one), repaint them so
+                call  nz,wm_repaint_all      ; the modal app's screen area is restored
                 ei
 la_escwait                                     ; if the app quit on ESC, wait for the
                 ld    a,66                     ; key to be released before the parent
@@ -866,6 +887,54 @@ la_escwait                                     ; if the app quit on ESC, wait fo
                 jr    nz,la_escwait            ; cascading all the way back to BASIC
                 ret
 launch_depth    db    0
+
+; wm_alloc_page: claim the lowest free app bank page -> A = PAGE_APP0+i (#C5..#C7),
+; or 0 if all three are busy. wm_free_page: A = page to release. The bitmap WM_PAGES
+; tracks pages held by co-resident WM windows and by modal launch_app calls alike.
+wm_alloc_page
+                ld    a,(WM_PAGES)
+                bit   0,a
+                jr    z,wap0
+                bit   1,a
+                jr    z,wap1
+                bit   2,a
+                jr    z,wap2
+                xor   a                         ; none free
+                ret
+wap0            set   0,a
+                ld    (WM_PAGES),a
+                ld    a,PAGE_APP0
+                ret
+wap1            set   1,a
+                ld    (WM_PAGES),a
+                ld    a,PAGE_APP0+1
+                ret
+wap2            set   2,a
+                ld    (WM_PAGES),a
+                ld    a,PAGE_APP0+2
+                ret
+wm_free_page
+                sub   PAGE_APP0               ; A = page index 0..2
+                ld    c,a
+                ld    a,(WM_PAGES)
+                or    a                         ; (defensive) nothing to clear
+                ret   z
+                ld    b,a
+                ld    a,c
+                or    a
+                jr    z,wfp0
+                dec   a
+                jr    z,wfp1
+                ld    a,b
+                res   2,a
+                jr    wfp_store
+wfp0            ld    a,b
+                res   0,a
+                jr    wfp_store
+wfp1            ld    a,b
+                res   1,a
+wfp_store       ld    (WM_PAGES),a
+                ret
 
 ; k_run (GB_RUN): run a named app. HL = 8.3 name (in the caller's page).
 k_run
@@ -1002,92 +1071,324 @@ k_onrepaint
                 ld    (hl),d
                 ret
 
-; k_restore_parent (GB_RESTPAR): repaint every ancestor app behind the caller,
-; bottom-up, so the area a moved window vacated shows what was under it. Maps each
-; ancestor's page in turn and calls its registered repaint handler, then restores
-; the caller's page. The caller redraws its own window on top afterwards. Mirrors
-; launch_app's map/call/restore discipline.
+; k_restore_parent (GB_RESTPAR): repaint everything behind the caller. Under the
+; window manager (issue #45) the live windows below a modal app are exactly the WM
+; windows, so this repaints them all bottom-up (wm_repaint_all) - e.g. a modal
+; Notepad dragging its window restores the desktop + file manager underneath, then
+; redraws itself on top. (Replaces the old per-depth REPAINT_HDLR walk, which the
+; co-resident model made obsolete.)
 k_restore_parent
-                ld    a,(launch_depth)
-                cp    2
-                ret   c                          ; depth<2 -> no ancestor to repaint
-                ld    a,(bank_cur)              ; remember the caller's page
-                ld    (krp_save),a
-                di
-                ld    b,0                        ; ancestor page index 0..depth-2
-krp_loop
-                ld    a,(launch_depth)
-                sub   2                          ; last ancestor index = depth-2
-                cp    b
-                jr    c,krp_restore
-                push  bc                          ; map ancestor page (clobbers A,B,C)
-                ld    a,b
-                add   a,PAGE_APP0
-                call  bank_set
-                pop   bc
-                ld    a,b                         ; handler = REPAINT_HDLR[b]
-                add   a,a
-                ld    e,a
-                ld    d,0
-                ld    hl,REPAINT_HDLR
-                add   hl,de
-                ld    e,(hl)
-                inc   hl
-                ld    d,(hl)
-                ld    a,d
-                or    e
-                jr    z,krp_next                  ; no handler registered -> skip
-                push  bc
-                ex    de,hl                       ; HL = handler
-                call  md_call                     ; call (hl)
-                pop   bc
-krp_next
-                inc   b
-                jr    krp_loop
-krp_restore
-                ld    a,(krp_save)
-                call  bank_set                    ; back to the caller's page
-                ei
-                ret
-krp_save        db    0
+                jp    wm_repaint_all
 
-; k_wm_run (GB_WMRUN): the cooperative window-manager loop (issue #45). The app
-; calls this once from main() with HL = a window descriptor in its page:
-;   { u8 x, u8 y, u8 w, u8 h, void(*on_frame)(void), void(*on_repaint)(void) }
-; It registers the window in WM_TABLE (page = the caller's), makes it the focus,
-; then runs the master loop forever: poll input, then CALL the focused window's
-; on_frame. Phase 1 has a single window (the desktop), always focused and already
-; mapped, so the loop is a thin inversion of the app's old for(;;); Phase 2 will
-; hit-test the rect on a click to switch focus and bank to another window's page.
-k_wm_run
-                push  hl                          ; HL = descriptor in the app page
-                ld    a,(WM_NWIN)
-                ld    (WM_FOCUS),a               ; the new window takes focus
-                call  wm_entry                    ; HL = WM_TABLE[NWIN]
-                ld    a,(bank_cur)               ; entry.page = the caller's page
+; ---- cooperative window manager (issue #45, phase 2) --------------------------
+; The kernel owns the master loop (wm_loop) and a table of co-resident windows.
+; The root window (desktop) enters the loop via GB_WMRUN; further windows are
+; opened non-blocking with GB_WMOPEN (load app -> its main calls GB_WMADD and
+; returns). The loop polls, then on a fresh click hit-tests the windows top-down
+; (z-order) and raises+focuses the one clicked, then calls the focused window's
+; on_frame. A window closes itself with GB_WMCLOSE.
+;
+; A descriptor is { u8 x,y,w,h; on_frame(2); on_repaint(2); on_event(2) }.
+
+; wm_register: HL = descriptor in the caller's page. Allocate a table slot, store
+; page = caller, copy the descriptor, mark alive, push onto z-order top and focus.
+wm_register
+                ld    (wm_desc),hl
+                call  wm_free_slot               ; A = first dead slot
+                ld    (wm_slot),a
+                call  wm_entry                    ; HL = WM_TABLE[slot]
+                ld    a,(bank_cur)               ; +0 page = caller
                 ld    (hl),a
                 inc   hl
-                ex    de,hl                       ; DE = entry+1 (x..on_repaint)
-                pop   hl                          ; HL = descriptor
-                ld    bc,8
-                ldir                              ; copy x,y,w,h,on_frame,on_repaint
+                ex    de,hl                       ; DE = entry+1
+                ld    hl,(wm_desc)
+                ld    bc,10                       ; x,y,w,h,on_frame,on_repaint,on_event
+                ldir
+                ld    a,1                          ; entry+11 flags = alive
+                ld    (de),a
+                ld    a,(wm_slot)                 ; focus the new window
+                ld    (WM_FOCUS),a
+                ld    hl,WM_Z                      ; WM_Z[NWIN] = slot (new z-top)
                 ld    a,(WM_NWIN)
-                inc   a
-                ld    (WM_NWIN),a
+                add   a,l
+                ld    l,a
+                ld    a,(wm_slot)
+                ld    (hl),a
+                ld    hl,WM_NWIN
+                inc   (hl)
+                ret
+
+; wm_free_slot: -> A = lowest table slot whose alive flag is clear.
+wm_free_slot
+                ld    hl,WM_TABLE+WM_FR_FLAGS
+                ld    de,WM_ESZ
+                ld    c,0
+wfs_l           ld    a,(hl)
+                and   1
+                jr    z,wfs_found
+                add   hl,de
+                inc   c
+                ld    a,c
+                cp    WM_MAXWIN
+                jr    c,wfs_l
+                ld    c,WM_MAXWIN-1               ; full (shouldn't happen) -> reuse last
+wfs_found       ld    a,c
+                ret
+
+; k_wm_run (GB_WMRUN): register the caller (the root/desktop window) and enter the
+; master loop. Never returns.
+k_wm_run
+                call  wm_register
 wm_loop
-                call  k_poll                      ; pace + cursor + clock + low-RAM result
-                ld    a,(WM_FOCUS)               ; HL = focused entry's on_frame
+                call  wm_map_focus               ; bank focused page; APP_HANDLER = its
+                call  k_poll                      ; on_event, so a top-bar click reaches
+                call  wm_focus_click             ; the right app. then route the click.
+                call  wm_map_focus               ; focus may have changed
+                ld    a,(WM_FOCUS)               ; call the focused window's on_frame
                 call  wm_entry
-                ld    de,5                        ; +5 = on_frame (after page,x,y,w,h)
+                ld    de,WM_FR_FRAME
                 add   hl,de
                 ld    a,(hl)
                 inc   hl
                 ld    h,(hl)
                 ld    l,a
-                call  md_call                     ; on_frame() in the focused page
+                call  md_call
                 jr    wm_loop
 
-; wm_entry: A = window index -> HL = WM_TABLE + A*WM_ESZ. Clobbers A,B,DE.
+; k_wm_add (GB_WMADD): register the caller's window (used by an app opened with
+; GB_WMOPEN); returns to the opener. The kernel's wm_loop then services it.
+k_wm_add
+                jp    wm_register
+
+; k_wm_open (GB_WMOPEN): HL = 8.3 app name in the caller page. Load it into a free
+; bank page and CALL its entry once (its main registers a window via GB_WMADD and
+; returns), then restore the caller's page. Non-blocking: the app becomes a live
+; window the master loop services, rather than running its own loop.
+k_wm_open
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                call  wm_alloc_page
+                or    a
+                ret   z                            ; no free page
+                ld    (wm_open_page),a
+                ld    a,(bank_cur)
+                ld    (wm_open_back),a
+                di
+                ld    a,(wm_open_page)
+                call  bank_set
+                ld    hl,#3F00
+                ld    (fs_load_max),hl
+                ld    hl,APP_BASE
+                ld    (fs_load_dst),hl
+                call  fs_load_file
+                jr    nc,wmo_fail
+                ei
+                call  APP_BASE                    ; main -> GB_WMADD + paint, then ret
+                di
+                ld    a,(wm_open_back)
+                call  bank_set
+                ei
+                ret
+wmo_fail
+                ld    a,(wm_open_back)
+                call  bank_set
+                ld    a,(wm_open_page)
+                call  wm_free_page
+                ei
+                ret
+
+; k_wm_close (GB_WMCLOSE): close the focused (calling) window - free its page, drop
+; it from the table and z-order, refocus the new z-top, and repaint. The caller's
+; on_frame must return immediately after. Mapping is unchanged on return so the
+; closing on_frame can still execute (its page content survives until reused).
+k_wm_close
+                ld    a,(WM_FOCUS)
+                ld    c,a                          ; C = slot being closed
+                call  wm_entry                    ; HL = entry
+                push  hl
+                ld    a,(hl)                       ; page
+                call  wm_free_page
+                pop   hl
+                ld    de,WM_FR_FLAGS
+                add   hl,de
+                ld    (hl),0                       ; mark dead
+                ld    hl,WM_Z                      ; compact WM_Z, dropping slot C
+                ld    de,WM_Z
+                ld    a,(WM_NWIN)
+                ld    b,a
+wmc_l           ld    a,(hl)
+                cp    c
+                jr    z,wmc_skip
+                ld    (de),a
+                inc   de
+wmc_skip        inc   hl
+                djnz  wmc_l
+                ld    hl,WM_NWIN
+                dec   (hl)
+                ld    a,(WM_NWIN)                  ; new focus = z-top = WM_Z[NWIN-1]
+                dec   a
+                ld    hl,WM_Z
+                add   a,l
+                ld    l,a
+                ld    a,(hl)
+                ld    (WM_FOCUS),a
+                jp    wm_repaint_all               ; repaint remaining windows + return
+
+; wm_map_focus: bank to the focused window's page and point APP_HANDLER at its
+; on_event (so menu_dispatch in k_poll delivers top-bar clicks to the focused app).
+wm_map_focus
+                ld    a,(WM_FOCUS)
+                call  wm_entry                    ; HL = entry
+                ld    a,(hl)                       ; page (+0)
+                call  bank_set                     ; preserves HL
+                ld    de,WM_FR_EVENT
+                add   hl,de
+                ld    a,(hl)
+                inc   hl
+                ld    h,(hl)
+                ld    l,a
+                ld    (APP_HANDLER),hl
+                ret
+
+; wm_focus_click: if a fresh click landed on a window other than the focused one,
+; move focus there. App windows also rise to the z-top (and the stack repaints) if
+; not already on top; the desktop (slot 0) stays pinned at the bottom. The click is
+; not consumed - it is then delivered to the newly focused window's on_frame.
+wm_focus_click
+                ld    a,(POLL_FLAGS)
+                bit   0,a
+                ret   z                            ; no fresh click
+                call  wm_hit_test                  ; CF set = no window hit (e.g. top bar)
+                ret   c
+                ld    b,a
+                ld    a,(WM_FOCUS)
+                cp    b
+                ret   z                            ; already focused -> deliver
+                ld    a,b
+                ld    (WM_FOCUS),a               ; focus the clicked window
+                or    a
+                ret   z                            ; desktop: keep it at the bottom
+                ld    c,a                          ; c = clicked app slot
+                ld    a,(WM_NWIN)               ; already the z-top? then nothing to raise
+                dec   a
+                ld    hl,WM_Z
+                add   a,l
+                ld    l,a
+                ld    a,(hl)
+                cp    c
+                ret   z
+                ld    a,c
+                call  wm_raise                     ; bring it to the front
+                jp    wm_repaint_all               ; restack the screen
+
+; wm_hit_test: -> A = slot of the top-most window whose rect contains the pointer
+; (POLL_MX, POLL_MY), scanning z-order top->bottom; CF set if none.
+wm_hit_test
+                ld    a,(WM_NWIN)
+                ld    (wm_hz),a
+wht_l           ld    a,(wm_hz)
+                or    a
+                jr    z,wht_none
+                dec   a
+                ld    (wm_hz),a
+                ld    hl,WM_Z
+                add   a,l
+                ld    l,a
+                ld    a,(hl)                       ; slot = WM_Z[i]
+                call  wm_entry                     ; HL = entry
+                inc   hl                            ; +1 x
+                ld    a,(POLL_MX)
+                sub   (hl)
+                jr    c,wht_l                       ; mx < x
+                ld    c,a                            ; mx - x
+                inc   hl                            ; +2 y
+                inc   hl                            ; +3 w
+                ld    a,c
+                cp    (hl)
+                jr    nc,wht_l                      ; mx-x >= w
+                dec   hl                            ; +2 y
+                ld    a,(POLL_MY)
+                sub   (hl)
+                jr    c,wht_l                       ; my < y
+                ld    c,a                            ; my - y
+                inc   hl                            ; +3 w
+                inc   hl                            ; +4 h
+                ld    a,c
+                cp    (hl)
+                jr    nc,wht_l                      ; my-y >= h
+                ld    a,(wm_hz)                     ; hit -> recover slot
+                ld    hl,WM_Z
+                add   a,l
+                ld    l,a
+                ld    a,(hl)
+                or    a                             ; clear CF
+                ret
+wht_none        scf
+                ret
+
+; wm_raise: A = slot -> move it to z-order top and focus it (keeps the others'
+; relative order). Compacts WM_Z removing the slot, then re-appends it at the end.
+wm_raise
+                ld    (WM_FOCUS),a
+                ld    c,a
+                ld    hl,WM_Z
+                ld    de,WM_Z
+                ld    a,(WM_NWIN)
+                ld    b,a
+wr_l            ld    a,(hl)
+                cp    c
+                jr    z,wr_skip
+                ld    (de),a
+                inc   de
+wr_skip         inc   hl
+                djnz  wr_l
+                ld    a,c
+                ld    (de),a                       ; slot back on top
+                ret
+
+; wm_repaint_all: repaint every window bottom-up (each in its own page, via its
+; on_repaint), then restore the caller's page. The cursor is left to the handlers:
+; each on_repaint redraws over the old pointer (a full backdrop fill, or a leading
+; gb_curhide) and ends with gb_curshow, so the cursor stays correct with no double
+; save-under here. WM_Z[0] is always the desktop, so its full paint runs first.
+wm_repaint_all
+                ld    a,(bank_cur)
+                ld    (wm_rp_back),a
+                di
+                xor   a
+                ld    (wm_rp_i),a
+wra_l           ld    a,(wm_rp_i)
+                ld    hl,WM_NWIN
+                cp    (hl)
+                jr    nc,wra_done
+                ld    hl,WM_Z
+                add   a,l
+                ld    l,a
+                ld    a,(hl)                       ; slot = WM_Z[i]
+                call  wm_entry                     ; HL = entry
+                ld    a,(hl)                       ; page
+                call  bank_set
+                ld    de,WM_FR_REPAINT
+                add   hl,de
+                ld    a,(hl)
+                inc   hl
+                ld    h,(hl)
+                ld    l,a
+                ld    a,h
+                or    l
+                jr    z,wra_next                   ; no handler
+                call  md_call
+wra_next        ld    a,(wm_rp_i)
+                inc   a
+                ld    (wm_rp_i),a
+                jr    wra_l
+wra_done        ld    a,(wm_rp_back)
+                call  bank_set
+                ei
+                ret
+
+; wm_entry: A = slot index -> HL = WM_TABLE + A*WM_ESZ. Clobbers A,B,DE.
 wm_entry
                 ld    hl,WM_TABLE
                 or    a
@@ -1098,6 +1399,14 @@ we_add
                 add   hl,de
                 djnz  we_add
                 ret
+
+wm_desc         dw    0            ; wm_register: descriptor ptr
+wm_slot         db    0            ; wm_register: chosen slot
+wm_open_page    db    0            ; k_wm_open: page being loaded
+wm_open_back    db    0            ; k_wm_open: caller's page to restore
+wm_hz           db    0            ; wm_hit_test: z scan index
+wm_rp_back      db    0            ; wm_repaint_all: caller's page
+wm_rp_i         db    0            ; wm_repaint_all: z index
 
 ; menu_dispatch: called from k_poll. If a fresh click (D bit0) landed in the
 ; kernel-owned top bar and the app registered a handler, deliver a GB_MSG_MENU

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -91,6 +91,7 @@ WM_FR_FLAGS     equ   11
                 jp    k_wm_add               ; GB_WMADD       #805D
                 jp    k_wm_open              ; GB_WMOPEN      #8060
                 jp    k_wm_close             ; GB_WMCLOSE     #8063
+                jp    k_wm_setpos            ; GB_WMSETPOS    #8066
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -1234,6 +1235,25 @@ wmc_skip        inc   hl
                 ld    a,(hl)
                 ld    (WM_FOCUS),a
                 jp    wm_repaint_all               ; repaint remaining windows + return
+
+; k_wm_setpos (GB_WMSETPOS): A = x, L = y -> move the focused window's hit rect to
+; (x,y), so click-to-focus follows a window the app has dragged. The caller updates
+; its own draw position and repaints (gb_restore_parent) separately.
+k_wm_setpos
+                ld    (sp_x),a
+                ld    a,l
+                ld    (sp_y),a
+                ld    a,(WM_FOCUS)
+                call  wm_entry                    ; HL = entry
+                inc   hl                            ; +1 x
+                ld    a,(sp_x)
+                ld    (hl),a
+                inc   hl                            ; +2 y
+                ld    a,(sp_y)
+                ld    (hl),a
+                ret
+sp_x            db    0
+sp_y            db    0
 
 ; wm_map_focus: bank to the focused window's page and point APP_HANDLER at its
 ; on_event (so menu_dispatch in k_poll delivers top-bar clicks to the focused app).

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -107,4 +107,5 @@ void gb_wm_run(const gb_win_t *desc);
 void gb_wm_add(const gb_win_t *desc);
 void gb_wm_open(const char *name);
 void gb_wm_close(void);
+void gb_wm_setpos(unsigned char x, unsigned char y);  /* move our hit rect (drag) */
 #endif /* GB_H */

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -85,16 +85,26 @@ void gb_on_repaint(void (*handler)(void));   /* register full-repaint handler */
 void gb_restore_parent(void);                /* repaint ancestor apps behind us */
 
 /* Cooperative window manager (issue #45). Instead of owning a for(;;) loop, an
- * app fills a gb_win_t and calls gb_wm_run once from main(): the KERNEL runs the
- * master loop and calls the window's on_frame every frame (read input with
- * gb_flags/gb_mx/gb_my - do NOT call gb_poll inside it). on_repaint redraws the
- * whole window with no input. The rect (x,y,w,h) is the window's screen area, for
- * click-to-focus hit-testing once multiple windows coexist. gb_wm_run does not
- * return (Phase 1: the desktop is the single, permanent window). */
+ * app fills a gb_win_t and registers a window: the KERNEL runs the master loop,
+ * calls the focused window's on_frame every frame (read input with gb_flags/
+ * gb_mx/gb_my - do NOT call gb_poll inside it), and on a click hit-tests the
+ * rects to switch focus. on_repaint redraws the whole window with no input;
+ * on_event handles a top-bar click (0 = none). The rect (x,y,w,h) is the
+ * window's screen area used for click-to-focus.
+ *
+ *   gb_wm_run   - the ROOT window (desktop): register + enter the loop (no return).
+ *   gb_wm_open  - open an app as a new co-resident window on top (non-blocking).
+ *   gb_wm_add   - register the calling window (an app's main() does this when it
+ *                 was started by gb_wm_open), then return to the opener.
+ *   gb_wm_close - close the calling window; return from on_frame right after. */
 typedef struct {
-    unsigned char x, y, w, h;       /* window rect (byte col, line, size) */
-    void (*on_frame)(void);         /* called each frame when focused      */
-    void (*on_repaint)(void);       /* redraw the whole window, no input   */
+    unsigned char x, y, w, h;       /* window rect (byte col, line, size)  */
+    void (*on_frame)(void);         /* called each frame when focused       */
+    void (*on_repaint)(void);       /* redraw the whole window, no input    */
+    void (*on_event)(void);         /* top-bar click handler, or 0          */
 } gb_win_t;
 void gb_wm_run(const gb_win_t *desc);
+void gb_wm_add(const gb_win_t *desc);
+void gb_wm_open(const char *name);
+void gb_wm_close(void);
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -38,6 +38,7 @@
         .globl  _gb_wm_add
         .globl  _gb_wm_open
         .globl  _gb_wm_close
+        .globl  _gb_wm_setpos
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -234,3 +235,7 @@ _gb_wm_open:
 ;; void gb_wm_close(void);   close the calling window (return from on_frame after).
 _gb_wm_close:
         jp      0x8063          ; GB_WMCLOSE
+;; void gb_wm_setpos(u8 x, u8 y);   A=x, L=y -> move the focused window's hit rect
+;; (call after dragging so click-to-focus follows the window).
+_gb_wm_setpos:
+        jp      0x8066          ; GB_WMSETPOS

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -35,6 +35,9 @@
         .globl  _gb_restore_parent
         .globl  _gb_flags
         .globl  _gb_wm_run
+        .globl  _gb_wm_add
+        .globl  _gb_wm_open
+        .globl  _gb_wm_close
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -216,7 +219,18 @@ _gb_on_repaint:
 _gb_restore_parent:
         jp      0x8057          ; GB_RESTPAR
 
-;; void gb_wm_run(const gb_win_t *desc);   desc in HL -> kernel registers the
-;; window and enters the master loop (issue #45). Does not return (Phase 1).
+;; void gb_wm_run(const gb_win_t *desc);   desc in HL -> register the root window
+;; and enter the kernel master loop (issue #45). Does not return.
 _gb_wm_run:
         jp      0x805A          ; GB_WMRUN
+;; void gb_wm_add(const gb_win_t *desc);   desc in HL -> register a co-resident
+;; window (called from an app opened with gb_wm_open); returns to the opener.
+_gb_wm_add:
+        jp      0x805D          ; GB_WMADD
+;; void gb_wm_open(const char *name);   8.3 name in HL -> open an app as a new
+;; co-resident window (non-blocking); returns once it has registered.
+_gb_wm_open:
+        jp      0x8060          ; GB_WMOPEN
+;; void gb_wm_close(void);   close the calling window (return from on_frame after).
+_gb_wm_close:
+        jp      0x8063          ; GB_WMCLOSE

--- a/tools/build_ide_img.sh
+++ b/tools/build_ide_img.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Build a *partitioned* FAT16 IDE/Symbiface disk image carrying GEOBENCH, for
+# booting under UniDOS+FatFS (run"GBKERN). Layout:
+#
+#   LBA 0            MBR (one primary partition, type 0x06 = FAT16)
+#   LBA PSTART..end  FAT16 volume (the partition)
+#
+# FatFS (ChaN, on the Symbiface FATFS ROMs) scans the MBR partition table and
+# mounts the first FAT partition; a bare superfloppy image (FAT BPB at LBA 0)
+# is reported as "Device ???" and rejected, so the MBR is required.
+#
+# Everything stays inside the first 32 MB so the kernel's 16-bit LBA reader can
+# reach every sector (PSTART + volume sectors < 65536).
+#
+# GBKERN.BIN gets a 128-byte AMSDOS header so UniDOS can RUN it; every file
+# GBKERN loads itself (fside_load_file) is copied RAW (the IDE backend does NOT
+# strip a header, unlike the floppy backend).
+#
+# Usage: tools/build_ide_img.sh [out.img]
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+OUT="${1:-build/GEOBENCH.IMG}"
+HDR="tools/amsdos_header.py"
+
+TOTAL_SECTORS=65536          # 32 MB total (keeps every LBA < 65536, 16-bit)
+PSTART=64                    # partition starts at LBA 64 (32 KB in)
+PSECTORS=$(( TOTAL_SECTORS - PSTART ))
+POFF=$(( PSTART * 512 ))     # partition byte offset for mtools @@
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+# 1) Blank image of the full size.
+rm -f "$OUT"
+truncate -s $(( TOTAL_SECTORS * 512 )) "$OUT"
+
+# 2) Hand-built MBR: one FAT16 partition. Boot code left zero (first byte 0x00,
+#    so the kernel can tell an MBR from a FAT boot sector, which starts 0xEB).
+python3 - "$OUT" "$PSTART" "$PSECTORS" <<'PY'
+import sys, struct
+path, pstart, psecs = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+mbr = bytearray(512)
+ent = bytearray(16)
+ent[0]  = 0x00                                   # not bootable
+ent[1:4] = bytes((0xFE, 0xFF, 0xFF))             # start CHS (ignored, LBA used)
+ent[4]  = 0x06                                   # type: FAT16
+ent[5:8] = bytes((0xFE, 0xFF, 0xFF))             # end CHS (ignored)
+ent[8:12]  = struct.pack("<I", pstart)           # start LBA
+ent[12:16] = struct.pack("<I", psecs)            # sector count
+mbr[446:462] = ent
+mbr[510], mbr[511] = 0x55, 0xAA
+with open(path, "r+b") as f:
+    f.write(mbr)
+PY
+
+# 3) Format the partition region as FAT16 (mformat picks FAT16 for ~32 MB).
+MIMG="${OUT}@@${POFF}"
+mformat -i "$MIMG" -T "$PSECTORS" -h 0 -s 0 -v GEOBENCH ::
+
+# 4) Stage files: GBKERN headered, everything else raw.
+python3 "$HDR" build/GBKERN.RAW "$STAGE/GBKERN.BIN" GBKERN BIN 0x8000
+cp build/DESKTOP.RAW "$STAGE/DESKTOP.BIN"
+cp build/FILEMGR.RAW "$STAGE/FILEMGR.BIN"
+cp build/VIEWER.RAW  "$STAGE/VIEWER.BIN"
+cp build/NOTEPAD.RAW "$STAGE/NOTEPAD.BIN"
+cp build/CHELLO.RAW  "$STAGE/CHELLO.BIN"
+cp build/GBCFG.RAW   "$STAGE/GBCFG.BIN"
+cp build/GBFAT.RAW   "$STAGE/GBFAT.BIN"
+cp build/DEFAULT.FNT "$STAGE/DEFAULT.FNT"
+cp build/DEFAULT.IST "$STAGE/DEFAULT.IST"
+cp assets/WELCOME.TXT "$STAGE/WELCOME.TXT"
+
+for f in "$STAGE"/*; do
+    mcopy -i "$MIMG" -o "$f" "::/$(basename "$f")"
+done
+
+echo "Built $OUT  (MBR + FAT16 partition @ LBA $PSTART)"
+mdir -i "$MIMG" ::/


### PR DESCRIPTION
## Phase 2 of the cooperative window manager (#45)

Co-resident windows with **click-to-focus**. File Manager is no longer modal — it opens beside the desktop, and clicking a window focuses it. Dragging works for both desktop icons and the File Manager window.

### What changed
**Kernel (`gbkern.asm`)**
- **Page allocator** (`wm_alloc_page`/`wm_free_page` over a `PAGE_APP0..+2` bitmap); `launch_app` now allocates/frees a page instead of `PAGE_APP0+launch_depth`, so modal apps never collide with co-resident window pages.
- **Window table** grows: per window page, rect, `on_frame`, `on_repaint`, `on_event`, alive flag; plus a **z-order** array. All in low RAM (0 resident image bytes).
- **Master loop** banks to the focused window before `k_poll` (so a top-bar click reaches the focused app's `on_event`) and before `on_frame`; on a click it **hit-tests windows top-down** and raises+focuses the one clicked. The desktop is pinned to the bottom as the full-screen catch-all.
- **Lifecycle**: `GB_WMADD` (register + return), `GB_WMOPEN` (load app into a free page, non-blocking), `GB_WMCLOSE` (close caller: free page, drop from table/z-order, refocus, repaint), `GB_WMSETPOS` (move a window's hit rect after a drag).
- `GB_RESTPAR` now repaints all live WM windows (`wm_repaint_all`) — a modal app (e.g. Notepad) dragging its window restores the desktop + File Manager beneath it; `launch_app` repaints the windows when a modal app returns.

**libgb**: `gb_wm_add/open/close/setpos`, `on_event` in `gb_win_t`.

**desktop**: registers `on_event` via the descriptor; double-click Disk opens File Manager co-resident (`gb_wm_open`).

**filemgr**: ported to a co-resident window (`gb_wm_add`; `on_frame`/`on_repaint=draw_list`; close gadget/ESC → `gb_wm_close`); title-bar drag updates its hit rect via `gb_wm_setpos` and repaints the stack.

### Verified
- Headless: identical desktop boot.
- Interactive: desktop ↔ File Manager click-to-focus, window + icon dragging.

### Known / next
Apps launched from File Manager (Notepad, etc.) are **still modal** — you close them (Ctrl-Q/ESC) to return. Making them focusable co-resident windows is **Phase 3** (port Notepad + a non-blocking `gb_wm_launch`).
