### PR TITLE
DnD phase 2: Trash drop deletes the file for real (#62)

### DIFF
--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -124,9 +124,10 @@ static void on_event(void)
     static char msg[] = "Top-bar click @ col 00";
     unsigned char c;
     if (gb_msg.type == GB_MSG_DROP) {          /* a file was dropped on the desktop (#62) */
-        if (hit_icon(gb_mx(), gb_my()) == 2) { /* on the Trash icon? (phase 1: marker) */
+        if (hit_icon(gb_mx(), gb_my()) == 2) { /* on the Trash icon -> delete the file */
+            gb_file_delete(gb_dragname);       /* (the source window then re-lists) */
             gb_curhide();
-            gb_text(1, 10, trash_label());
+            gb_text(1, 10, trash_label());     /* "Trash: NAME" confirmation */
             gb_curshow();
         }
         return;

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -110,6 +110,7 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_back                 ; GB_BACK        #8072
                 jp    k_entname              ; GB_ENTNAME     #8075
                 jp    k_drag_start           ; GB_DRAGSTART   #8078
+                jp    k_fs_delete            ; GB_FSDELETE    #807B
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -1100,6 +1101,17 @@ k_fssave
 
 ; k_getkey (GB_GETKEY): A = a typed character from the keyboard buffer, or 0 if
 ; none is waiting. Non-blocking (the firmware's IRQ scan fills the buffer).
+; k_fs_delete (GB_FSDELETE, #62): HL = 11-byte 8.3 name in the caller page. Delete
+; that file from the current directory (free clusters + clear the dir entry) via
+; the paged GBFAT module. CF set = deleted. Used by drag-to-Trash.
+k_fs_delete
+                ld    de,fs_req_name
+                call  copy11
+                di
+                call  fs_delete_file
+                ei
+                ret
+
 k_getkey
                 call  KM_READ_CHAR           ; CF + A = char, or NC = none. (Apps frame
                 jr    nc,kgk_none            ; on IY now, so KM_READ_CHAR clobbering IX

--- a/kernel/modules/gbfat.asm
+++ b/kernel/modules/gbfat.asm
@@ -22,6 +22,8 @@ GBFAT_ORG       equ   #5000
 GBFAT_LEN       equ   #1400
 GBFAT_NAME      equ   #1402
 GBFAT_RES       equ   #140D
+GBFAT_OP        equ   #140E        ; operation: 0 = save, 1 = delete (#62)
+GBFAT_DIR       equ   #140F        ; directory cluster (4 bytes) to operate in
 GBFAT_DATA      equ   #2200
 
 FS_IDE_SCNT     equ   #FD0A
@@ -37,13 +39,59 @@ fs_secbuf       equ   #1800        ; shared low-RAM sector buffer (resident agre
 
                 org   GBFAT_ORG
 
-; entry: run the save, store the result byte, return to the kernel.
+; entry: dispatch on GBFAT_OP (0 = save, 1 = delete), store the result, return.
+                ld    a,(GBFAT_OP)
+                or    a
+                jr    nz,ge_delete
                 call  gbfat_save
+                jr    ge_res
+ge_delete
+                call  gbfat_delete
+ge_res
                 ld    a,1
                 jr    c,gf_setres
                 xor   a
 gf_setres
                 ld    (GBFAT_RES),a
+                ret
+
+; gbfat_delete: remove the file named GBFAT_NAME from the directory at cluster
+; GBFAT_DIR - free its cluster chain and mark the directory entry deleted (0xE5).
+; Refuses directories (only files). CF set = deleted.
+gbfat_delete
+                call  fs_mount                   ; geometry (also sets fs_dir_clus=root)
+                ld    hl,GBFAT_DIR              ; operate in the requested directory
+                ld    de,fs_dir_clus
+                ld    bc,4
+                ldir
+                call  fs_dir_find_slot          ; locate GBFAT_NAME
+                ret   nc                          ; directory walk failed
+                ld    a,(sav_found)
+                or    a
+                jr    z,gd_fail                   ; name not present
+                ld    hl,sav_ent_lba             ; check the entry's attribute: refuse
+                call  lbatmp_from_var             ; directories (would orphan contents)
+                call  fs_read_sector
+                ld    hl,(sav_ent_off)
+                ld    de,fs_secbuf+#0B           ; attr byte at offset 0x0B
+                add   hl,de
+                ld    a,(hl)
+                and   #10
+                jr    nz,gd_fail                  ; directory -> refuse
+                ld    hl,sav_old_clus            ; free the file's cluster chain
+                call  fs_free_chain               ; (this reuses fs_secbuf)
+                ld    hl,sav_ent_lba             ; reload the dir sector and mark the
+                call  lbatmp_from_var             ; entry deleted
+                call  fs_read_sector
+                ld    hl,(sav_ent_off)
+                ld    de,fs_secbuf
+                add   hl,de
+                ld    (hl),#E5
+                call  fs_write_sector
+                scf
+                ret
+gd_fail
+                or    a
                 ret
 
 ; ---------------------------------------------------------------------------

--- a/lib/fs.asm
+++ b/lib/fs.asm
@@ -28,6 +28,8 @@ fs_init
                 ld    (fs_p_load),hl
                 ld    hl,fside_save_file
                 ld    (fs_p_save),hl
+                ld    hl,fside_delete_file
+                ld    (fs_p_delete),hl
                 ret
 fsi_floppy
                 ld    hl,fsam_dir_first
@@ -38,6 +40,8 @@ fsi_floppy
                 ld    (fs_p_load),hl
                 ld    hl,fsam_save_file
                 ld    (fs_p_save),hl
+                ld    hl,fs_load_none          ; delete not implemented on floppy
+                ld    (fs_p_delete),hl
                 ret
 
 ; fs_dir_first / fs_dir_next / fs_load_file: route to the selected backend.
@@ -57,6 +61,11 @@ fs_load_file
 ; full, too big, or - FAT16 - not yet implemented).
 fs_save_file
                 ld    hl,(fs_p_save)
+                jp    (hl)
+; fs_delete_file: delete the file named fs_req_name from the current directory.
+; CF set = deleted, NC = failed/unsupported. (#62 drag-to-Trash)
+fs_delete_file
+                ld    hl,(fs_p_delete)
                 jp    (hl)
 fs_load_none
                 or    a                        ; not implemented -> NC
@@ -89,6 +98,7 @@ fs_p_first      defw  fside_dir_first   ; default IDE; fs_init rewrites on detec
 fs_p_next       defw  fside_dir_next
 fs_p_load       defw  fside_load_file
 fs_p_save       defw  fside_save_file
+fs_p_delete     defw  fside_delete_file
 fs_ent_name     defs  11
 fs_ent_attr     defb  0
 fs_ent_size     defs  4

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -37,6 +37,8 @@ FS_IDE_DATA     equ   #FD08
 GBFAT_LEN       equ   #1400        ; bytes to write (word)
 GBFAT_NAME      equ   #1402        ; 8.3 name (11 bytes)
 GBFAT_RES       equ   #140D        ; result: 1 = saved, 0 = failed
+GBFAT_OP        equ   #140E        ; operation: 0 = save, 1 = delete (#62)
+GBFAT_DIR       equ   #140F        ; directory cluster (4 bytes) to operate in
 GBFAT_DATA      equ   #2200        ; staged data (<= GBFAT_MAX bytes)
 GBFAT_MAX       equ   #1C00        ; 7 KB staging cap (fits #2200..#3DFF in low RAM)
 GBFAT_LOAD      equ   #5000        ; module load address (above the font/icons)
@@ -263,6 +265,8 @@ fsvm_nlen
                 ldir
                 ld    hl,(fs_save_len)
                 ld    (GBFAT_LEN),hl
+                xor   a                        ; op = save
+                ld    (GBFAT_OP),a
                 ld    a,(bank_cur)            ; page in PAGE_DATA, load + run the module
                 push  af
                 ld    a,PAGE_DATA
@@ -288,6 +292,44 @@ fsvm_unload
                 ret
 fsvm_fail
                 or    a
+                ret
+
+; fside_delete_file: delete the file named fs_req_name from the current directory
+; (fs_dir_clus) - free its clusters and clear its dir entry, via the GBFAT module
+; (op = delete). CF set = deleted. Used by drag-to-Trash (#62).
+fside_delete_file
+                ld    hl,fs_req_name          ; name + current dir -> the transfer area
+                ld    de,GBFAT_NAME
+                ld    bc,11
+                ldir
+                ld    hl,fs_dir_clus
+                ld    de,GBFAT_DIR
+                ld    bc,4
+                ldir
+                ld    a,1
+                ld    (GBFAT_OP),a            ; op = delete
+                ld    a,(bank_cur)            ; page in PAGE_DATA, load + run the module
+                push  af
+                ld    a,PAGE_DATA
+                call  bank_set
+                ld    hl,gbfat_modname
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    hl,#2000
+                ld    (fs_load_max),hl
+                ld    hl,GBFAT_LOAD
+                ld    (fs_load_dst),hl
+                call  fs_load_file           ; load GBFAT.BIN -> #5000
+                jr    nc,fsd_unload           ; module missing -> fail
+                call  GBFAT_LOAD             ; run it (reads low RAM, writes the IDE)
+fsd_unload
+                pop   af
+                call  bank_set
+                ld    a,(GBFAT_RES)
+                or    a
+                ret   z
+                scf
                 ret
 gbfat_modname   db    "GBFAT   BIN"          ; 8.3, space-padded
 

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -131,4 +131,10 @@ char *gb_entname(void);  /* current entry's raw 11-byte 8.3 name (with extension
  * on_event got a GB_MSG_DROP and handled it), or 0 if it was just a click (no
  * movement / no target) so the caller should treat it as a normal selection. */
 unsigned char gb_drag_start(const char *name);
+
+/* gb_file_delete: delete a file (11-byte 8.3 name) from the current directory -
+ * frees its clusters and clears its directory entry. Returns 1 if deleted, 0 on
+ * failure (not found, a directory, or unsupported backend). Used by the desktop
+ * Trash drop handler (#62). */
+unsigned char gb_file_delete(const char *name);
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -45,6 +45,7 @@
         .globl  _gb_back
         .globl  _gb_entname
         .globl  _gb_drag_start
+        .globl  _gb_file_delete
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -269,3 +270,12 @@ _gb_entname:
 ;; Returns 1 if dropped on another window (it handled it), 0 if it was just a click.
 _gb_drag_start:
         jp      0x8078          ; GB_DRAGSTART (returns 1/0 in A)
+
+;; unsigned char gb_file_delete(const char *name);  name (11-byte 8.3) in HL ->
+;; delete that file from the current directory. Returns 1 if deleted, else 0.
+_gb_file_delete:
+        call    0x807B          ; GB_FSDELETE -> CF = deleted
+        ld      a, #0
+        ret     nc
+        inc     a
+        ret


### PR DESCRIPTION
Phase 2 of #62 — dragging a file onto the desktop **Trash** now actually deletes it (FAT cluster chain freed + directory entry cleared). User-tested: single-sector and multi-sector files delete and stay gone across reopen/reboot; directories are refused.

## How
- **GBFAT module** (paged write path): `GBFAT_OP` selects save (0) / delete (1); `GBFAT_DIR` carries the directory cluster. `gbfat_delete` mounts, retargets its *own* FAT-core `fs_dir_clus` to that dir, finds the entry, refuses directories (attr&0x10, avoids orphaning contents), frees the chain (`fs_free_chain`), marks the entry 0xE5.
- **Resident**: `fside_delete_file` marshals name + current `fs_dir_clus` + op=delete and runs the module (`fs_save_file` now sets op=0). Dispatcher `fs_delete_file`/`fs_p_delete` (floppy = unsupported). Kernel API **GB_FSDELETE #807B** -> `k_fs_delete`; libgb `gb_file_delete(name)`.
- **Desktop**: a drop on Trash calls `gb_file_delete(gb_dragname)`; the source File Manager re-lists on drop so the file disappears.

## Scope
Delete only. Folder-to-folder **move** is next (needs per-window directory state — one global current-dir today).

Kernel 8704 B (136 B headroom); GBFAT module 1917 B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)