### PR TITLE
Cooperative window manager: co-resident apps + focus-following menu (#45 phase 3)

### DIFF
--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -163,14 +163,14 @@ static void on_frame(void)
 }
 
 /* the desktop is the root window: full screen below the top bar, on_repaint = the
-   full paint() (restacked behind any window), on_event = the top-bar click demo.
-   Its rect spans the screen so it is the bottom catch-all for click-to-focus. */
-static const gb_win_t deskwin = { 0, 8, 80, 192, on_frame, paint, on_event };
+   full paint() (restacked behind any window), on_event = the top-bar click demo,
+   menu = the "Disk" title. Its rect spans the screen so it is the bottom catch-all
+   for click-to-focus; the kernel installs its menu when it has focus. */
+static const gb_win_t deskwin = { 0, 8, 80, 192, on_frame, paint, on_event, dt_menu };
 
 void main(void)
 {
     paint();
-    gb_menu(dt_menu);                          /* draw the desktop menu title */
     drag_active = 0;
     dc_timer = 0;
     held_prev = 0;

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -71,16 +71,17 @@ static void draw_list(void)
     gb_curshow();
 }
 
-/* launch: open the file at absolute index idx. The launched app runs MODALLY (it
-   owns the screen until it quits); the kernel repaints all WM windows - including
-   our draw_list - when it returns, so we just clear the selection beforehand. */
+/* launch: open the file at absolute index idx as a co-resident window (#45) - it
+   opens on top and takes focus; we stay live underneath. Click between windows to
+   switch focus. (gb_wm_launch picks the app by type and passes the file as the arg,
+   the non-blocking gb_launch.) */
 static void launch(unsigned char idx)
 {
     unsigned char i;
     char *p = gb_dir1();
     for (i = 0; i < idx && p; i++) p = gb_dirn();
     nsel = 0;
-    gb_launch();
+    gb_wm_launch();
 }
 
 /* on_frame: one frame when this window is focused (kernel WM loop, issue #45).
@@ -144,7 +145,7 @@ static void on_frame(void)
 /* a co-resident window: click it to focus, drag the title bar to move it (the hit
    rect follows via gb_wm_setpos), the close gadget or ESC to close. on_repaint =
    draw_list, which the kernel calls to restack us. */
-static const gb_win_t fmwin = { DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, draw_list, 0 };
+static const gb_win_t fmwin = { DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, draw_list, 0, 0 };
 
 void main(void)
 {

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -9,10 +9,13 @@
  *   File > Load     pick a file from a list and open it
  *   File > Save     write the buffer (creates / grows the file via the new
  *                   AMSDOS write layer)
- *   Ctrl-Q          quit back to the file manager
+ *   Ctrl-Q          close the window (back to the file manager)
  *
- * Input is GB_POLL (pointer + click + the menu callback) plus GB_GETKEY for
- * typing. The view scrolls to keep the caret visible. */
+ * Issue #45: a co-resident window. main() loads the file, registers via gb_wm_add
+ * and returns; the kernel WM loop calls on_frame (read input with gb_flags/mx/my)
+ * and np_repaint to restack us. The modal popups (menu, Load, confirm) still poll
+ * themselves. Click our window to focus it; the view scrolls to keep the caret
+ * visible. */
 #include "gb.h"
 
 #define NP_MAX    1024
@@ -332,89 +335,110 @@ static unsigned char try_close(void)
     return (unsigned char)(status == 1);
 }
 
+/* np_repaint: kernel on_repaint - redraw the whole window (no input) when the WM
+   restacks us behind/above another window. */
+static void np_repaint(void)
+{
+    gb_curhide();
+    render(0xFF);
+    gb_curshow();
+}
+
+/* on_frame: one frame when Notepad is focused (kernel WM loop, issue #45). Reads
+   input with gb_flags/mx/my; the modal popups (run_menu/confirm) still poll
+   themselves. Each old loop 'continue' is a 'return'; quitting is gb_wm_close. */
+static void on_frame(void)
+{
+    unsigned char flags = gb_flags(), c, n, edited;
+
+    if (flags & GB_QUIT) { gb_wm_close(); return; }   /* ESC closes the window */
+
+    if (want_menu) {                            /* File title was clicked */
+        want_menu = 0;
+        run_menu();
+        draw();
+        gb_curshow();
+        return;
+    }
+
+    if (flags & GB_FIRE) keycool = 4;           /* fire held -> flush its 'Z'/'X' */
+    if (flags & GB_CLICK) {
+        unsigned char my = gb_my(), mx = gb_mx();
+        keycool = 4;
+        if (my >= win_y && my < win_y + TITLE_H &&  /* close gadget (title-bar left) */
+            mx >= win_x && mx < win_x + 5) {
+            if (try_close()) { gb_wm_close(); return; }  /* close the window */
+            draw(); gb_curshow();                /* cancelled -> repaint */
+            return;
+        }
+        if (my >= win_y && my < win_y + TITLE_H &&  /* title bar -> drag the window */
+            mx >= win_x + 5 && mx < win_x + WIN_W) {
+            if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
+                gb_wm_setpos(win_x, win_y);      /* move our hit rect to follow */
+                gb_restore_parent();             /* repaint the stack (incl. our window) */
+            }
+            return;
+        }
+        if (my >= TX_Y0 && my < TX_Y0 + MAX_LINES * LINE_H && mx >= TX_COL) {
+            unsigned int nc = idx_of(view_first + (my - TX_Y0) / LINE_H,
+                                     ((mx - TX_COL) * 2) / 3);
+            if (nc != cur) {                     /* redraw only if the caret moved */
+                cur = nc;
+                gb_curhide(); draw(); gb_curshow();
+            }
+        }
+        return;
+    }
+
+    if (keycool) {                               /* after a click/fire: drop the */
+        keycool--;                                /* buffered fire/direction chars */
+        while (gb_getkey()) ;
+        return;
+    }
+
+    edited = 0;                                  /* drain typed keys */
+    n = 8;
+    while (n--) {
+        c = gb_getkey();
+        if (!c) break;
+        if (c == K_QUIT) { gb_wm_close(); return; }
+        if (c == K_BS || c == K_DEL) { del_back(); edited = 1; }
+        else if (c == K_ENTER) { ins('\n'); edited = 1; }
+        else if (c >= 32 && c < 127) { ins((char)c); edited = 1; }
+        /* other keys (arrows etc.) are ignored - no redraw */
+    }
+    if (edited) {
+        unsigned char t = count_lines(), oldvf = view_first, cr, cc;
+        gb_curhide();
+        scroll_to_caret();
+        pos_of(cur, &cr, &cc);
+        if (t != prev_total || view_first != oldvf) {
+            render(0xFF);                        /* line count or scroll changed */
+            prev_total = t;
+        } else {
+            render(cr - view_first);             /* just the caret's line */
+        }
+        gb_curshow();
+    }
+}
+
+/* a co-resident window (issue #45): on_repaint redraws it, on_event = the top-bar
+   File click, menu = the File title the kernel shows while we are focused. */
+static const gb_win_t npwin = {
+    DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, np_repaint, on_menu, file_menu
+};
+
 void main(void)
 {
-    unsigned char flags, c, n, edited;
+    unsigned char n;
 
-    len = gb_fs_load(buf, NP_MAX);
+    win_x = DEF_X; win_y = DEF_Y;
+    len = gb_fs_load(buf, NP_MAX);              /* the file we were launched with */
     cur = len; view_first = 0; dirty = 0; status = 0;
     want_menu = 0; modal = 0;
     for (n = 64; n; n--) if (!gb_getkey()) break;   /* drop buffered keys */
 
-    gb_on_event(on_menu);
-    gb_menu(file_menu);
     draw();
     gb_curshow();
-
-    for (;;) {
-        flags = gb_poll();
-        if (flags & GB_QUIT) return;                /* ESC quits */
-
-        if (want_menu) {                            /* File title was clicked */
-            want_menu = 0;
-            run_menu();
-            draw();
-            gb_curshow();
-            continue;
-        }
-
-        if (flags & GB_FIRE) keycool = 4;           /* fire held -> flush its 'Z'/'X' */
-        if (flags & GB_CLICK) {
-            unsigned char my = gb_my(), mx = gb_mx();
-            keycool = 4;
-            if (my >= win_y && my < win_y + TITLE_H &&  /* close gadget (title-bar left) */
-                mx >= win_x && mx < win_x + 5) {
-                if (try_close()) return;             /* quit back to the file manager */
-                draw(); gb_curshow();                /* cancelled -> repaint */
-                continue;
-            }
-            if (my >= win_y && my < win_y + TITLE_H &&  /* title bar -> drag the window */
-                mx >= win_x + 5 && mx < win_x + WIN_W) {
-                if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
-                    gb_restore_parent();             /* repaint what was behind us */
-                    gb_curhide(); draw(); gb_curshow();  /* our window on top */
-                }
-                continue;
-            }
-            if (my >= TX_Y0 && my < TX_Y0 + MAX_LINES * LINE_H && mx >= TX_COL) {
-                unsigned int nc = idx_of(view_first + (my - TX_Y0) / LINE_H,
-                                         ((mx - TX_COL) * 2) / 3);
-                if (nc != cur) {                     /* redraw only if the caret moved */
-                    cur = nc;
-                    gb_curhide(); draw(); gb_curshow();
-                }
-            }
-        }
-
-        if (keycool) {                               /* after a click/fire: drop the */
-            keycool--;                                /* buffered fire/direction chars */
-            while (gb_getkey()) ;
-            continue;
-        }
-
-        edited = 0;                                  /* drain typed keys */
-        n = 8;
-        while (n--) {
-            c = gb_getkey();
-            if (!c) break;
-            if (c == K_QUIT) return;
-            if (c == K_BS || c == K_DEL) { del_back(); edited = 1; }
-            else if (c == K_ENTER) { ins('\n'); edited = 1; }
-            else if (c >= 32 && c < 127) { ins((char)c); edited = 1; }
-            /* other keys (arrows etc.) are ignored - no redraw */
-        }
-        if (edited) {
-            unsigned char t = count_lines(), oldvf = view_first, cr, cc;
-            gb_curhide();
-            scroll_to_caret();
-            pos_of(cur, &cr, &cc);
-            if (t != prev_total || view_first != oldvf) {
-                render(0xFF);                        /* line count or scroll changed */
-                prev_total = t;
-            } else {
-                render(cr - view_first);             /* just the caret's line */
-            }
-            gb_curshow();
-        }
-    }
+    gb_wm_add(&npwin);                           /* register; the kernel WM drives us */
 }

--- a/apps/viewer/main.c
+++ b/apps/viewer/main.c
@@ -1,10 +1,9 @@
 /* viewer - GEOBENCH text-file viewer, the first C app that does real work.
  *
- * Launched by the file manager when a file is double-clicked (and the type->app
- * table routes .TXT here). Runs co-resident in its own bank page, asks the
- * kernel to load the opened file into a bank buffer (gb_fs_load), and renders
- * the text in a window - word-wrapped, the first screenful. A click or ESC
- * closes it, back to the file manager.
+ * Launched by the file manager for any non-.TXT file (the type->app default).
+ * Issue #45: a co-resident window - main() loads the file, renders it, registers
+ * with gb_wm_add and returns; the kernel WM loop drives on_frame / on_repaint.
+ * The close gadget (title-bar left) or ESC closes it; other clicks just focus it.
  *
  * Binary files load fine too; they just show as gibberish (control bytes are
  * skipped), so this doubles as a quick "peek" at anything on the disk. */
@@ -17,8 +16,15 @@
 #define MAX_LINES 14     /* visible lines (no scrolling yet)                  */
 #define WRAP      44     /* characters per line before a forced wrap          */
 
+#define WIN_X     2
+#define WIN_Y     14
+#define WIN_W     76
+#define WIN_H     180
+#define TITLE_H   14
+
 static char filebuf[VIEW_MAX];
 static char line[WRAP + 1];
+static unsigned int filen;       /* bytes loaded (for repaint) */
 
 /* render: lay out n bytes of filebuf as wrapped text lines in the window. */
 static void render(unsigned int n)
@@ -49,19 +55,42 @@ static void render(unsigned int n)
     }
 }
 
-void main(void)
+/* paint the whole window (title + text). */
+static void v_draw(void)
 {
-    unsigned int n;
-
-    gb_window(2, 14, 76, 180, "VIEWER");
-    n = gb_fs_load(filebuf, VIEW_MAX);
-    if (n == 0)
+    gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, "VIEWER");
+    if (filen == 0)
         gb_text(TX_COL, TX_Y0, "(file is empty or could not be read)");
     else
-        render(n);
+        render(filen);
+}
 
+/* on_repaint: redraw the window when the WM restacks us. */
+static void v_repaint(void)
+{
+    gb_curhide();
+    v_draw();
     gb_curshow();
-    while (!(gb_poll() & (GB_QUIT | GB_CLICK))) {
-        /* idle until ESC or a click closes the viewer */
-    }
+}
+
+/* on_frame: close on ESC or a click in the close gadget; other clicks just focus. */
+static void on_frame(void)
+{
+    unsigned char flags = gb_flags();
+    if (flags & GB_QUIT) { gb_wm_close(); return; }
+    if (!(flags & GB_CLICK)) return;
+    if (gb_my() >= WIN_Y && gb_my() < WIN_Y + TITLE_H &&
+        gb_mx() >= WIN_X && gb_mx() < WIN_X + 5)
+        gb_wm_close();                     /* close gadget */
+}
+
+static const gb_win_t vwin = { WIN_X, WIN_Y, WIN_W, WIN_H, on_frame, v_repaint, 0, 0 };
+
+void main(void)
+{
+    filen = gb_fs_load(filebuf, VIEW_MAX);
+    gb_curhide();
+    v_draw();
+    gb_curshow();
+    gb_wm_add(&vwin);                       /* register; the kernel WM drives us */
 }

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -45,15 +45,16 @@ WM_PAGES        equ   #134F        ; page-in-use bitmap: bit i = PAGE_APP0+i bus
 WM_NWIN         equ   #1350        ; number of live windows
 WM_FOCUS        equ   #1351        ; slot index of the focused window
 WM_TABLE        equ   #1352        ; WM_MAXWIN * WM_ESZ-byte entries:
-WM_ESZ          equ   12           ;   page,x,y,w,h, on_frame(2),on_repaint(2),
-WM_MAXWIN       equ   4            ;   on_event(2), flags(1: bit0 alive)
-WM_Z            equ   #1382        ; z-order: WM_NWIN slot indices, [0]=bottom
-WM_FR_PAGE      equ   1            ; entry field offsets (after +0 page):
-WM_FR_X         equ   1            ;   page,x,y,w,h, frame,repaint,event, flags
+WM_ESZ          equ   14           ;   page,x,y,w,h, on_frame(2),on_repaint(2),
+WM_MAXWIN       equ   4            ;   on_event(2), menu(2), flags(1: bit0 alive)
+WM_Z            equ   #138A        ; z-order: WM_NWIN slot indices, [0]=bottom
+WM_FPREV        equ   #138E        ; previously focused slot (menu-swap edge detect)
+WM_FR_X         equ   1            ; entry field offsets (after +0 page):
 WM_FR_FRAME     equ   5
 WM_FR_REPAINT   equ   7
 WM_FR_EVENT     equ   9
-WM_FR_FLAGS     equ   11
+WM_FR_MENU      equ   11
+WM_FR_FLAGS     equ   13
 
                 org   GB_KERNEL
 ; --- fixed API jump table (order is the ABI; see lib/gbapp.inc) -----------
@@ -92,6 +93,7 @@ WM_FR_FLAGS     equ   11
                 jp    k_wm_open              ; GB_WMOPEN      #8060
                 jp    k_wm_close             ; GB_WMCLOSE     #8063
                 jp    k_wm_setpos            ; GB_WMSETPOS    #8066
+                jp    k_wm_launch            ; GB_WMLAUNCH    #8069
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -136,6 +138,8 @@ kernel_main
                 ld    bc,WM_Z+WM_MAXWIN-WM_PAGES-1
                 ld    (hl),0
                 ldir
+                ld    a,#FF                   ; no previous focus yet -> first map_focus
+                ld    (WM_FPREV),a           ; installs the desktop's menu
                 ld    hl,name_desktop        ; the desktop is the first app
                 call  launch_app             ; run DESKTOP in PAGE_APP0
                 ld    a,2                     ; desktop quit (ESC) -> back to BASIC
@@ -1103,9 +1107,9 @@ wm_register
                 inc   hl
                 ex    de,hl                       ; DE = entry+1
                 ld    hl,(wm_desc)
-                ld    bc,10                       ; x,y,w,h,on_frame,on_repaint,on_event
+                ld    bc,12                       ; x,y,w,h,on_frame,on_repaint,on_event,menu
                 ldir
-                ld    a,1                          ; entry+11 flags = alive
+                ld    a,1                          ; entry+13 flags = alive
                 ld    (de),a
                 ld    a,(wm_slot)                 ; focus the new window
                 ld    (WM_FOCUS),a
@@ -1169,6 +1173,21 @@ k_wm_open
                 ld    de,fs_req_name
                 ld    bc,11
                 ldir
+                jr    wm_open_go
+
+; k_wm_launch (GB_WMLAUNCH): open the current dir entry's app as a co-resident
+; window (non-blocking), with the file as the launch arg - the gb_launch of the WM
+; world. The file manager uses this so an opened file becomes a focusable window.
+k_wm_launch
+                ld    hl,fs_ent_name              ; the file -> launch arg (for the app)
+                ld    de,launch_arg
+                ld    bc,11
+                ldir
+                call  app_for_ext                 ; HL = the app .BIN for the file type
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+wm_open_go
                 call  wm_alloc_page
                 or    a
                 ret   z                            ; no free page
@@ -1257,11 +1276,14 @@ sp_y            db    0
 
 ; wm_map_focus: bank to the focused window's page and point APP_HANDLER at its
 ; on_event (so menu_dispatch in k_poll delivers top-bar clicks to the focused app).
+; On a focus change, also swap the top-bar menu to the focused window's (or clear
+; it) so the bar shows the right menu and clicks reach the right handler.
 wm_map_focus
                 ld    a,(WM_FOCUS)
                 call  wm_entry                    ; HL = entry
                 ld    a,(hl)                       ; page (+0)
                 call  bank_set                     ; preserves HL
+                push  hl
                 ld    de,WM_FR_EVENT
                 add   hl,de
                 ld    a,(hl)
@@ -1269,7 +1291,25 @@ wm_map_focus
                 ld    h,(hl)
                 ld    l,a
                 ld    (APP_HANDLER),hl
-                ret
+                pop   hl                            ; HL = entry
+                ld    a,(WM_FOCUS)               ; focus changed since last frame?
+                ld    de,WM_FPREV
+                ld    a,(de)
+                ld    b,a
+                ld    a,(WM_FOCUS)
+                cp    b
+                ret   z                            ; no change -> leave the bar as is
+                ld    (de),a                       ; WM_FPREV = focus
+                ld    de,WM_FR_MENU               ; focused window's menu def ptr
+                add   hl,de
+                ld    a,(hl)
+                inc   hl
+                ld    h,(hl)
+                ld    l,a
+                ld    a,h
+                or    l
+                jp    z,menu_clear                 ; no menu -> empty the bar
+                jp    menu_install                 ; install the focused window's menu
 
 ; wm_focus_click: if a fresh click landed on a window other than the focused one,
 ; move focus there. App windows also rise to the z-top (and the stack repaints) if
@@ -1458,6 +1498,7 @@ md_call         jp    (hl)
 ; Copied into resident MENU_DEF so draw_topbar can render it across clock ticks
 ; and app switches; redraws the bar. launch_app clears it for a child app.
 k_menu
+menu_install                                    ; HL = menu def (mapped page) -> MENU_DEF
                 ld    a,(hl)                  ; count
                 cp    5
                 ret   nc                       ; > 4 titles unsupported -> ignore
@@ -1471,6 +1512,12 @@ k_menu
                 ld    b,0
                 ld    de,MENU_DEF
                 ldir
+                jp    draw_topbar
+; menu_clear: empty the top-bar menu and redraw the bar (focus moved to a window
+; with no menu).
+menu_clear
+                xor   a
+                ld    (MENU_DEF),a
                 jp    draw_topbar
 
 ; draw_menu_titles: render the registered menu titles in the top bar. Called from

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -102,10 +102,12 @@ typedef struct {
     void (*on_frame)(void);         /* called each frame when focused       */
     void (*on_repaint)(void);       /* redraw the whole window, no input    */
     void (*on_event)(void);         /* top-bar click handler, or 0          */
+    const void *menu;               /* top-bar menu def (gb_menu fmt), or 0 */
 } gb_win_t;
 void gb_wm_run(const gb_win_t *desc);
 void gb_wm_add(const gb_win_t *desc);
 void gb_wm_open(const char *name);
 void gb_wm_close(void);
 void gb_wm_setpos(unsigned char x, unsigned char y);  /* move our hit rect (drag) */
+void gb_wm_launch(void);              /* open current dir entry co-resident (+ arg) */
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -39,6 +39,7 @@
         .globl  _gb_wm_open
         .globl  _gb_wm_close
         .globl  _gb_wm_setpos
+        .globl  _gb_wm_launch
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -239,3 +240,7 @@ _gb_wm_close:
 ;; (call after dragging so click-to-focus follows the window).
 _gb_wm_setpos:
         jp      0x8066          ; GB_WMSETPOS
+;; void gb_wm_launch(void);   open the current dir entry's app as a co-resident
+;; window with the file as its launch arg (the non-blocking gb_launch).
+_gb_wm_launch:
+        jp      0x8069          ; GB_WMLAUNCH


### PR DESCRIPTION
## Phase 3 of the cooperative window manager (#45)

Apps opened from File Manager are now **focusable co-resident windows** — click between Notepad/Viewer and File Manager (or the desktop) with no modal lock. The top-bar menu follows focus.

### What changed
**Kernel (`gbkern.asm`)**
- **Per-window top-bar menu**: `gb_win_t` gains a menu-def pointer; `wm_map_focus` installs the focused window's menu (or clears the bar) on a focus change. Fixes the Phase 2 leak where the desktop's "Disk" title lingered under other windows.
- **`GB_WMLAUNCH`**: the non-blocking `gb_launch` — picks the app by file type (`app_for_ext`), sets the file as the launch arg, loads it into a free page and registers it as a window. Shares the load path with `GB_WMOPEN`.

**Apps**
- **notepad**: ported to a co-resident window (`on_frame`/`np_repaint`/`on_event=on_menu`, `menu=file_menu`; close gadget/Ctrl-Q/ESC → `gb_wm_close`; title-bar drag → `gb_wm_setpos` + repaint). Modal popups (menu/Load/confirm) still poll themselves.
- **viewer**: ported likewise (close gadget/ESC closes; other clicks just focus) so File Manager opening a non-text file no longer hangs — `gb_wm_launch` requires the target app to register-and-return.
- **filemgr**: opens files with `gb_wm_launch` (co-resident) instead of `gb_launch`.
- **desktop**: "Disk" menu now lives in its descriptor (installed on focus).

### Verified
- Headless: identical desktop boot, menu installed via the WM.
- Interactive: Notepad ↔ File Manager click-to-focus, focus-following menu, drag, close.

### Known limits (follow-ups)
- **Max 3 windows** at once (desktop + 2 app pages).
- **One editor at a time** is safe — the launch arg is shared (could make it per-window later).
