### PR TITLE
Ship CLASSIC.FNT so GEOBENCH.CFG font/icon selection is usable (#56)

### DIFF
--- a/GEOBENCH.CFG.example
+++ b/GEOBENCH.CFG.example
@@ -4,3 +4,6 @@ ICONS=DEFAULT
 # FONT: name of the font set to load (<name>.FNT); default DEFAULT (6x8).
 # Use CLASSIC for the original 8x8 CPC ROM font.
 FONT=DEFAULT
+# VIEW: File Manager view - DEFAULT (icons) or LIST. The "View" menu toggles this
+# and rewrites the line.
+VIEW=DEFAULT

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -53,8 +53,10 @@ static unsigned char dc_timer;
 static unsigned char view = V_ICONS;   /* default = icon view (GEOBENCH.CFG VIEW=) */
 
 /* GEOBENCH.CFG is loaded once at startup; the View toggle rewrites the VIEW= line
-   and saves it, so the choice persists across reboots. */
-static char cfgbuf[256];
+   and saves it, so the choice persists across reboots. NOTE: gb_fs_load copies in
+   whole 512-byte sectors, so the buffer must be a full sector even though the file
+   is tiny (a smaller buffer overflows into the globals after it). */
+static char cfgbuf[512];
 static unsigned int cfglen;
 
 /* the top-bar menu: "View" toggles list/icons, "Back" goes up a directory */

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -194,6 +194,22 @@ static void draw_name(unsigned char col, unsigned char line, char *name)
     gb_text(col, line, tmp);
 }
 
+/* fullname: the current entry's 8.3 name as "NAME.EXT" (list view shows the
+   extension; gb_dir* return name only). */
+static char *fullname(void)
+{
+    static char fn[13];
+    char *e = gb_entname();              /* 11-byte 8.3, space-padded, no dot */
+    unsigned char i, j = 0;
+    for (i = 0; i < 8 && e[i] != ' '; i++) fn[j++] = e[i];
+    if (e[8] != ' ') {                   /* has an extension */
+        fn[j++] = '.';
+        for (i = 8; i < 11 && e[i] != ' '; i++) fn[j++] = e[i];
+    }
+    fn[j] = 0;
+    return fn;
+}
+
 static void draw_list_view(void)
 {
     unsigned char i, y;
@@ -201,7 +217,7 @@ static void draw_list_view(void)
     for (i = 0; i < LVIS && name; i++) {
         y = CT_Y + i * ROW_H;
         gb_blite(CT_X, y + 1);              /* type icon (8 cols x 16 lines) */
-        gb_text(CT_X + 9, y + 6, name);
+        gb_text(CT_X + 9, y + 6, fullname());   /* NAME.EXT (icon view is name only) */
         name = gb_dirn();
     }
     if (nsel) {                              /* red frame on the selected row */

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -50,7 +50,12 @@ static unsigned char top;         /* first visible LINE (row / grid row)  */
 static unsigned char nsel;        /* 0 = none, else selected index + 1    */
 static unsigned char dc_idx;      /* index of the last click              */
 static unsigned char dc_timer;
-static unsigned char view = V_LIST;
+static unsigned char view = V_ICONS;   /* default = icon view (GEOBENCH.CFG VIEW=) */
+
+/* GEOBENCH.CFG is loaded once at startup; the View toggle rewrites the VIEW= line
+   and saves it, so the choice persists across reboots. */
+static char cfgbuf[256];
+static unsigned int cfglen;
 
 /* the top-bar menu: "View" toggles list/icons, "Back" goes up a directory */
 static const unsigned char fm_menu[] = {
@@ -76,6 +81,67 @@ static char *dir_seek(unsigned char idx)
     char *p = gb_dir1();
     for (i = 0; i < idx && p; i++) p = gb_dirn();
     return p;
+}
+
+/* cfg_view_pos: index just past "VIEW=" in cfgbuf, or 0xFFFF if there's no such key. */
+static unsigned int cfg_view_pos(void)
+{
+    unsigned int i;
+    for (i = 0; i + 5 <= cfglen; i++)
+        if (cfgbuf[i] == 'V' && cfgbuf[i+1] == 'I' && cfgbuf[i+2] == 'E'
+            && cfgbuf[i+3] == 'W' && cfgbuf[i+4] == '=')
+            return i + 5;
+    return 0xFFFF;
+}
+
+/* cfg_load_view: load GEOBENCH.CFG and set the initial view from VIEW= (LIST -> list;
+   DEFAULT / absent / missing file -> icons). Keeps the buffer for cfg_save_view. */
+static void cfg_load_view(void)
+{
+    unsigned int p;
+    gb_set_name("GEOBENCHCFG");
+    cfglen = gb_fs_load(cfgbuf, sizeof(cfgbuf));
+    view = V_ICONS;
+    p = cfg_view_pos();
+    if (p != 0xFFFF && p + 4 <= cfglen && cfgbuf[p] == 'L' && cfgbuf[p+1] == 'I'
+        && cfgbuf[p+2] == 'S' && cfgbuf[p+3] == 'T')
+        view = V_LIST;
+}
+
+/* cfg_save_view: write the current view into GEOBENCH.CFG's VIEW= line (LIST or
+   DEFAULT), preserving the other keys, and save. Best-effort (no-op if the file
+   can't be written - e.g. it doesn't exist). */
+static void cfg_save_view(void)
+{
+    const char *val = (view == V_LIST) ? "LIST" : "DEFAULT";
+    unsigned char vlen = (view == V_LIST) ? 4 : 7;
+    unsigned int p, end, i;
+
+    if (cfglen == 0) return;                 /* no config loaded -> nothing to update */
+    p = cfg_view_pos();
+    if (p == 0xFFFF) {                        /* no VIEW= key: append a line */
+        if (cfglen + 7 + vlen > sizeof(cfgbuf)) return;
+        cfgbuf[cfglen++] = 'V'; cfgbuf[cfglen++] = 'I'; cfgbuf[cfglen++] = 'E';
+        cfgbuf[cfglen++] = 'W'; cfgbuf[cfglen++] = '=';
+        for (i = 0; i < vlen; i++) cfgbuf[cfglen++] = val[i];
+        cfgbuf[cfglen++] = '\r'; cfgbuf[cfglen++] = '\n';
+    } else {                                  /* replace the existing value in place */
+        end = p;
+        while (end < cfglen && cfgbuf[end] != '\r' && cfgbuf[end] != '\n') end++;
+        if (vlen > (unsigned char)(end - p)) {           /* grow: shift tail right */
+            unsigned int d = vlen - (end - p);
+            if (cfglen + d > sizeof(cfgbuf)) return;
+            for (i = cfglen; i > end; i--) cfgbuf[i - 1 + d] = cfgbuf[i - 1];
+            cfglen += d;
+        } else if (vlen < (unsigned char)(end - p)) {    /* shrink: shift tail left */
+            unsigned int d = (end - p) - vlen;
+            for (i = end; i < cfglen; i++) cfgbuf[i - d] = cfgbuf[i];
+            cfglen -= d;
+        }
+        for (i = 0; i < vlen; i++) cfgbuf[p + i] = val[i];
+    }
+    gb_set_name("GEOBENCHCFG");
+    gb_fs_save(cfgbuf, cfglen);
 }
 
 /* scroll model: lines (rows in list, grid rows in icons) and how many are visible */
@@ -231,8 +297,9 @@ static void on_event(void)
     if (gb_msg.p0 >= MENU_BACK_COL) {     /* Back */
         gb_back();
         relist();
-    } else {                              /* View */
+    } else {                              /* View: toggle + persist to GEOBENCH.CFG */
         view ^= 1;
+        cfg_save_view();
         top = 0; nsel = 0;
         clamp_top();
         draw();
@@ -303,8 +370,12 @@ void main(void)
 {
     win_x = DEF_X;
     win_y = DEF_Y;
+    nsel = 0; dc_timer = 0;
+    gb_wm_add(&fmwin);           /* register first (focus) so gb_set_name/fs_load
+                                   target our window for the config read below */
+    cfg_load_view();             /* VIEW= from GEOBENCH.CFG -> view (default icons) */
     total = count_files();
-    top = 0; nsel = 0; dc_timer = 0; view = V_LIST;
+    top = 0;
+    clamp_top();
     draw();
-    gb_wm_add(&fmwin);           /* register; the kernel WM drives us (#45) */
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -50,6 +50,23 @@ cap32 and 1984 both accept a `.dsk` slot file. Two quick paths:
 1984 has its own invocation (see `../1984/INSTALL.md` / `1984.conf.example`);
 the build artifacts (`.bin` / `.dsk`) are the same.
 
+## Icon and font sets (GEOBENCH.CFG)
+
+`GEOBENCH.CFG` selects a named set: `ICONS=<name>` loads `<name>.IST`, `FONT=<name>`
+loads `<name>.FNT`; both fall back to `DEFAULT` if absent. Sets ship as files on
+the disk (and are `incbin`/`save`d onto `build/gbkern.dsk` in `kernel/gbkern.asm`).
+
+Build a set, then package it (add an `incbin` + a `save "<NAME>.<EXT>",...,DSK`
+line in `gbkern.asm`, and copy it to the IDE image in the deploy step):
+
+- **Font** (`.FNT`): from an 8×8 `.asm` font source — `tools/packfont.py
+  build/NAME.FNT lib/font.asm` (ships `CLASSIC.FNT`, the 8×8 ROM font). The 6×8
+  `DEFAULT.FNT` is generated procedurally by `tools/genfont.py`.
+- **Icons** (`.IST`): each icon is a 32×32 PNG → `tools/png2cpc.py assets/x.png
+  lib/icon_x.asm icon_x 32x32`, then `tools/packicons.py build/NAME.IST
+  lib/icon_*.asm ...` in **slot order** (must match `ext_to_icon` in `gbkern.asm`:
+  floppy ide clock trash geobench basic binary picture text folder).
+
 ## File line endings
 
 Any text/data file the CPC reads must use **CR+LF** (`0x0D 0x0A`), not Unix LF.

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -2184,6 +2184,8 @@ fat_img         incbin "../build/GBFAT.RAW"     ; FAT16/IDE write module, as GBF
 fat_imgend
 font_img        incbin "../build/DEFAULT.FNT"   ; packaged on the disk as DEFAULT.FNT
 font_imgend
+cfont_img       incbin "../build/CLASSIC.FNT"   ; alternate 8x8 font (FONT=CLASSIC)
+cfont_imgend
 icon_img        incbin "../build/DEFAULT.IST"   ; packaged on the disk as DEFAULT.IST
 icon_imgend
 wel_img         incbin "../assets/WELCOME.TXT"  ; a sample text file to open in VIEWER
@@ -2197,6 +2199,7 @@ wel_imgend
                 save  "GBCFG.BIN",cfg_img,cfg_imgend-cfg_img,DSK,"build/gbkern.dsk"
                 save  "GBFAT.BIN",fat_img,fat_imgend-fat_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.FNT",font_img,font_imgend-font_img,DSK,"build/gbkern.dsk"
+                save  "CLASSIC.FNT",cfont_img,cfont_imgend-cfont_img,DSK,"build/gbkern.dsk"
                 save  "DEFAULT.IST",icon_img,icon_imgend-icon_img,DSK,"build/gbkern.dsk"
                 save  "WELCOME.TXT",wel_img,wel_imgend-wel_img,DSK,"build/gbkern.dsk"
                 save  "build/GBKERN.RAW",GB_KERNEL,kern_end-GB_KERNEL

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -1718,6 +1718,8 @@ afe_default
                 ret
 app_table
                 db    "TXT","NOTEPAD BIN"      ; .TXT -> NOTEPAD (edit + save)
+                db    "CFG","NOTEPAD BIN"      ; .CFG -> NOTEPAD (edit GEOBENCH.CFG)
+                db    "BAS","NOTEPAD BIN"      ; .BAS -> NOTEPAD (ASCII BASIC)
                 db    0                          ; end of table
 name_viewer     db    "VIEWER  BIN"
 launch_arg      defs  11

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -98,6 +98,7 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_isdir                ; GB_ISDIR       #806C
                 jp    k_chdir                ; GB_CHDIR       #806F
                 jp    k_back                 ; GB_BACK        #8072
+                jp    k_entname              ; GB_ENTNAME     #8075
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -1017,6 +1018,12 @@ k_back
                 ldir
                 ret
 
+; k_entname (GB_ENTNAME): HL = the last-enumerated entry's raw 11-byte 8.3 name
+; (space-padded, no dot) so an app can show the extension (gb_dir* return name-only).
+k_entname
+                ld    hl,fs_ent_name
+                ret
+
 ; focus_arg_ptr: HL = the focused window's 11-byte file arg (per-window, so two
 ; editors keep separate files). Each window captured the pending launch_arg at
 ; gb_wm_add; getarg/setname/fsload/fssave all act on the focused window's copy.
@@ -1690,37 +1697,34 @@ dmt_loop
 ; is a 3-char extension + an 11-char 8.3 app name; a 0 ends the table -> default.
 ; (Only VIEWER exists today, so most types fall through to it; add rows as new
 ; apps land.)
+; app_for_ext: HL = the app to open the current entry. Text-ish types (in the
+; edit_exts list) open in NOTEPAD; everything else in the read-only VIEWER.
 app_for_ext
-                ld    hl,app_table
-afe_loop
-                ld    a,(hl)                  ; 0 = end of table -> default app
+                ld    hl,edit_exts           ; 3-char editable extensions, 0-terminated
+afe_grp
+                ld    a,(hl)
                 or    a
-                jr    z,afe_default
-                push  hl                       ; compare the 3-char extension
-                ld    de,fs_ent_name+8
+                jr    z,afe_default          ; end of list -> default VIEWER
+                ld    de,fs_ent_name+8       ; compare this 3-char ext
                 ld    b,3
 afe_cmp
                 ld    a,(de)
                 cp    (hl)
-                jr    nz,afe_miss
+                jr    nz,afe_next
                 inc   hl
                 inc   de
                 djnz  afe_cmp
-                pop   de                       ; matched -> HL = the app name (after ext)
+                ld    hl,name_notepad        ; matched -> NOTEPAD
                 ret
-afe_miss
-                pop   hl                       ; skip this entry (3 ext + 11 name)
-                ld    de,14
-                add   hl,de
-                jr    afe_loop
+afe_next                                       ; skip the rest of this 3-char ext (B = the
+                inc   hl                       ; chars left from the mismatch) -> next group
+                djnz  afe_next
+                jr    afe_grp
 afe_default
                 ld    hl,name_viewer
                 ret
-app_table
-                db    "TXT","NOTEPAD BIN"      ; .TXT -> NOTEPAD (edit + save)
-                db    "CFG","NOTEPAD BIN"      ; .CFG -> NOTEPAD (edit GEOBENCH.CFG)
-                db    "BAS","NOTEPAD BIN"      ; .BAS -> NOTEPAD (ASCII BASIC)
-                db    0                          ; end of table
+edit_exts       db    "TXTCFGBAS",0          ; .TXT/.CFG/.BAS -> NOTEPAD (editable)
+name_notepad    db    "NOTEPAD BIN"
 name_viewer     db    "VIEWER  BIN"
 launch_arg      defs  11
 

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -118,4 +118,5 @@ void gb_wm_launch(void);              /* open current dir entry co-resident (+ a
 unsigned char gb_isdir(void);
 void gb_chdir(void);
 void gb_back(void);
+char *gb_entname(void);  /* current entry's raw 11-byte 8.3 name (with extension) */
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -43,6 +43,7 @@
         .globl  _gb_isdir
         .globl  _gb_chdir
         .globl  _gb_back
+        .globl  _gb_entname
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -256,3 +257,8 @@ _gb_chdir:
 ;; void gb_back(void);    up to the parent directory
 _gb_back:
         jp      0x8072          ; GB_BACK
+;; char *gb_entname(void);  the current dir entry's raw 11-byte 8.3 name (with ext)
+_gb_entname:
+        call    0x8075          ; GB_ENTNAME -> HL = fs_ent_name
+        ex      de, hl
+        ret

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -14,6 +14,7 @@ mkdir -p build
 rm -f build/gbkern.dsk                        # save-to-DSK appends; start clean
 
 python3 tools/genfont.py build/DEFAULT.FNT   # 6x8 font -> PAGE_DATA
+python3 tools/packfont.py build/CLASSIC.FNT lib/font.asm  # 8x8 ROM font (FONT=CLASSIC)
 python3 tools/packicons.py build/DEFAULT.IST \
     lib/icon_floppy.asm lib/icon_ide.asm lib/icon_clock.asm lib/icon_trash.asm \
     lib/icon_geobench.asm lib/icon_basic.asm lib/icon_binary.asm \


### PR DESCRIPTION
Closes #56. The ICONS=/FONT= parser + loaders existed (and are unit-tested) but only DEFAULT.FNT/DEFAULT.IST were ever built, so there was no alternate set on the disk to select. This builds + packages CLASSIC.FNT (8x8 ROM font via packfont) onto gbkern.dsk and the IDE image, so FONT=CLASSIC works; ICONS=/FONT= still fall back to DEFAULT when a named set is absent. Verified headless: a GEOBENCH.CFG with FONT=CLASSIC renders the desktop in the wide 8x8 font. docs/DEVELOPMENT.md documents building + packaging a set.