### PR TITLE
CLOCK.APP: analog clock window (#72)

### DIFF
--- a/apps/clock/main.c
+++ b/apps/clock/main.c
@@ -1,37 +1,42 @@
 /* clock - the GEOBENCH analog clock (C), a co-resident window (#72).
  *
- * An xclock-style analog face: a round rim, 12 hour ticks, and hour/minute/second
- * hands placed from a fixed-point sin/cos table, with a digital HH:MM:SS readout
- * below. The kernel exposes the time (gb_time -> gb_hour/min/sec) and a pixel-coord
- * line primitive (gb_line); the hands are drawn with those.
+ * An xclock-style analog face: a round rim, 12 hour ticks, and hour/minute (and
+ * optionally second) hands placed from a fixed-point sin/cos table, with a digital
+ * read-out below. By default it shows hours+minutes and refreshes once a minute; an
+ * "Options" top-bar menu toggles "Show Seconds" (per-second refresh) and offers
+ * "Set time".
  *
- * It updates once a second while focused (the cooperative WM only calls the focused
- * window's on_frame). To avoid flicker the face is not cleared each tick: the old
- * hands are erased (redrawn in the background pen), the rim/ticks repaired, and the
- * new hands drawn. Drag the title bar to move it; the close gadget / ESC closes it.
+ * Flicker-free: the hands are all shorter than the tick ring, so erasing a hand
+ * (redrawing it in the background) never touches the rim/ticks - a tick just erases
+ * the old hands and draws the new ones, and only lifts the pointer when it actually
+ * sits over the window. The kernel has no line primitive (to stay lean); the clock
+ * calls the CPC firmware graphics VDU directly for the hands.
  */
 #include "gb.h"
 
-#define DEF_X    24           /* initial window position (draggable) */
+#define DEF_X    24
 #define DEF_Y    20
 #define WIN_W    28           /* bytes (112 px) */
-#define WIN_H    128          /* px */
+#define WIN_H    122          /* px */
 #define TITLE_H  14
 
 #define R        44           /* face radius (px) */
-#define TICK_IN  37           /* hour-tick inner radius */
-#define L_HOUR   24           /* hand lengths */
-#define L_MIN    36
-#define L_SEC    42
+#define TICK_IN  37           /* hour-tick inner radius; hands stay inside this */
+#define L_HOUR   20
+#define L_MIN    30
+#define L_SEC    36
 
-/* live (draggable) clock centre, in screen pixels */
-#define CX       (win_x * 4 + WIN_W * 2)
-#define CY       (win_y + 60)
+#define MENU_COL 10           /* "Options" title column in the top bar */
+#define MENU_END 22
+
+#define CX       (win_x * 4 + WIN_W * 2)     /* live clock centre, screen pixels */
+#define CY       (win_y + 58)
 
 static unsigned char win_x = DEF_X, win_y = DEF_Y;
-static unsigned char ph, pm, ps, have_prev;   /* previous h/m/s, for erasing hands */
+static unsigned char show_sec;               /* 0 = H:M (minute refresh), 1 = +seconds */
+static unsigned char ph, pm, ps, pshow, have_prev;  /* previous h/m/s + show state */
+static unsigned char want_menu, modal;
 
-/* sin/cos * 64 for the 60 clock positions (0 = 12 o'clock, clockwise, 6 deg each) */
 static const signed char SIN64[60] = {
       0,  7, 13, 20, 26, 32, 38, 43, 48, 52, 55, 58,
      61, 63, 64, 64, 64, 63, 61, 58, 55, 52, 48, 43,
@@ -47,11 +52,7 @@ static const signed char COS64[60] = {
      20, 26, 32, 38, 43, 48, 52, 55, 58, 61, 63, 64
 };
 
-/* The kernel exposes no line primitive (to stay lean), so the clock draws its hands
-   by calling the CPC firmware graphics VDU directly: GRA_SET_PEN (&BBDE), GRA_MOVE_
-   ABS (&BBC0), GRA_LINE_ABS (&BBF6). Coords are firmware graphics units (0-639 x
-   0-399 from the bottom-left). The jumpblock is always mapped, so an app can call it;
-   the screen (&C000+) is untouched by our #4000 bank. */
+/* --- firmware graphics line (the kernel has no line primitive) --------------- */
 static volatile unsigned int fx0, fy0, fx1, fy1;
 static volatile unsigned char fpen;
 static void fw_line(void) __naked
@@ -78,14 +79,34 @@ static void line(int x0, int y0, int x1, int y1, unsigned char pen)
     fw_line();
 }
 
-/* the kernel hands us raw RTC registers; convert BCD -> binary unless it's already
-   binary (software clock, or an RTC running in binary mode). */
+/* --- RTC write (Set time), straight to the Dallas registers via inline asm ----- */
+static volatile unsigned char rtc_reg, rtc_val;
+static void rtc_poke(void) __naked
+{
+__asm
+    ld   a, (_rtc_reg)
+    ld   bc, #0xFD15     ; RTC address port
+    out  (c), a
+    ld   a, (_rtc_val)
+    ld   bc, #0xFD14     ; RTC data port
+    out  (c), a
+    ret
+__endasm;
+}
+static void set_rtc(unsigned char reg, unsigned char val) { rtc_reg = reg; rtc_val = val; rtc_poke(); }
+
+/* the kernel hands us raw RTC registers; convert BCD -> binary unless it's binary */
 static unsigned char bin(unsigned char v)
 {
     return gb_binmode ? v : (unsigned char)((v >> 4) * 10 + (v & 15));
 }
+static unsigned char tobcd(unsigned char v)
+{
+    return gb_binmode ? v : (unsigned char)(((v / 10) << 4) | (v % 10));
+}
 
-/* px/py of position `pos` (0..59) at radius `rad` from the clock centre */
+/* --- drawing ----------------------------------------------------------------- */
+
 static int px_at(unsigned char pos, unsigned char rad) { return CX + (int)SIN64[pos] * rad / 64; }
 static int py_at(unsigned char pos, unsigned char rad) { return CY - (int)COS64[pos] * rad / 64; }
 
@@ -99,7 +120,7 @@ static unsigned char hourpos(unsigned char h, unsigned char m)
     return (unsigned char)(((h % 12) * 5 + m / 12) % 60);
 }
 
-static void draw_marks(void)
+static void draw_face(void)
 {
     unsigned char k, k2;
     for (k = 0; k < 60; k += 2) {                 /* rim: 30 segments */
@@ -110,24 +131,34 @@ static void draw_marks(void)
         line(px_at(k, R), py_at(k, R), px_at(k, TICK_IN), py_at(k, TICK_IN), 1);
 }
 
-static void draw_hands(unsigned char h, unsigned char m, unsigned char s,
-                       unsigned char pen_hm, unsigned char pen_s)
+/* draw (or erase, pen 0) the hands for h:m[:s]. withsec controls the second hand. */
+static void hands(unsigned char h, unsigned char m, unsigned char s,
+                  unsigned char withsec, unsigned char pen_hm, unsigned char pen_s)
 {
     hand(hourpos(h, m), L_HOUR, pen_hm);
     hand(m, L_MIN, pen_hm);
-    hand(s, L_SEC, pen_s);
+    if (withsec) hand(s, L_SEC, pen_s);
 }
 
 static char dig[9];
 static void put2(char *p, unsigned char v) { p[0] = '0' + v / 10; p[1] = '0' + v % 10; }
 static void draw_digital(unsigned char h, unsigned char m, unsigned char s)
 {
-    put2(dig, h); dig[2] = ':'; put2(dig + 3, m); dig[5] = ':'; put2(dig + 6, s); dig[8] = 0;
-    gb_fill(win_x + 8, win_y + 108, 12, 8, 0);
-    gb_text(win_x + 8, win_y + 108, dig);
+    unsigned char x = show_sec ? (win_x + 8) : (win_x + 9);
+    put2(dig, h); dig[2] = ':'; put2(dig + 3, m);
+    if (show_sec) { dig[5] = ':'; put2(dig + 6, s); dig[8] = 0; }
+    else dig[5] = 0;
+    gb_fill(win_x + 6, win_y + 106, 16, 8, 0);
+    gb_text(x, win_y + 106, dig);
 }
 
-/* full_draw: paint the whole window (initial / on_repaint). */
+static unsigned char cursor_over(void)
+{
+    unsigned char mx = gb_mx(), my = gb_my();
+    return (unsigned char)(mx >= win_x && mx < win_x + WIN_W && my >= win_y && my < win_y + WIN_H);
+}
+
+/* full_draw: paint the whole window (open / on_repaint / after a drag or toggle). */
 static void full_draw(void)
 {
     unsigned char h, m, s;
@@ -135,28 +166,149 @@ static void full_draw(void)
     h = bin(gb_hour); m = bin(gb_min); s = bin(gb_sec);
     gb_curhide();
     gb_window(win_x, win_y, WIN_W, WIN_H, "Clock");
-    draw_marks();
-    draw_hands(h, m, s, 1, 3);
+    draw_face();
+    hands(h, m, s, show_sec, 1, 3);
     draw_digital(h, m, s);
     gb_curshow();
-    ph = h; pm = m; ps = s; have_prev = 1;
+    ph = h; pm = m; ps = s; pshow = show_sec; have_prev = 1;
 }
 
-/* tick: advance the hands one step without clearing the face (erase old, repair the
-   rim/ticks, draw new) so only the hands appear to move. */
+/* tick: move the hands without touching the face. Only lifts the pointer if it is
+   actually over the window (else no per-tick cursor flicker). */
 static void tick(void)
 {
     unsigned char h = bin(gb_hour), m = bin(gb_min), s = bin(gb_sec);
-    gb_curhide();
-    if (have_prev) {
-        draw_hands(ph, pm, ps, 0, 0);             /* erase old hands (background) */
-        draw_marks();                              /* repair the rim/ticks they crossed */
-    }
-    draw_hands(h, m, s, 1, 3);                     /* white hands, red second */
+    unsigned char co = cursor_over();
+    if (co) gb_curhide();
+    if (have_prev) hands(ph, pm, ps, pshow, 0, 0);  /* erase old hands (background) */
+    hands(h, m, s, show_sec, 1, 3);                 /* white hands, red second */
     draw_digital(h, m, s);
-    gb_curshow();
-    ph = h; pm = m; ps = s; have_prev = 1;
+    if (co) gb_curshow();
+    ph = h; pm = m; ps = s; pshow = show_sec; have_prev = 1;
 }
+
+/* changed: has the displayed time advanced (minute, or second when shown)? */
+static unsigned char changed(void)
+{
+    if (!have_prev) return 1;
+    return show_sec ? (bin(gb_sec) != ps) : (bin(gb_min) != pm);
+}
+
+/* --- Options menu + dialogs (modal, self-polling like the other apps) --------- */
+
+static const unsigned char clk_menu[] = { 1, MENU_COL, 'O','p','t','i','o','n','s' };
+
+static void on_menu(void)
+{
+    if (gb_msg.type != GB_MSG_MENU) return;
+    if (gb_msg.p0 < MENU_COL || gb_msg.p0 >= MENU_END) return;
+    want_menu = 1;
+}
+
+static unsigned char popup(unsigned char x, unsigned char y,
+                           const char *const *labels, unsigned char n)
+{
+    unsigned char i, flags, row, sel = 0xFF;
+    modal = 1;
+    gb_curhide();
+    gb_fill(x, y, 22, n * 10 + 4, 1);
+    gb_frame(x, y, 22, n * 10 + 4, 2);
+    for (i = 0; i < n; i++) gb_textk(x + 1, y + 2 + i * 10, labels[i]);
+    gb_curshow();
+    for (;;) {
+        flags = gb_poll();
+        if (flags & GB_QUIT) break;
+        if (!(flags & GB_CLICK)) continue;
+        if (gb_my() >= y + 2 && gb_my() < y + 2 + n * 10 && gb_mx() >= x && gb_mx() < x + 22) {
+            row = (gb_my() - (y + 2)) / 10;
+            if (row < n) { sel = row; break; }
+        }
+        break;
+    }
+    modal = 0;
+    if (sel == 0xFF) while (gb_poll() & GB_QUIT) ;
+    gb_curhide();
+    gb_fill(x, y, 22, n * 10 + 4, 0);
+    gb_curshow();
+    return sel;
+}
+
+/* set_time_dialog: +/- on hours and minutes (triangle glyphs), OK applies to the
+   RTC. Returns 1 if the time was set. */
+static unsigned char hh, mm;
+static void draw_field(unsigned char x, unsigned char y, unsigned char v)
+{
+    char t[3];
+    gb_textk(x, y, GLYPH_TRI_UP);
+    put2(t, v); t[2] = 0;
+    gb_fill(x, y + 9, 4, 8, 1);
+    gb_textk(x, y + 9, t);
+    gb_textk(x, y + 18, GLYPH_TRI_DOWN);
+}
+static unsigned char set_time_dialog(void)
+{
+    unsigned char flags, done = 0, ok = 0;
+    unsigned char x = win_x + 3, y = win_y + 34, w = 22, h = 44;
+    unsigned char hx = x + 4, mx = x + 13, ay = y + 6;
+
+    gb_time();
+    hh = bin(gb_hour); mm = bin(gb_min);
+    modal = 1;
+    gb_curhide();
+    gb_fill(x, y, w, h, 1);
+    gb_frame(x, y, w, h, 2);
+    gb_textk(x + 1, y + 1, "Set time");
+    gb_textk(hx + 5, ay + 9, ":");
+    draw_field(hx, ay, hh);
+    draw_field(mx, ay, mm);
+    gb_textk(x + 7, y + h - 9, "OK");
+    gb_curshow();
+
+    while (!done) {
+        flags = gb_poll();
+        if (flags & GB_QUIT) { done = 1; break; }
+        if (!(flags & GB_CLICK)) continue;
+        {
+            unsigned char cx = gb_mx(), cy = gb_my();
+            if (cy >= ay && cy < ay + 8) {                 /* up arrows */
+                if (cx >= hx && cx < hx + 3) { hh = (hh + 1) % 24; draw_field(hx, ay, hh); }
+                else if (cx >= mx && cx < mx + 3) { mm = (mm + 1) % 60; draw_field(mx, ay, mm); }
+            } else if (cy >= ay + 18 && cy < ay + 26) {    /* down arrows */
+                if (cx >= hx && cx < hx + 3) { hh = (hh + 23) % 24; draw_field(hx, ay, hh); }
+                else if (cx >= mx && cx < mx + 3) { mm = (mm + 59) % 60; draw_field(mx, ay, mm); }
+            } else if (cy >= y + h - 9 && cx >= x + 7 && cx < x + 13) {  /* OK */
+                ok = 1; done = 1;
+            } else if (cy < y || cy >= y + h || cx < x || cx >= x + w) {
+                done = 1;                                   /* clicked away -> cancel */
+            }
+        }
+    }
+    modal = 0;
+    if (flags & GB_QUIT) while (gb_poll() & GB_QUIT) ;
+    gb_curhide();
+    gb_fill(x, y, w, h, 0);
+    gb_curshow();
+    if (ok) {
+        gb_time();                       /* refresh binmode before writing */
+        set_rtc(4, tobcd(hh));           /* hours  */
+        set_rtc(2, tobcd(mm));           /* minutes */
+        set_rtc(0, tobcd(0));            /* seconds */
+    }
+    return ok;
+}
+
+static void run_menu(void)
+{
+    const char *items[2];
+    unsigned char sel;
+    items[0] = "Set time";
+    items[1] = show_sec ? "Hide Seconds" : "Show Seconds";
+    sel = popup(MENU_COL, 8, items, 2);
+    if (sel == 0) { if (set_time_dialog()) have_prev = 0; full_draw(); }
+    else if (sel == 1) { show_sec ^= 1; full_draw(); }
+}
+
+/* --- WM callbacks ------------------------------------------------------------ */
 
 static void on_frame(void)
 {
@@ -164,29 +316,33 @@ static void on_frame(void)
 
     if (flags & GB_QUIT) { gb_wm_close(); return; }
 
-    gb_time();                                     /* update once the second changes */
-    if (!have_prev || bin(gb_sec) != ps) tick();
+    if (want_menu) { want_menu = 0; run_menu(); return; }
+
+    gb_time();
+    if (changed()) tick();
 
     if (!(flags & GB_CLICK)) return;
     mx = gb_mx(); my = gb_my();
     if (my >= win_y && my < win_y + TITLE_H) {
-        if (mx >= win_x && mx < win_x + 5) { gb_wm_close(); return; }   /* close gadget */
-        if (mx >= win_x + 5 && mx < win_x + WIN_W) {                    /* drag */
+        if (mx >= win_x && mx < win_x + 5) { gb_wm_close(); return; }
+        if (mx >= win_x + 5 && mx < win_x + WIN_W) {
             if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
                 gb_wm_setpos(win_x, win_y);
                 gb_restore_parent();
+                full_draw();                       /* redraw the face at the new spot */
             }
         }
     }
 }
 
 static const gb_win_t clkwin = {
-    DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, full_draw, 0, 0
+    DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, full_draw, on_menu, clk_menu
 };
 
 void main(void)
 {
-    win_x = DEF_X; win_y = DEF_Y; have_prev = 0;
+    win_x = DEF_X; win_y = DEF_Y;
+    show_sec = 0; have_prev = 0; want_menu = 0; modal = 0;
     gb_wm_add(&clkwin);
     full_draw();
 }

--- a/apps/clock/main.c
+++ b/apps/clock/main.c
@@ -211,9 +211,9 @@ static unsigned char popup(unsigned char x, unsigned char y,
     unsigned char i, flags, row, sel = 0xFF;
     modal = 1;
     gb_curhide();
-    gb_fill(x, y, 22, n * 10 + 4, 1);
-    gb_frame(x, y, 22, n * 10 + 4, 2);
-    for (i = 0; i < n; i++) gb_textk(x + 1, y + 2 + i * 10, labels[i]);
+    gb_fill(x, y, 22, n * 10 + 4, 1);          /* white, no frame: a seamless drop from
+                                                  the (white) top bar - black ink only */
+    for (i = 0; i < n; i++) gb_textbw(x + 1, y + 2 + i * 10, labels[i]);
     gb_curshow();
     for (;;) {
         flags = gb_poll();
@@ -239,11 +239,11 @@ static unsigned char hh, mm;
 static void draw_field(unsigned char x, unsigned char y, unsigned char v)
 {
     char t[3];
-    gb_textk(x, y, GLYPH_TRI_UP);
+    gb_textbw(x, y, GLYPH_TRI_UP);
     put2(t, v); t[2] = 0;
     gb_fill(x, y + 9, 4, 8, 1);
-    gb_textk(x, y + 9, t);
-    gb_textk(x, y + 18, GLYPH_TRI_DOWN);
+    gb_textbw(x, y + 9, t);
+    gb_textbw(x, y + 18, GLYPH_TRI_DOWN);
 }
 static unsigned char set_time_dialog(void)
 {
@@ -257,11 +257,11 @@ static unsigned char set_time_dialog(void)
     gb_curhide();
     gb_fill(x, y, w, h, 1);
     gb_frame(x, y, w, h, 2);
-    gb_textk(x + 1, y + 1, "Set time");
-    gb_textk(hx + 5, ay + 9, ":");
+    gb_textbw(x + 1, y + 1, "Set time");
+    gb_textbw(hx + 5, ay + 9, ":");
     draw_field(hx, ay, hh);
     draw_field(mx, ay, mm);
-    gb_textk(x + 7, y + h - 9, "OK");
+    gb_textbw(x + 7, y + h - 9, "OK");
     gb_curshow();
 
     while (!done) {

--- a/apps/clock/main.c
+++ b/apps/clock/main.c
@@ -1,0 +1,192 @@
+/* clock - the GEOBENCH analog clock (C), a co-resident window (#72).
+ *
+ * An xclock-style analog face: a round rim, 12 hour ticks, and hour/minute/second
+ * hands placed from a fixed-point sin/cos table, with a digital HH:MM:SS readout
+ * below. The kernel exposes the time (gb_time -> gb_hour/min/sec) and a pixel-coord
+ * line primitive (gb_line); the hands are drawn with those.
+ *
+ * It updates once a second while focused (the cooperative WM only calls the focused
+ * window's on_frame). To avoid flicker the face is not cleared each tick: the old
+ * hands are erased (redrawn in the background pen), the rim/ticks repaired, and the
+ * new hands drawn. Drag the title bar to move it; the close gadget / ESC closes it.
+ */
+#include "gb.h"
+
+#define DEF_X    24           /* initial window position (draggable) */
+#define DEF_Y    20
+#define WIN_W    28           /* bytes (112 px) */
+#define WIN_H    128          /* px */
+#define TITLE_H  14
+
+#define R        44           /* face radius (px) */
+#define TICK_IN  37           /* hour-tick inner radius */
+#define L_HOUR   24           /* hand lengths */
+#define L_MIN    36
+#define L_SEC    42
+
+/* live (draggable) clock centre, in screen pixels */
+#define CX       (win_x * 4 + WIN_W * 2)
+#define CY       (win_y + 60)
+
+static unsigned char win_x = DEF_X, win_y = DEF_Y;
+static unsigned char ph, pm, ps, have_prev;   /* previous h/m/s, for erasing hands */
+
+/* sin/cos * 64 for the 60 clock positions (0 = 12 o'clock, clockwise, 6 deg each) */
+static const signed char SIN64[60] = {
+      0,  7, 13, 20, 26, 32, 38, 43, 48, 52, 55, 58,
+     61, 63, 64, 64, 64, 63, 61, 58, 55, 52, 48, 43,
+     38, 32, 26, 20, 13,  7,  0, -7,-13,-20,-26,-32,
+    -38,-43,-48,-52,-55,-58,-61,-63,-64,-64,-64,-63,
+    -61,-58,-55,-52,-48,-43,-38,-32,-26,-20,-13, -7
+};
+static const signed char COS64[60] = {
+     64, 64, 63, 61, 58, 55, 52, 48, 43, 38, 32, 26,
+     20, 13,  7,  0, -7,-13,-20,-26,-32,-38,-43,-48,
+    -52,-55,-58,-61,-63,-64,-64,-64,-63,-61,-58,-55,
+    -52,-48,-43,-38,-32,-26,-20,-13, -7,  0,  7, 13,
+     20, 26, 32, 38, 43, 48, 52, 55, 58, 61, 63, 64
+};
+
+/* The kernel exposes no line primitive (to stay lean), so the clock draws its hands
+   by calling the CPC firmware graphics VDU directly: GRA_SET_PEN (&BBDE), GRA_MOVE_
+   ABS (&BBC0), GRA_LINE_ABS (&BBF6). Coords are firmware graphics units (0-639 x
+   0-399 from the bottom-left). The jumpblock is always mapped, so an app can call it;
+   the screen (&C000+) is untouched by our #4000 bank. */
+static volatile unsigned int fx0, fy0, fx1, fy1;
+static volatile unsigned char fpen;
+static void fw_line(void) __naked
+{
+__asm
+    ld   a, (_fpen)
+    call 0xBBDE          ; GRA_SET_PEN  (A = pen)
+    ld   de, (_fx0)
+    ld   hl, (_fy0)
+    call 0xBBC0          ; GRA_MOVE_ABS (DE = x, HL = y)
+    ld   de, (_fx1)
+    ld   hl, (_fy1)
+    call 0xBBF6          ; GRA_LINE_ABS (DE = x, HL = y)
+    ret
+__endasm;
+}
+
+/* line: pixel coords (x 0-319, y 0-199 from top-left) -> firmware coords, then draw. */
+static void line(int x0, int y0, int x1, int y1, unsigned char pen)
+{
+    fx0 = (unsigned int)(x0 * 2); fy0 = (unsigned int)((199 - y0) * 2);
+    fx1 = (unsigned int)(x1 * 2); fy1 = (unsigned int)((199 - y1) * 2);
+    fpen = pen;
+    fw_line();
+}
+
+/* the kernel hands us raw RTC registers; convert BCD -> binary unless it's already
+   binary (software clock, or an RTC running in binary mode). */
+static unsigned char bin(unsigned char v)
+{
+    return gb_binmode ? v : (unsigned char)((v >> 4) * 10 + (v & 15));
+}
+
+/* px/py of position `pos` (0..59) at radius `rad` from the clock centre */
+static int px_at(unsigned char pos, unsigned char rad) { return CX + (int)SIN64[pos] * rad / 64; }
+static int py_at(unsigned char pos, unsigned char rad) { return CY - (int)COS64[pos] * rad / 64; }
+
+static void hand(unsigned char pos, unsigned char len, unsigned char pen)
+{
+    line(CX, CY, px_at(pos, len), py_at(pos, len), pen);
+}
+
+static unsigned char hourpos(unsigned char h, unsigned char m)
+{
+    return (unsigned char)(((h % 12) * 5 + m / 12) % 60);
+}
+
+static void draw_marks(void)
+{
+    unsigned char k, k2;
+    for (k = 0; k < 60; k += 2) {                 /* rim: 30 segments */
+        k2 = (unsigned char)((k + 2) % 60);
+        line(px_at(k, R), py_at(k, R), px_at(k2, R), py_at(k2, R), 1);
+    }
+    for (k = 0; k < 60; k += 5)                    /* 12 hour ticks */
+        line(px_at(k, R), py_at(k, R), px_at(k, TICK_IN), py_at(k, TICK_IN), 1);
+}
+
+static void draw_hands(unsigned char h, unsigned char m, unsigned char s,
+                       unsigned char pen_hm, unsigned char pen_s)
+{
+    hand(hourpos(h, m), L_HOUR, pen_hm);
+    hand(m, L_MIN, pen_hm);
+    hand(s, L_SEC, pen_s);
+}
+
+static char dig[9];
+static void put2(char *p, unsigned char v) { p[0] = '0' + v / 10; p[1] = '0' + v % 10; }
+static void draw_digital(unsigned char h, unsigned char m, unsigned char s)
+{
+    put2(dig, h); dig[2] = ':'; put2(dig + 3, m); dig[5] = ':'; put2(dig + 6, s); dig[8] = 0;
+    gb_fill(win_x + 8, win_y + 108, 12, 8, 0);
+    gb_text(win_x + 8, win_y + 108, dig);
+}
+
+/* full_draw: paint the whole window (initial / on_repaint). */
+static void full_draw(void)
+{
+    unsigned char h, m, s;
+    gb_time();
+    h = bin(gb_hour); m = bin(gb_min); s = bin(gb_sec);
+    gb_curhide();
+    gb_window(win_x, win_y, WIN_W, WIN_H, "Clock");
+    draw_marks();
+    draw_hands(h, m, s, 1, 3);
+    draw_digital(h, m, s);
+    gb_curshow();
+    ph = h; pm = m; ps = s; have_prev = 1;
+}
+
+/* tick: advance the hands one step without clearing the face (erase old, repair the
+   rim/ticks, draw new) so only the hands appear to move. */
+static void tick(void)
+{
+    unsigned char h = bin(gb_hour), m = bin(gb_min), s = bin(gb_sec);
+    gb_curhide();
+    if (have_prev) {
+        draw_hands(ph, pm, ps, 0, 0);             /* erase old hands (background) */
+        draw_marks();                              /* repair the rim/ticks they crossed */
+    }
+    draw_hands(h, m, s, 1, 3);                     /* white hands, red second */
+    draw_digital(h, m, s);
+    gb_curshow();
+    ph = h; pm = m; ps = s; have_prev = 1;
+}
+
+static void on_frame(void)
+{
+    unsigned char flags = gb_flags(), mx, my;
+
+    if (flags & GB_QUIT) { gb_wm_close(); return; }
+
+    gb_time();                                     /* update once the second changes */
+    if (!have_prev || bin(gb_sec) != ps) tick();
+
+    if (!(flags & GB_CLICK)) return;
+    mx = gb_mx(); my = gb_my();
+    if (my >= win_y && my < win_y + TITLE_H) {
+        if (mx >= win_x && mx < win_x + 5) { gb_wm_close(); return; }   /* close gadget */
+        if (mx >= win_x + 5 && mx < win_x + WIN_W) {                    /* drag */
+            if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
+                gb_wm_setpos(win_x, win_y);
+                gb_restore_parent();
+            }
+        }
+    }
+}
+
+static const gb_win_t clkwin = {
+    DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, full_draw, 0, 0
+};
+
+void main(void)
+{
+    win_x = DEF_X; win_y = DEF_Y; have_prev = 0;
+    gb_wm_add(&clkwin);
+    full_draw();
+}

--- a/apps/desktop/main.c
+++ b/apps/desktop/main.c
@@ -204,8 +204,7 @@ static void on_frame(void)
             gb_set_drive(icon);                              /* icon idx 0/1/2 = C/A/B   */
             gb_wm_open("FILEMGR APP");
         }
-        else if (icon == IDX_CLOCK) gb_run("CHELLO  APP");   /* modal; kernel repaints
-                                                                the windows on return */
+        else if (icon == IDX_CLOCK) gb_wm_open("CLOCK   APP"); /* analog clock window (#72) */
         dc_timer = 0;
         held_prev = 0;
     } else {                               /* first click: arm + start drag */

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -2474,25 +2474,13 @@ fs_secbuf       equ   #1800            ; IDE sector buffer / aliased AMSDOS writ
 fsam_buf        equ   #1A00            ; floppy whole-directory buffer
                                                 ; The packaging incbins below are
                                                 ; never loaded at runtime, only read
-                                                ; by `save`. They are ORG'd into low
-                                                ; memory (below the #8000 kernel) so
-                                                ; the growing payload (now incl.
-                                                ; ICONED) stays within the 64K image.
-                org   #0100
-dtp_img         incbin "../build/DESKTOP.RAW"   ; packaged on the disk as DESKTOP.APP
-dtp_imgend
-app_img         incbin "../build/FILEMGR.RAW"   ; packaged on the disk as FILEMGR.APP
-app_imgend
-vwr_img         incbin "../build/VIEWER.RAW"    ; packaged on the disk as VIEWER.APP
-vwr_imgend
-npd_img         incbin "../build/NOTEPAD.RAW"   ; packaged on the disk as NOTEPAD.APP
-npd_imgend
-ied_img         incbin "../build/ICONED.RAW"    ; packaged on the disk as ICONED.APP
-ied_imgend
-clk_img         incbin "../build/CLOCK.RAW"     ; packaged on the disk as CLOCK.APP
-clk_imgend
-chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.APP
-chl_imgend
+                                                ; by `save`. The payload outgrew a
+                                                ; single free region, so it is split:
+                                                ; the modules/fonts/assets sit ABOVE
+                                                ; the kernel, the (larger) app binaries
+                                                ; in low memory at #0100 - both within
+                                                ; the 64K image and clear of #8000..
+                                                ; kern_end (GBKERN.BIN).
 cfg_img         incbin "../build/GBCFG.RAW"     ; config-parser C module, as GBCFG.BIN
 cfg_imgend
 fat_img         incbin "../build/GBFAT.RAW"     ; FAT16/IDE write module, as GBFAT.BIN
@@ -2507,6 +2495,21 @@ wel_img         incbin "../assets/WELCOME.TXT"  ; a sample text file to open in 
 wel_imgend
                 include "../lib/cursor_data.asm" ; cur_spr_data..cur_spr_end -> DEFAULT.SPR
                 include "../lib/cursor_hand_data.asm" ; cur_hand_data..end -> HAND.SPR
+                org   #0100                     ; --- app binaries, low region ---
+dtp_img         incbin "../build/DESKTOP.RAW"   ; packaged on the disk as DESKTOP.APP
+dtp_imgend
+app_img         incbin "../build/FILEMGR.RAW"   ; packaged on the disk as FILEMGR.APP
+app_imgend
+vwr_img         incbin "../build/VIEWER.RAW"    ; packaged on the disk as VIEWER.APP
+vwr_imgend
+npd_img         incbin "../build/NOTEPAD.RAW"   ; packaged on the disk as NOTEPAD.APP
+npd_imgend
+ied_img         incbin "../build/ICONED.RAW"    ; packaged on the disk as ICONED.APP
+ied_imgend
+clk_img         incbin "../build/CLOCK.RAW"     ; packaged on the disk as CLOCK.APP
+clk_imgend
+chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.APP
+chl_imgend
                 save  "GBKERN.BIN",GB_KERNEL,kern_end-GB_KERNEL,DSK,"build/gbkern.dsk"
                 save  "DESKTOP.APP",dtp_img,dtp_imgend-dtp_img,DSK,"build/gbkern.dsk"
                 save  "FILEMGR.APP",app_img,app_imgend-app_img,DSK,"build/gbkern.dsk"

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -26,6 +26,11 @@ KCFG_FONTNAME   equ   #120D        ; 11-byte 8.3 font filename, built by the mod
 KCFG_MEMKB      equ   #1218        ; word: total RAM in KB (kernel -> module)
 KCFG_MEMSTR     equ   #121A        ; "<decimal>K" top-bar string (module -> kernel)
 KCFG_CURSORNAME equ   #1221        ; 11-byte 8.3 cursor filename (CURSOR=), built by module
+; CLOCK.APP support (#72): a tiny time read-out (kept minimal - the BCD->binary
+; conversion lives in the C app; the clock draws its hands by calling the firmware
+; graphics directly, so no resident line primitive is needed).
+GB_TIME_BUF     equ   #1240        ; raw time: +0 hours(&3F), +1 min, +2 sec, +3 binmode
+                                    ; (binmode 0 = BCD regs, nonzero = already binary)
 
 ; Callback API (issue #32) - kernel->app event delivery, state in low RAM so it
 ; costs no resident image bytes (low RAM stays main RAM under banking).
@@ -122,6 +127,7 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_get_drive            ; GB_GETDRIVE    #8084
                 jp    k_file_copy            ; GB_FSCOPY      #8087
                 jp    k_wm_launch_as         ; GB_WMLAUNCHAS  #808A (HL = app name)
+                jp    k_time                 ; GB_TIME        #808D (-> GB_TIME_BUF h,m,s)
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -2308,6 +2314,39 @@ ckc_loop
                 xor   a
                 ret
 
+; k_time (GB_TIME #808D): current time -> GB_TIME_BUF (raw h, m, s + binmode). From
+; the Dallas RTC (regs 4/2/0; binmode = reg B bit2) or the software clock (binary).
+; The app converts BCD->binary when binmode is 0. Kept tiny (#72).
+k_time
+                ld    a,(have_rtc)
+                or    a
+                jr    z,kt_soft
+                ld    a,#0B
+                call  read_rtc_reg
+                and   #04
+                ld    (GB_TIME_BUF+3),a       ; binmode (0 = BCD)
+                ld    a,#04
+                call  read_rtc_reg
+                and   #3F
+                ld    (GB_TIME_BUF+0),a
+                ld    a,#02
+                call  read_rtc_reg
+                ld    (GB_TIME_BUF+1),a
+                ld    a,#00
+                call  read_rtc_reg
+                ld    (GB_TIME_BUF+2),a
+                ret
+kt_soft
+                ld    a,(sw_hour)
+                ld    (GB_TIME_BUF+0),a
+                ld    a,(sw_min)
+                ld    (GB_TIME_BUF+1),a
+                ld    a,(sw_sec)
+                ld    (GB_TIME_BUF+2),a
+                ld    a,4                       ; nonzero -> already binary, no convert
+                ld    (GB_TIME_BUF+3),a
+                ret
+
 ; (fmt_mem migrated to the GBCFG C module: gb_fmt_mem in kernel/kc/kcfg.c. The
 ; kernel leaves the KB count in KCFG_MEMKB before cfg_boot; the module writes the
 ; "<decimal>K" string to KCFG_MEMSTR, which draw_topbar renders.)
@@ -2450,6 +2489,8 @@ npd_img         incbin "../build/NOTEPAD.RAW"   ; packaged on the disk as NOTEPA
 npd_imgend
 ied_img         incbin "../build/ICONED.RAW"    ; packaged on the disk as ICONED.APP
 ied_imgend
+clk_img         incbin "../build/CLOCK.RAW"     ; packaged on the disk as CLOCK.APP
+clk_imgend
 chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.APP
 chl_imgend
 cfg_img         incbin "../build/GBCFG.RAW"     ; config-parser C module, as GBCFG.BIN
@@ -2472,6 +2513,7 @@ wel_imgend
                 save  "VIEWER.APP",vwr_img,vwr_imgend-vwr_img,DSK,"build/gbkern.dsk"
                 save  "NOTEPAD.APP",npd_img,npd_imgend-npd_img,DSK,"build/gbkern.dsk"
                 save  "ICONED.APP",ied_img,ied_imgend-ied_img,DSK,"build/gbkern.dsk"
+                save  "CLOCK.APP",clk_img,clk_imgend-clk_img,DSK,"build/gbkern.dsk"
                 save  "CHELLO.APP",chl_img,chl_imgend-chl_img,DSK,"build/gbkern.dsk"
                 save  "GBCFG.BIN",cfg_img,cfg_imgend-cfg_img,DSK,"build/gbkern.dsk"
                 save  "GBFAT.BIN",fat_img,fat_imgend-fat_img,DSK,"build/gbkern.dsk"

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -131,6 +131,15 @@ void gb_wm_launch(void);              /* open current dir entry co-resident (+ a
  * kernel's app_for_ext now lives in C (#70). */
 void gb_wm_launch_as(const char *app);
 
+/* Clock read-out (#72). gb_time() refreshes the time; read gb_hour/min/sec - RAW
+ * values, BCD unless gb_binmode is nonzero (convert in the app, to keep the kernel
+ * lean). CLOCK.APP draws its hands by calling the firmware graphics directly. */
+void gb_time(void);
+#define gb_hour    (*(volatile unsigned char *)0x1240)
+#define gb_min     (*(volatile unsigned char *)0x1241)
+#define gb_sec     (*(volatile unsigned char *)0x1242)
+#define gb_binmode (*(volatile unsigned char *)0x1243)
+
 /* Directory navigation (issue #54). gb_isdir reports whether the entry just
  * returned by gb_dir1/gb_dirn is a directory; gb_chdir descends into the
  * positioned entry (re-list afterwards to show it in the same window); gb_back

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -43,6 +43,7 @@
         .globl  _gb_wm_setpos
         .globl  _gb_wm_launch
         .globl  _gb_wm_launch_as
+        .globl  _gb_time
         .globl  _gb_isdir
         .globl  _gb_chdir
         .globl  _gb_back
@@ -283,6 +284,9 @@ _gb_wm_launch:
 ;; co-resident window with the current dir entry as its file arg (#70).
 _gb_wm_launch_as:
         jp      0x808A          ; GB_WMLAUNCHAS
+;; void gb_time(void);   refresh GB_TIME_BUF (#1240: raw h, m, s, binmode) from the clock
+_gb_time:
+        jp      0x808D          ; GB_TIME
 ;; unsigned char gb_isdir(void);   1 if the last dir entry is a directory, else 0
 _gb_isdir:
         jp      0x806C          ; GB_ISDIR

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -25,6 +25,7 @@ tools/build_capp.sh apps/filemgr build/FILEMGR.RAW # FILEMGR (C/SDCC) -> build/F
 tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VIEWER.RAW
 tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD (C/SDCC) -> build/NOTEPAD.RAW
 tools/build_capp.sh apps/iconed build/ICONED.RAW   # ICONED (C/SDCC) -> build/ICONED.RAW
+tools/build_capp.sh apps/clock  build/CLOCK.RAW    # CLOCK  (C/SDCC) -> build/CLOCK.RAW
 tools/build_capp.sh apps/chello build/CHELLO.RAW   # C app (SDCC) -> build/CHELLO.RAW
 tools/build_cfgmod.sh build/GBCFG.RAW              # config-parser C kernel module -> build/GBCFG.RAW
 tools/build_fatmod.sh                              # FAT16/IDE write module -> build/GBFAT.RAW

--- a/tools/deploy_ide.sh
+++ b/tools/deploy_ide.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "$STAGE"' EXIT
 # kernel: headered
 python3 tools/amsdos_header.py build/GBKERN.RAW "$STAGE/GBKERN.BIN" GBKERN BIN 0x8000
 # launchable apps: headerless raw, .APP
-for a in DESKTOP FILEMGR VIEWER NOTEPAD ICONED CHELLO; do
+for a in DESKTOP FILEMGR VIEWER NOTEPAD ICONED CLOCK CHELLO; do
     cp "build/$a.RAW" "$STAGE/$a.APP"
 done
 # kernel modules: headerless raw, .BIN


### PR DESCRIPTION
Closes #72.

Replaces the throwaway demo behind the desktop **Clock** icon with a real **CLOCK.APP** — an xclock-style analog clock as a co-resident WM window.

- Round rim + 12 hour ticks, white hour/minute hands, red second hand (from a fixed-point sin/cos table), digital `HH:MM:SS` read-out.
- Defaults to **hours+minutes, refreshing once a minute**; an **Options** top-bar menu toggles **Show Seconds** (per-second refresh) and offers **Set time** (a +/- dialog that writes the Dallas RTC directly from the app).
- Flicker-free: all hands stay inside the tick ring so erasing a hand never touches the face (no rim repaint), and the pointer is only lifted when it actually sits over the window.
- Options dropdown styled like the top bar (white background, black ink).

### Kernel / build
- New minimal **`gb_time`** (#808D): raw h/m/s + binmode in low RAM; BCD→binary done in the app. No resident line primitive — the clock calls the firmware graphics VDU directly for the hands. Resident headroom stays ~137 B.
- Desktop: Clock icon → `gb_wm_open("CLOCK   APP")`.
- The packaging incbins are split across both free image regions (CLOCK pushed the payload past 32 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
