### PR TITLE
Reclaim resident space: cross-drive copy -> File Manager

### DIFF
--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -344,8 +344,15 @@ static void sb_click(unsigned char my)
 static void on_event(void)
 {
     if (gb_msg.type == GB_MSG_DROP) {     /* a file dropped here from another window (#65) */
-        gb_set_drive(my_drive);           /* copy it onto THIS window's drive, then re-list */
-        gb_file_copy();
+        unsigned int n;                   /* copy it onto THIS window's drive (#74) */
+        gb_set_drive(my_drive);
+        gb_copy_begin();                  /* switch to the drag source drive/dir */
+        gb_set_name(gb_dragname);
+        n = gb_fs_load(gb_copybuf, GB_COPYMAX);
+        gb_set_drive(my_drive);           /* back to this window's drive */
+        gb_set_name(gb_dragname);
+        gb_fs_save(gb_copybuf, n);        /* lands in the root */
+        gb_copy_end();                    /* restore this window's drive/dir */
         relist();
         return;
     }

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -127,10 +127,11 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_drive_poll           ; GB_DRIVES      #807E
                 jp    fs_set_drive           ; GB_SETDRIVE    #8081 (A = drive)
                 jp    k_get_drive            ; GB_GETDRIVE    #8084
-                jp    k_file_copy            ; GB_FSCOPY      #8087
+                jp    k_copy_begin           ; GB_COPYBEGIN   #8087 (-> drag source ctx)
                 jp    k_wm_launch_as         ; GB_WMLAUNCHAS  #808A (HL = app name)
                 jp    k_time                 ; GB_TIME        #808D (-> GB_TIME_BUF h,m,s)
                 jp    k_exit                 ; GB_EXIT        #8090 (leave -> AMSDOS)
+                jp    k_copy_end             ; GB_COPYEND     #8093 (restore target ctx)
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -1185,67 +1186,39 @@ k_get_drive
                 ld    a,(fs_cur_drive)
                 ret
 
-; k_file_copy (GB_FSCOPY, #65 phase 3): copy the dragged file (WM_DRAGNAME) from the
-; source drive/dir captured at drag start (WM_DRAGDRV/WM_DRAGDIR) to the CURRENT
-; (target) drive - landing in that drive's root. Loads into the staging buffer
-; (<= GBFAT_MAX) then saves. The caller (the drop target window) sets the active
-; drive first. CF set = copied. Restores the target drive/dir so the caller relists.
-k_file_copy
-                ld    a,(fs_cur_drive)        ; remember the target context to restore
-                ld    (fc_tdrv),a
+; Cross-drive copy (#65 phase 3): the orchestration moved into the File Manager (C)
+; to reclaim resident space (#74). The kernel just flips the active drive+dir context
+; between the dragged file's source (captured at drag start) and the drop target; the
+; app does the load->save itself through the shared staging buffer (GBFAT_DATA).
+;
+; k_copy_begin (GB_COPYBEGIN): save the current (target) drive+dir, then switch to the
+; source drive+dir, so the caller can load the dragged file. Pairs with k_copy_end.
+k_copy_begin
+                ld    a,(fs_cur_drive)        ; save the caller's (target) context
+                ld    (cb_tdrv),a
                 ld    hl,fs_dir_clus
-                ld    de,fc_tdir
+                ld    de,cb_tdir
                 ld    bc,4
                 ldir
-                ld    a,(WM_DRAGDRV)         ; --- switch to the source, load the file ---
+                ld    a,(WM_DRAGDRV)         ; switch to the drag source drive + dir
                 call  fs_set_drive
                 ld    hl,WM_DRAGDIR
                 ld    de,fs_dir_clus
                 ld    bc,4
                 ldir
-                ld    hl,WM_DRAGNAME
-                ld    de,fs_req_name
-                call  copy11
-                ld    hl,GBFAT_MAX
-                ld    (fs_load_max),hl
-                ld    hl,GBFAT_DATA
-                ld    (fs_load_dst),hl
-                di
-                call  fs_load_file           ; -> BC = bytes loaded
-                ei
-                jr    nc,fc_fail              ; source file not found
-                ld    (fc_len),bc
-                ld    a,(fc_tdrv)            ; --- switch to the target, save the file ---
-                call  fs_set_drive
-                ld    hl,WM_DRAGNAME
-                ld    de,fs_req_name
-                call  copy11
-                ld    hl,GBFAT_DATA
-                ld    (fs_save_src),hl
-                ld    hl,(fc_len)
-                ld    (fs_save_len),hl
-                di
-                call  fs_save_file           ; CF = saved
-                ei
-                push  af
-                call  fc_restore
-                pop   af
                 ret
-fc_fail
-                call  fc_restore
-                or    a
-                ret
-fc_restore                                    ; active drive + dir = the target's again
-                ld    a,(fc_tdrv)
+; k_copy_end (GB_COPYEND): restore the saved (target) drive+dir, so the caller can
+; re-list its own directory.
+k_copy_end
+                ld    a,(cb_tdrv)
                 call  fs_set_drive
-                ld    hl,fc_tdir
+                ld    hl,cb_tdir
                 ld    de,fs_dir_clus
                 ld    bc,4
                 ldir
                 ret
-fc_tdrv         db    0
-fc_tdir         defs  4
-fc_len          defw  0
+cb_tdrv         db    0
+cb_tdir         defs  4
 
 ; k_fs_delete (GB_FSDELETE, #62): HL = 11-byte 8.3 name in the caller page. Delete
 ; that file from the current directory (free clusters + clear the dir entry) via

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -186,9 +186,19 @@ unsigned char gb_drives(void);
 void gb_set_drive(unsigned char d);
 unsigned char gb_get_drive(void);
 
-/* gb_file_copy: copy the file currently being dragged (its name + source drive and
- * directory were captured by gb_drag_start) into the *current* drive's root. Called
- * by a drop-target window's on_event on GB_MSG_DROP to receive a cross-drive
- * drag-and-drop. Returns 1 if copied, 0 on failure (#65 phase 3). */
-unsigned char gb_file_copy(void);
+/* Cross-drive copy (#65 phase 3; orchestration moved app-side in #74). On a
+ * GB_MSG_DROP, the drop-target window copies the dragged file (name = gb_dragname)
+ * from its source drive/dir to its own drive's root, via the shared staging buffer:
+ *   gb_copy_begin();                          // switch to the drag source
+ *   gb_set_name(gb_dragname);
+ *   n = gb_fs_load(gb_copybuf, GB_COPYMAX);
+ *   gb_set_drive(my_drive);                    // back to this window's drive
+ *   gb_set_name(gb_dragname);
+ *   gb_fs_save(gb_copybuf, n);                 // lands in the root
+ *   gb_copy_end();                             // restore this window's drive/dir
+ * gb_copybuf is the kernel's FAT staging area (low RAM), so no app buffer is needed. */
+void gb_copy_begin(void);
+void gb_copy_end(void);
+#define gb_copybuf ((char *)0x2200)
+#define GB_COPYMAX 0x1C00
 #endif /* GB_H */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -54,7 +54,8 @@
         .globl  _gb_drives
         .globl  _gb_set_drive
         .globl  _gb_get_drive
-        .globl  _gb_file_copy
+        .globl  _gb_copy_begin
+        .globl  _gb_copy_end
 
         .area   _BSS
 sv_ret: .ds     2               ; saved return addr for the multi-pop wrappers
@@ -335,11 +336,10 @@ _gb_set_drive:
 _gb_get_drive:
         jp      0x8084          ; GB_GETDRIVE
 
-;; unsigned char gb_file_copy(void);  copy the dragged file (captured at drag start)
-;; from its source drive/dir into the current drive's root. Returns 1 if copied.
-_gb_file_copy:
-        call    0x8087          ; GB_FSCOPY -> CF = copied
-        ld      a, #0
-        ret     nc
-        inc     a
-        ret
+;; void gb_copy_begin(void);  switch the active drive+dir to the dragged file's source
+;; (captured at drag start), saving the caller's (target) context. Pair with gb_copy_end.
+_gb_copy_begin:
+        jp      0x8087          ; GB_COPYBEGIN
+;; void gb_copy_end(void);  restore the caller's (target) drive+dir saved by gb_copy_begin
+_gb_copy_end:
+        jp      0x8093          ; GB_COPYEND


### PR DESCRIPTION
Reclaims resident kernel space after the System menu (Exit-to-DOS) pulled headroom down to ~112 B.

Moves the **cross-drive copy** orchestration out of the resident kernel (the 104 B `k_file_copy`) into the **File Manager** (C) — the same kernel→app migration pattern that funded the `.APP` model:

- Kernel keeps only a tiny context pair: **`GB_COPYBEGIN`** switches the active drive+dir to the dragged file's source (captured at drag start), **`GB_COPYEND`** restores the target's.
- The app does the load→save itself through the shared `#2200` staging buffer (`gb_copybuf` / `GB_COPYMAX`), so no app buffer is needed.
- Behaviour unchanged — verified live: `C:` → `A:` copy works.

**Resident headroom: 112 B → 185 B** (−73 B kernel), comfortably back above the deep-path safety floor.

libgb: `gb_file_copy()` replaced by `gb_copy_begin()` / `gb_copy_end()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
