### PR TITLE
DnD phase 3: cross-drive copy (drag a file between drive windows) (#65)

### DIFF
--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -317,11 +317,10 @@ static void sb_click(unsigned char my)
    directory; "View" (left title) toggles list / icons. */
 static void on_event(void)
 {
-    if (gb_msg.type == GB_MSG_DROP) {     /* a file dropped on this folder window (#62) */
-        gb_curhide();                     /* phase 1: just show what landed here */
-        gb_text(CT_X, CT_Y, "Drop:");
-        gb_text(CT_X + 6, CT_Y, name83(gb_dragname));
-        gb_curshow();
+    if (gb_msg.type == GB_MSG_DROP) {     /* a file dropped here from another window (#65) */
+        gb_set_drive(my_drive);           /* copy it onto THIS window's drive, then re-list */
+        gb_file_copy();
+        relist();
         return;
     }
     if (gb_msg.type != GB_MSG_MENU) return;

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -58,6 +58,8 @@ WM_DRAGSRC      equ   #13C6        ; source window slot of the active drag
 WM_DRAGMOV      equ   #13C7        ; 1 once the pointer moved (a drag, not a click)
 WM_DRAGX0       equ   #13C8        ; last drag position (byte col / line); movement
 WM_DRAGY0       equ   #13C9        ; vs this drives both the ghost and click/drag tell
+WM_DRAGDRV      equ   #13CA        ; source drive of the active drag (for cross-drive copy)
+WM_DRAGDIR      equ   #13CB        ; source directory cluster (4 bytes), captured at start
 GHOST_W         equ   8            ; drag ghost outline box: 8 byte-cols x 16 lines
 GHOST_H         equ   16           ; (an icon footprint); save-under in fs_secbuf
 CUR_LOW         equ   #1500        ; low-RAM cursor sprite buffer (#65): DEFAULT.SPR is
@@ -118,6 +120,7 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_drive_poll           ; GB_DRIVES      #807E
                 jp    fs_set_drive           ; GB_SETDRIVE    #8081 (A = drive)
                 jp    k_get_drive            ; GB_GETDRIVE    #8084
+                jp    k_file_copy            ; GB_FSCOPY      #8087
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -1151,6 +1154,68 @@ k_get_drive
                 ld    a,(fs_cur_drive)
                 ret
 
+; k_file_copy (GB_FSCOPY, #65 phase 3): copy the dragged file (WM_DRAGNAME) from the
+; source drive/dir captured at drag start (WM_DRAGDRV/WM_DRAGDIR) to the CURRENT
+; (target) drive - landing in that drive's root. Loads into the staging buffer
+; (<= GBFAT_MAX) then saves. The caller (the drop target window) sets the active
+; drive first. CF set = copied. Restores the target drive/dir so the caller relists.
+k_file_copy
+                ld    a,(fs_cur_drive)        ; remember the target context to restore
+                ld    (fc_tdrv),a
+                ld    hl,fs_dir_clus
+                ld    de,fc_tdir
+                ld    bc,4
+                ldir
+                ld    a,(WM_DRAGDRV)         ; --- switch to the source, load the file ---
+                call  fs_set_drive
+                ld    hl,WM_DRAGDIR
+                ld    de,fs_dir_clus
+                ld    bc,4
+                ldir
+                ld    hl,WM_DRAGNAME
+                ld    de,fs_req_name
+                call  copy11
+                ld    hl,GBFAT_MAX
+                ld    (fs_load_max),hl
+                ld    hl,GBFAT_DATA
+                ld    (fs_load_dst),hl
+                di
+                call  fs_load_file           ; -> BC = bytes loaded
+                ei
+                jr    nc,fc_fail              ; source file not found
+                ld    (fc_len),bc
+                ld    a,(fc_tdrv)            ; --- switch to the target, save the file ---
+                call  fs_set_drive
+                ld    hl,WM_DRAGNAME
+                ld    de,fs_req_name
+                call  copy11
+                ld    hl,GBFAT_DATA
+                ld    (fs_save_src),hl
+                ld    hl,(fc_len)
+                ld    (fs_save_len),hl
+                di
+                call  fs_save_file           ; CF = saved
+                ei
+                push  af
+                call  fc_restore
+                pop   af
+                ret
+fc_fail
+                call  fc_restore
+                or    a
+                ret
+fc_restore                                    ; active drive + dir = the target's again
+                ld    a,(fc_tdrv)
+                call  fs_set_drive
+                ld    hl,fc_tdir
+                ld    de,fs_dir_clus
+                ld    bc,4
+                ldir
+                ret
+fc_tdrv         db    0
+fc_tdir         defs  4
+fc_len          defw  0
+
 ; k_fs_delete (GB_FSDELETE, #62): HL = 11-byte 8.3 name in the caller page. Delete
 ; that file from the current directory (free clusters + clear the dir entry) via
 ; the paged GBFAT module. CF set = deleted. Used by drag-to-Trash.
@@ -1583,6 +1648,12 @@ k_drag_start
                 ld    (wm_drag_pg),a
                 ld    a,(WM_FOCUS)               ; source = the focused (calling) window
                 ld    (WM_DRAGSRC),a
+                ld    a,(fs_cur_drive)           ; capture the source drive + directory now
+                ld    (WM_DRAGDRV),a             ; (active = the source FM's) for a later
+                ld    hl,fs_dir_clus             ; cross-drive copy (#65 phase 3)
+                ld    de,WM_DRAGDIR
+                ld    bc,4
+                ldir
                 xor   a
                 ld    (WM_DRAGMOV),a             ; moved = 0, ghost not shown yet
                 ld    (ghost_on),a

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -156,4 +156,10 @@ unsigned char gb_drives(void);
 #define GB_DRIVE_B 2
 void gb_set_drive(unsigned char d);
 unsigned char gb_get_drive(void);
+
+/* gb_file_copy: copy the file currently being dragged (its name + source drive and
+ * directory were captured by gb_drag_start) into the *current* drive's root. Called
+ * by a drop-target window's on_event on GB_MSG_DROP to receive a cross-drive
+ * drag-and-drop. Returns 1 if copied, 0 on failure (#65 phase 3). */
+unsigned char gb_file_copy(void);
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -49,6 +49,7 @@
         .globl  _gb_drives
         .globl  _gb_set_drive
         .globl  _gb_get_drive
+        .globl  _gb_file_copy
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -296,3 +297,12 @@ _gb_set_drive:
 ;; unsigned char gb_get_drive(void);  -> the current active drive in A
 _gb_get_drive:
         jp      0x8084          ; GB_GETDRIVE
+
+;; unsigned char gb_file_copy(void);  copy the dragged file (captured at drag start)
+;; from its source drive/dir into the current drive's root. Returns 1 if copied.
+_gb_file_copy:
+        call    0x8087          ; GB_FSCOPY -> CF = copied
+        ld      a, #0
+        ret     nc
+        inc     a
+        ret


### PR DESCRIPTION
Phase 3 of #65 — drag a file from one drive's File Manager window onto another's and it is **copied** onto that drive. User-tested (IDE ↔ floppy, both directions).

## How
- `gb_drag_start` captures the **source drive + directory** (WM_DRAGDRV/WM_DRAGDIR) at the start of a drag.
- **GB_FSCOPY #8087 / `k_file_copy`**: load the dragged file from the captured source drive/dir into the staging buffer (≤ ~7 KB), save it to the current (target) drive's root, restore the target drive/dir so the caller re-lists. libgb `gb_file_copy()`.
- File Manager `on_event` GB_MSG_DROP → `gb_set_drive(my_drive)` + `gb_file_copy()` + re-list (replaces the phase-1 marker).

## Limitations (follow-ups)
- ~7 KB size cap (single staging buffer) — bigger files need chunked copy.
- Copy lands in the target drive's **root** (saves are root-only today).
- IDE→IDE between two subdirs is ambiguous (one global current-dir); cross-*drive* (IDE↔floppy) is unaffected.
- **Copy only** — move (= copy + delete source) is the next step.

Kernel 8671 B / 169 B headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
