### PR TITLE
Cooperative window manager: rect-clipped repaint, no flicker / correct occlusion (#45 phase 4)

### DIFF
--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -1059,21 +1059,10 @@ k_onevent
                 ld    (APP_HANDLER),hl
                 ret
 
-; k_onrepaint (GB_ONREPAINT): register the calling app's full-repaint handler
-; (void(void) in its page) at its nesting slot, so a child can repaint it as the
-; background when a window moves over it (#43). HL = handler.
+; k_onrepaint (GB_ONREPAINT): now a no-op kept for ABI. Under the window manager
+; an app's repaint handler lives in its gb_win_t (on_repaint); the old per-depth
+; REPAINT_HDLR table is unused. Left as a stub so the jump-table address is fixed.
 k_onrepaint
-                ld    a,(launch_depth)        ; slot = depth-1 (this app's page index)
-                dec   a
-                add   a,a                       ; word index
-                ld    e,a
-                ld    d,0
-                ex    de,hl                     ; HL = offset, DE = handler
-                ld    bc,REPAINT_HDLR
-                add   hl,bc
-                ld    (hl),e
-                inc   hl
-                ld    (hl),d
                 ret
 
 ; k_restore_parent (GB_RESTPAR): repaint everything behind the caller. Under the
@@ -1224,6 +1213,8 @@ wmo_fail
 ; closing on_frame can still execute (its page content survives until reused).
 k_wm_close
                 ld    a,(WM_FOCUS)
+                call  wm_set_clip                 ; damage = the closing window's rect
+                ld    a,(WM_FOCUS)
                 ld    c,a                          ; C = slot being closed
                 call  wm_entry                    ; HL = entry
                 push  hl
@@ -1256,23 +1247,62 @@ wmc_skip        inc   hl
                 jp    wm_repaint_all               ; repaint remaining windows + return
 
 ; k_wm_setpos (GB_WMSETPOS): A = x, L = y -> move the focused window's hit rect to
-; (x,y), so click-to-focus follows a window the app has dragged. The caller updates
-; its own draw position and repaints (gb_restore_parent) separately.
+; (x,y), so click-to-focus follows a window the app has dragged. Also sets the fill
+; clip to the damage = the bounding box of the old and new window rects, so the
+; following gb_restore_parent only repaints there (no full-screen flicker).
 k_wm_setpos
-                ld    (sp_x),a
+                ld    (sp_x),a                    ; new x
                 ld    a,l
-                ld    (sp_y),a
+                ld    (sp_y),a                    ; new y
                 ld    a,(WM_FOCUS)
-                call  wm_entry                    ; HL = entry
-                inc   hl                            ; +1 x
+                call  wm_entry                    ; HL = entry (+0); damage_axis keeps HL
+                inc   hl                            ; +1 old x
+                ld    b,(hl)
+                inc   hl
+                inc   hl                            ; +3 w
+                ld    c,(hl)
                 ld    a,(sp_x)
+                call  damage_axis                 ; D = min(ox,nx), E = span
+                ld    a,d
+                ld    (clip_x),a
+                ld    a,e
+                ld    (clip_w),a
+                dec   hl                            ; +2 old y
+                ld    b,(hl)
+                inc   hl
+                inc   hl                            ; +4 h
+                ld    c,(hl)
+                ld    a,(sp_y)
+                call  damage_axis
+                ld    a,d
+                ld    (clip_y),a
+                ld    a,e
+                ld    (clip_h),a
+                dec   hl                            ; +4 -> +1 (x)
+                dec   hl
+                dec   hl
+                ld    a,(sp_x)                     ; commit the new position
                 ld    (hl),a
-                inc   hl                            ; +2 y
+                inc   hl
                 ld    a,(sp_y)
                 ld    (hl),a
                 ret
 sp_x            db    0
 sp_y            db    0
+
+; damage_axis: B = old, A = new, C = size -> D = min(old,new), E = span =
+; max(old,new) + size - min. The 1-D damage extent of a move. Preserves HL.
+damage_axis
+                cp    b
+                jr    nc,dax_oldmin              ; new >= old -> min = old, max = new
+                ld    d,a                           ; min = new
+                ld    a,b                           ; max = old
+                jr    dax_span
+dax_oldmin      ld    d,b                           ; min = old (A = new = max)
+dax_span        add   a,c                           ; max + size
+                sub   d                             ; - min
+                ld    e,a
+                ret
 
 ; wm_map_focus: bank to the focused window's page and point APP_HANDLER at its
 ; on_event (so menu_dispatch in k_poll delivers top-bar clicks to the focused app).
@@ -1340,7 +1370,9 @@ wm_focus_click
                 ret   z
                 ld    a,c
                 call  wm_raise                     ; bring it to the front
-                jp    wm_repaint_all               ; restack the screen
+                ld    a,(WM_FOCUS)               ; damage = the raised window's rect
+                call  wm_set_clip
+                jp    wm_repaint_all               ; restack the screen (clipped)
 
 ; wm_hit_test: -> A = slot of the top-most window whose rect contains the pointer
 ; (POLL_MX, POLL_MY), scanning z-order top->bottom; CF set if none.
@@ -1445,7 +1477,37 @@ wra_next        ld    a,(wm_rp_i)
                 jr    wra_l
 wra_done        ld    a,(wm_rp_back)
                 call  bank_set
-                ei
+                call  clip_set_full              ; repaints are clip-limited; restore the
+                ei                                ; full-screen clip for normal drawing
+                ret
+
+; clip_set_full: reset the fill clip to the whole screen (no clipping).
+clip_set_full
+                xor   a
+                ld    (clip_x),a
+                ld    (clip_y),a
+                ld    a,80
+                ld    (clip_w),a
+                ld    a,200
+                ld    (clip_h),a
+                ret
+
+; wm_set_clip: A = slot -> set the fill clip to that window's rect, so the next
+; wm_repaint_all only erases inside the window's area (its damage region).
+wm_set_clip
+                call  wm_entry                    ; HL = entry
+                inc   hl                            ; +1 x
+                ld    a,(hl)
+                ld    (clip_x),a
+                inc   hl                            ; +2 y
+                ld    a,(hl)
+                ld    (clip_y),a
+                inc   hl                            ; +3 w
+                ld    a,(hl)
+                ld    (clip_w),a
+                inc   hl                            ; +4 h
+                ld    a,(hl)
+                ld    (clip_h),a
                 ret
 
 ; wm_entry: A = slot index -> HL = WM_TABLE + A*WM_ESZ. Clobbers A,B,DE.

--- a/lib/screen.asm
+++ b/lib/screen.asm
@@ -66,6 +66,16 @@ scr_addr
 ; blit_bitmap: copy a bm_w x bm_h byte bitmap at (bm_x, bm_y) straight to the
 ; screen. bm_src points at row-major, already-encoded bytes.
 blit_bitmap
+                ld    a,(bm_x)               ; cull if fully outside the clip rect, so
+                ld    b,a                     ; an icon under a higher window is not drawn
+                ld    a,(bm_y)               ; over it during a partial repaint
+                ld    c,a
+                ld    a,(bm_w)
+                ld    d,a
+                ld    a,(bm_h)
+                ld    e,a
+                call  rect_cull
+                ret   c
                 ld    a,(bm_h)
                 ld    (bl_rows),a
                 ld    a,(bm_y)
@@ -186,6 +196,42 @@ cfc_yr          ld    b,a
                 or    a                         ; clear CF
                 ret
 cfc_empty       scf
+                ret
+
+; rect_cull: B=x C=y D=w E=h (byte cols / lines) -> CF set if the rectangle is
+; fully outside the clip rect (so the caller skips drawing). Used to cull whole
+; icons/glyphs so a lower layer never paints over a higher window during a partial
+; repaint. Clobbers A,H,L.
+rect_cull
+                ld    a,b                       ; X: right = x + w
+                add   a,d
+                ld    l,a
+                ld    a,(clip_x)
+                cp    l
+                jr    nc,rc_out                 ; clip_x >= right -> left of clip
+                ld    a,(clip_x)               ; clip_right = clip_x + clip_w
+                ld    h,a
+                ld    a,(clip_w)
+                add   a,h
+                cp    b
+                jr    c,rc_out                  ; clip_right < x -> right of clip
+                jr    z,rc_out                  ; clip_right == x -> right of clip
+                ld    a,c                       ; Y: bottom = y + h
+                add   a,e
+                ld    l,a
+                ld    a,(clip_y)
+                cp    l
+                jr    nc,rc_out                 ; above clip
+                ld    a,(clip_y)               ; clip_bottom = clip_y + clip_h
+                ld    h,a
+                ld    a,(clip_h)
+                add   a,h
+                cp    c
+                jr    c,rc_out                  ; below clip
+                jr    z,rc_out
+                or    a                          ; clear CF -> visible
+                ret
+rc_out          scf
                 ret
 
 ; ---------------------------------------------------------------------------

--- a/lib/screen.asm
+++ b/lib/screen.asm
@@ -97,17 +97,19 @@ bl_loop
 ; fill_block: fill an fb_w x fb_h byte rectangle at (fb_x, fb_y) with fb_val.
 ; (fb_val is a Mode 1 byte: #00 blue, #F0 white, #0F black, #FF red.)
 fill_block
-                ld    a,(fb_h)
+                call  clip_fb_copy           ; fbw_* = fb_* clipped to the clip rect
+                ret   c                        ; fully outside -> nothing to fill
+                ld    a,(fbw_h)
                 ld    (fb_rows),a
-                ld    a,(fb_y)
+                ld    a,(fbw_y)
                 ld    (fb_cy),a
 fbk_loop
-                ld    a,(fb_x)
+                ld    a,(fbw_x)
                 ld    d,a
                 ld    a,(fb_cy)
                 ld    e,a
                 call  scr_addr
-                ld    a,(fb_w)
+                ld    a,(fbw_w)
                 ld    b,a
                 ld    a,(fb_val)
                 ld    c,a
@@ -124,40 +126,66 @@ fbk_row
                 jr    nz,fbk_loop
                 ret
 
-; ---------------------------------------------------------------------------
-; fill_pattern: like fill_block but alternates fp_even / fp_odd by line, for a
-; two-tone dither (e.g. #50 / #A0 = a blue/white checkerboard in Mode 1).
-fill_pattern
-                ld    a,(fb_h)
-                ld    (fb_rows),a
-                ld    a,(fb_y)
-                ld    (fb_cy),a
-fp_loop
-                ld    a,(fb_x)
-                ld    d,a
-                ld    a,(fb_cy)
-                ld    e,a
-                call  scr_addr
-                ld    a,(fb_cy)             ; even or odd line?
-                rrca
-                ld    a,(fp_even)
-                jr    nc,fp_pick
-                ld    a,(fp_odd)
-fp_pick
-                ld    c,a
+; clip_fb_copy: fbw_* = intersection of fb_* (x,y,w,h) with the clip rect. CF set
+; if the intersection is empty. Leaves fb_* untouched. Clobbers A,B,C,D,E,H,L.
+clip_fb_copy
+                ld    a,(fb_x)               ; X: seg [fb_x, fb_x+fb_w)
+                ld    h,a
                 ld    a,(fb_w)
-                ld    b,a
-fp_row
-                ld    (hl),c
-                inc   hl
-                djnz  fp_row
-                ld    a,(fb_cy)
-                inc   a
-                ld    (fb_cy),a
-                ld    a,(fb_rows)
-                dec   a
-                ld    (fb_rows),a
-                jr    nz,fp_loop
+                add   a,h
+                ld    l,a                      ; L = fb_x + fb_w
+                ld    a,(clip_x)
+                ld    d,a
+                ld    a,(clip_w)
+                add   a,d
+                ld    e,a                      ; E = clip_x + clip_w
+                ld    a,h                      ; left = max(fb_x, clip_x)
+                cp    d
+                jr    nc,cfc_xl
+                ld    a,d
+cfc_xl          ld    c,a                      ; C = left
+                ld    a,l                      ; right = min(fb_end, clip_end)
+                cp    e
+                jr    c,cfc_xr
+                ld    a,e
+cfc_xr          ld    b,a                      ; B = right
+                ld    a,c
+                cp    b
+                jr    nc,cfc_empty            ; left >= right -> empty
+                ld    (fbw_x),a
+                ld    a,b
+                sub   c
+                ld    (fbw_w),a
+                ld    a,(fb_y)               ; Y: seg [fb_y, fb_y+fb_h)
+                ld    h,a
+                ld    a,(fb_h)
+                add   a,h
+                ld    l,a
+                ld    a,(clip_y)
+                ld    d,a
+                ld    a,(clip_h)
+                add   a,d
+                ld    e,a
+                ld    a,h
+                cp    d
+                jr    nc,cfc_yl
+                ld    a,d
+cfc_yl          ld    c,a
+                ld    a,l
+                cp    e
+                jr    c,cfc_yr
+                ld    a,e
+cfc_yr          ld    b,a
+                ld    a,c
+                cp    b
+                jr    nc,cfc_empty
+                ld    (fbw_y),a
+                ld    a,b
+                sub   c
+                ld    (fbw_h),a
+                or    a                         ; clear CF
+                ret
+cfc_empty       scf
                 ret
 
 ; ---------------------------------------------------------------------------
@@ -257,8 +285,20 @@ fb_h            db    0            ; height in rows
 fb_val          db    0            ; Mode 1 fill byte
 fb_rows         db    0
 fb_cy           db    0
-fp_even         db    #50          ; pattern byte on even lines
-fp_odd          db    #A0          ; pattern byte on odd lines
+
+; --- clip rectangle (issue #45 phase 4) ----------------------------------
+; fill_block clips its rect to this window before drawing, so a partial repaint
+; (a moved/closed window's damage area) only erases inside that area - the rest of
+; the screen is untouched, so unchanged windows/icons don't flicker. Default =
+; whole screen (no clipping). The WM narrows it around a repaint, then resets it.
+clip_x          db    0            ; clip rect, byte col / line / byte-w / lines
+clip_y          db    0
+clip_w          db    80
+clip_h          db    200
+fbw_x           db    0            ; fill_block's clipped working rect (fb_* kept
+fbw_y           db    0            ; intact so callers that reuse fb_* still work)
+fbw_w           db    0
+fbw_h           db    0
 
 ; --- save_block / restore_block parameters / scratch ---------------------
 sb_x            db    0            ; rectangle x in bytes

--- a/lib/text.asm
+++ b/lib/text.asm
@@ -136,9 +136,34 @@ draw_char
                 ld    a,c
                 ; fall through
 
-; draw_glyph: A = char. Draws the glyph at (dc_px pixels, tc_y line).
+; draw_glyph: A = char. Draws the glyph at (dc_px pixels, tc_y line). Culled if the
+; glyph cell is fully outside the clip rect, so a lower layer's text never paints
+; over a higher window during a partial repaint.
 draw_glyph
+                push  af                      ; cull clobbers A (the char)
+                ld    hl,(dc_px)             ; glyph byte col = dc_px / 4
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                ld    b,l                      ; B = x (byte col)
+                ld    a,(tc_y)
+                ld    c,a                      ; C = y
+                ld    a,(font_w)             ; D = w in byte cols (generous: px/4 + 2)
+                srl   a
+                srl   a
+                add   a,2
+                ld    d,a
+                ld    a,(font_h)
+                ld    e,a                      ; E = h
+                call  rect_cull
+                jr    c,dg_culled
+                pop   af
                 ld    hl,font_first          ; glyph = font_glyphs + (char-first)*h
+                jr    dg_go
+dg_culled       pop   af
+                ret
+dg_go
                 sub   (hl)
                 ld    e,a
                 ld    d,0


### PR DESCRIPTION
## Phase 4 of the cooperative window manager (#45)

Rect-clipped repaint: window repaints now only touch the **damage area** instead of the whole screen, so unchanged windows/icons no longer flash on a drag, focus-switch or close — and a lower layer never paints over a higher window.

### Insight
Redraws of unchanged elements are idempotent (same pixels → invisible). Only the *erase* caused the visible flash, and an *unclipped* lower layer (the desktop) painting its icons/labels over a higher window caused the occlusion bug. Clipping every primitive to the damage rect fixes both.

### What changed
**`lib/screen.asm`**
- `fill_block` clips its rect to a clip rectangle (`clip_x/y/w/h`) via `clip_fb_copy` (into a working copy, so callers reusing `fb_*` still work). Every erase (`k_fill`, `gb_window` bg, `k_frame`, `draw_topbar`) routes through it.
- `rect_cull` + culling in `blit_bitmap` (icons) and `draw_glyph` (text): a whole icon/glyph fully outside the clip rect is skipped, so layer-0 elements stay hidden behind a higher window even when focus/z-order above them changes.

**Kernel WM**
- Each repaint sets the clip to the damage rect, then `wm_repaint_all` restores the full-screen clip. Damage = the moved window's old∪new bbox (`gb_wm_setpos`), the closed window's rect (`k_wm_close`), or the raised window's rect (`wm_focus_click`). Modal-app return stays a full repaint.

### Space
Reclaimed to stay under the UniDOS HIMEM ceiling: stubbed the now-dead `k_onrepaint` (no app uses `gb_on_repaint` under the WM), removed unused `fill_pattern`, factored the bbox math into `damage_axis`. `GBKERN.RAW` = 8563 bytes.

### Verified
- Headless: identical desktop boot, labels render fully (clip defaults to full screen).
- Interactive: dragging/closing/focus-switching repaints only the damage area; desktop icons stay correctly occluded behind windows.
