### PR TITLE
Resizeable windows (#81)

### DIFF
--- a/apps/clock/main.c
+++ b/apps/clock/main.c
@@ -16,26 +16,43 @@
 
 #define DEF_X    24
 #define DEF_Y    20
-#define WIN_W    28           /* bytes (112 px) */
-#define WIN_H    122          /* px */
+#define DEF_W    28           /* default size, bytes (112 px); resizeable (#81) */
+#define DEF_H    122          /* px */
+#define MIN_W    22
+#define MIN_H    96
 #define TITLE_H  14
-
-#define R        44           /* face radius (px) */
-#define TICK_IN  37           /* hour-tick inner radius; hands stay inside this */
-#define L_HOUR   20
-#define L_MIN    30
-#define L_SEC    36
 
 #define MENU_COL 10           /* "Options" title column in the top bar */
 #define MENU_END 22
 
-#define CX       (win_x * 4 + WIN_W * 2)     /* live clock centre, screen pixels */
-#define CY       (win_y + 58)
-
 static unsigned char win_x = DEF_X, win_y = DEF_Y;
+static unsigned char win_w = DEF_W, win_h = DEF_H;  /* live size (resizeable) */
 static unsigned char show_sec;               /* 0 = H:M (minute refresh), 1 = +seconds */
 static unsigned char ph, pm, ps, pshow, have_prev;  /* previous h/m/s + show state */
 static unsigned char want_menu, modal;
+
+/* face geometry, recomputed from the live window rect on every full draw (#81): the
+   analog face scales to whatever the window has been resized to. */
+static int cx, cy;                           /* face centre, screen pixels */
+static unsigned char rr, tick_in, l_hour, l_min, l_sec;  /* radius + hand lengths */
+static unsigned char dig_y;                  /* digital read-out row (px) */
+
+static void relayout(void)
+{
+    unsigned char top   = (unsigned char)(win_y + TITLE_H);
+    unsigned char dy    = (unsigned char)(win_y + win_h - 16);   /* read-out row */
+    unsigned char avail = (unsigned char)(dy - 2 - top);         /* face height band */
+    unsigned char rw    = (unsigned char)(win_w * 2 - 6);        /* radius bound: width  */
+    unsigned char rh    = (unsigned char)(avail / 2 - 2);        /* radius bound: height */
+    rr = (rw < rh) ? rw : rh;
+    cx = win_x * 4 + win_w * 2;
+    cy = top + avail / 2;
+    tick_in = (unsigned char)((unsigned int)rr * 37 / 44);       /* keep proportions */
+    l_hour  = (unsigned char)((unsigned int)rr * 20 / 44);
+    l_min   = (unsigned char)((unsigned int)rr * 30 / 44);
+    l_sec   = (unsigned char)((unsigned int)rr * 36 / 44);
+    dig_y = dy;
+}
 
 static const signed char SIN64[60] = {
       0,  7, 13, 20, 26, 32, 38, 43, 48, 52, 55, 58,
@@ -107,12 +124,12 @@ static unsigned char tobcd(unsigned char v)
 
 /* --- drawing ----------------------------------------------------------------- */
 
-static int px_at(unsigned char pos, unsigned char rad) { return CX + (int)SIN64[pos] * rad / 64; }
-static int py_at(unsigned char pos, unsigned char rad) { return CY - (int)COS64[pos] * rad / 64; }
+static int px_at(unsigned char pos, unsigned char rad) { return cx + (int)SIN64[pos] * rad / 64; }
+static int py_at(unsigned char pos, unsigned char rad) { return cy - (int)COS64[pos] * rad / 64; }
 
 static void hand(unsigned char pos, unsigned char len, unsigned char pen)
 {
-    line(CX, CY, px_at(pos, len), py_at(pos, len), pen);
+    line(cx, cy, px_at(pos, len), py_at(pos, len), pen);
 }
 
 static unsigned char hourpos(unsigned char h, unsigned char m)
@@ -125,50 +142,52 @@ static void draw_face(void)
     unsigned char k, k2;
     for (k = 0; k < 60; k += 2) {                 /* rim: 30 segments */
         k2 = (unsigned char)((k + 2) % 60);
-        line(px_at(k, R), py_at(k, R), px_at(k2, R), py_at(k2, R), 1);
+        line(px_at(k, rr), py_at(k, rr), px_at(k2, rr), py_at(k2, rr), 1);
     }
     for (k = 0; k < 60; k += 5)                    /* 12 hour ticks */
-        line(px_at(k, R), py_at(k, R), px_at(k, TICK_IN), py_at(k, TICK_IN), 1);
+        line(px_at(k, rr), py_at(k, rr), px_at(k, tick_in), py_at(k, tick_in), 1);
 }
 
 /* draw (or erase, pen 0) the hands for h:m[:s]. withsec controls the second hand. */
 static void hands(unsigned char h, unsigned char m, unsigned char s,
                   unsigned char withsec, unsigned char pen_hm, unsigned char pen_s)
 {
-    hand(hourpos(h, m), L_HOUR, pen_hm);
-    hand(m, L_MIN, pen_hm);
-    if (withsec) hand(s, L_SEC, pen_s);
+    hand(hourpos(h, m), l_hour, pen_hm);
+    hand(m, l_min, pen_hm);
+    if (withsec) hand(s, l_sec, pen_s);
 }
 
 static char dig[9];
 static void put2(char *p, unsigned char v) { p[0] = '0' + v / 10; p[1] = '0' + v % 10; }
 static void draw_digital(unsigned char h, unsigned char m, unsigned char s)
 {
-    unsigned char x = show_sec ? (win_x + 8) : (win_x + 9);
+    unsigned char x = (unsigned char)(win_x + (win_w - (show_sec ? 12 : 8)) / 2);
     put2(dig, h); dig[2] = ':'; put2(dig + 3, m);
     if (show_sec) { dig[5] = ':'; put2(dig + 6, s); dig[8] = 0; }
     else dig[5] = 0;
-    gb_fill(win_x + 6, win_y + 106, 16, 8, 0);
-    gb_text(x, win_y + 106, dig);
+    gb_fill((unsigned char)(win_x + (win_w - 16) / 2), dig_y, 16, 8, 0);
+    gb_text(x, dig_y, dig);
 }
 
 static unsigned char cursor_over(void)
 {
     unsigned char mx = gb_mx(), my = gb_my();
-    return (unsigned char)(mx >= win_x && mx < win_x + WIN_W && my >= win_y && my < win_y + WIN_H);
+    return (unsigned char)(mx >= win_x && mx < win_x + win_w && my >= win_y && my < win_y + win_h);
 }
 
 /* full_draw: paint the whole window (open / on_repaint / after a drag or toggle). */
 static void full_draw(void)
 {
     unsigned char h, m, s;
+    relayout();
     gb_time();
     h = bin(gb_hour); m = bin(gb_min); s = bin(gb_sec);
     gb_curhide();
-    gb_window(win_x, win_y, WIN_W, WIN_H, "Clock");
+    gb_window(win_x, win_y, win_w, win_h, "Clock");
     draw_face();
     hands(h, m, s, show_sec, 1, 3);
     draw_digital(h, m, s);
+    gb_draw_grip(win_x, win_y, win_w, win_h);   /* resize grip (#81) */
     gb_curshow();
     ph = h; pm = m; ps = s; pshow = show_sec; have_prev = 1;
 }
@@ -323,10 +342,19 @@ static void on_frame(void)
 
     if (!(flags & GB_CLICK)) return;
     mx = gb_mx(); my = gb_my();
+    if (gb_in_grip(win_x, win_y, win_w, win_h, mx, my)) {  /* resize grip (#81) */
+        if (gb_drag_resize(win_x, win_y, &win_w, &win_h, MIN_W, MIN_H)) {
+            gb_wm_setsize(win_w, win_h);
+            gb_restore_parent();
+            have_prev = 0;                         /* face rescaled: no stale hands */
+            full_draw();                           /* redraw the face at the new size */
+        }
+        return;
+    }
     if (my >= win_y && my < win_y + TITLE_H) {
         if (mx >= win_x && mx < win_x + 5) { gb_wm_close(); return; }
-        if (mx >= win_x + 5 && mx < win_x + WIN_W) {
-            if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
+        if (mx >= win_x + 5 && mx < win_x + win_w) {
+            if (gb_drag_window(&win_x, &win_y, win_w, win_h)) {
                 gb_wm_setpos(win_x, win_y);
                 gb_restore_parent();
                 full_draw();                       /* redraw the face at the new spot */
@@ -336,12 +364,12 @@ static void on_frame(void)
 }
 
 static const gb_win_t clkwin = {
-    DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, full_draw, on_menu, clk_menu
+    DEF_X, DEF_Y, DEF_W, DEF_H, on_frame, full_draw, on_menu, clk_menu
 };
 
 void main(void)
 {
-    win_x = DEF_X; win_y = DEF_Y;
+    win_x = DEF_X; win_y = DEF_Y; win_w = DEF_W; win_h = DEF_H;
     show_sec = 0; have_prev = 0; want_menu = 0; modal = 0;
     gb_wm_add(&clkwin);
     full_draw();

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -31,6 +31,10 @@
 #define CT_Y     (win_y + TITLE_H)       /* content top, below the title bar */
 #define CT_W     (win_w - 2 - SB_W)      /* content width (runtime, resizeable) */
 #define CT_H     (win_h - TITLE_H - 2)   /* content height (runtime) */
+#define CT_BOT   (win_y + win_h - 2)     /* content bottom = CT_Y + CT_H, but written
+                                            flat: SDCC miscompiles the summed-macro form
+                                            CT_Y + CT_H (TITLE_H cancels), placing the
+                                            down-button mid-window (#81) */
 
 /* list view */
 #define ROW_H    18
@@ -193,8 +197,8 @@ static void draw_scrollbar(void)
        the glyph black-on-white, aligned with the thumb (SB_X+1) */
     gb_fill(SB_X, CT_Y, SB_W, ARR_H, 1);
     gb_textbw(SB_X + 1, CT_Y, GLYPH_TRI_UP);
-    gb_fill(SB_X, CT_Y + CT_H - ARR_H, SB_W, ARR_H, 1);
-    gb_textbw(SB_X + 1, CT_Y + CT_H - ARR_H, GLYPH_TRI_DOWN);
+    gb_fill(SB_X, CT_BOT - ARR_H, SB_W, ARR_H, 1);
+    gb_textbw(SB_X + 1, CT_BOT - ARR_H, GLYPH_TRI_DOWN);
 }
 
 /* draw a name truncated to fit a cell (icons view) */
@@ -327,7 +331,7 @@ static void sb_drag(void)
         if (!(gb_poll() & GB_FIRE)) break;
         my = gb_my();
         if (my < CT_Y) my = CT_Y;
-        if (my >= CT_Y + CT_H) my = CT_Y + CT_H - 1;
+        if (my >= CT_BOT) my = CT_BOT - 1;
         nt = (unsigned char)(((unsigned)(my - CT_Y) * (tl - vl)) / CT_H);
         if (nt != top) { top = nt; clamp_top(); draw(); }
     }
@@ -405,6 +409,8 @@ static void on_frame(void)
     if (gb_in_grip(win_x, win_y, win_w, win_h, mx, my)) {
         if (gb_drag_resize(win_x, win_y, &win_w, &win_h, MIN_W, MIN_H)) {
             gb_wm_setsize(win_w, win_h);
+            clamp_top();          /* taller window shows more rows -> re-clamp the scroll,
+                                     else the thumb runs past the new track bottom (#81) */
             gb_restore_parent();
             draw();
         }
@@ -412,11 +418,11 @@ static void on_frame(void)
     }
 
     /* scrollbar: up/down arrow buttons (one line) at the ends, page/drag between */
-    if (mx >= SB_X && mx < SB_X + SB_W && my >= CT_Y && my < CT_Y + CT_H) {
+    if (mx >= SB_X && mx < SB_X + SB_W && my >= CT_Y && my < CT_BOT) {
         unsigned char old = top, tl = total_lines(), vl = vis_lines();
         if (my < CT_Y + ARR_H) {                     /* up arrow */
             if (top) top--;
-        } else if (my >= CT_Y + CT_H - ARR_H) {      /* down arrow */
+        } else if (my >= CT_BOT - ARR_H) {           /* down arrow */
             if (tl > vl && top < tl - vl) top++;
         } else {
             sb_click(my);
@@ -427,7 +433,7 @@ static void on_frame(void)
     }
 
     /* content: pick the entry under the pointer (list row or grid cell) */
-    if (my >= CT_Y && my < CT_Y + CT_H && mx >= CT_X && mx < win_x + win_w) {
+    if (my >= CT_Y && my < CT_BOT && mx >= CT_X && mx < win_x + win_w) {
         if (view == V_ICONS) {
             unsigned char c = (mx - CT_X) / CELL_W;
             unsigned char r = (my - CT_Y) / CELL_H;

--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -17,8 +17,10 @@
 
 #define DEF_X    4            /* window position */
 #define DEF_Y    26
-#define WIN_W    56
-#define WIN_H    130
+#define DEF_W    56            /* default size; the window is resizeable (#81) */
+#define DEF_H    130
+#define MIN_W    24            /* min size keeps the title + a couple of rows usable */
+#define MIN_H    62
 #define TITLE_H  14
 #define DCLICK   40           /* double-click window, frames */
 
@@ -27,8 +29,8 @@
 #define SB_X     (win_x + 1)             /* just inside the left border */
 #define CT_X     (win_x + 1 + SB_W)      /* content left */
 #define CT_Y     (win_y + TITLE_H)       /* content top, below the title bar */
-#define CT_W     (WIN_W - 2 - SB_W)      /* content width (52) */
-#define CT_H     (WIN_H - TITLE_H - 2)   /* content height (114) */
+#define CT_W     (win_w - 2 - SB_W)      /* content width (runtime, resizeable) */
+#define CT_H     (win_h - TITLE_H - 2)   /* content height (runtime) */
 
 /* list view */
 #define ROW_H    18
@@ -45,6 +47,7 @@
 #define V_ICONS  1
 
 static unsigned char win_x = DEF_X, win_y = DEF_Y;
+static unsigned char win_w = DEF_W, win_h = DEF_H;
 static unsigned char total;       /* number of files on the disk          */
 static unsigned char top;         /* first visible LINE (row / grid row)  */
 static unsigned char nsel;        /* 0 = none, else selected index + 1    */
@@ -265,10 +268,11 @@ static void draw(void)
     gb_set_drive(my_drive);              /* this window's drive (#65) - on_repaint may
                                             run while another window's drive is active */
     gb_curhide();
-    gb_window(win_x, win_y, WIN_W, WIN_H, drive_title[my_drive]);
+    gb_window(win_x, win_y, win_w, win_h, drive_title[my_drive]);
     draw_scrollbar();
     if (view == V_ICONS) draw_icons_view();
     else                 draw_list_view();
+    gb_draw_grip(win_x, win_y, win_w, win_h);   /* resize grip, bottom-right (#81) */
     gb_curshow();
 }
 
@@ -389,10 +393,20 @@ static void on_frame(void)
     }
 
     /* title bar (right of the close gadget) -> drag the window */
-    if (my >= win_y && my < win_y + TITLE_H && mx >= win_x + 4 && mx < win_x + WIN_W) {
-        if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
+    if (my >= win_y && my < win_y + TITLE_H && mx >= win_x + 4 && mx < win_x + win_w) {
+        if (gb_drag_window(&win_x, &win_y, win_w, win_h)) {
             gb_wm_setpos(win_x, win_y);
             gb_restore_parent();
+        }
+        return;
+    }
+
+    /* resize grip (bottom-right corner) -> resize the window (#81) */
+    if (gb_in_grip(win_x, win_y, win_w, win_h, mx, my)) {
+        if (gb_drag_resize(win_x, win_y, &win_w, &win_h, MIN_W, MIN_H)) {
+            gb_wm_setsize(win_w, win_h);
+            gb_restore_parent();
+            draw();
         }
         return;
     }
@@ -413,7 +427,7 @@ static void on_frame(void)
     }
 
     /* content: pick the entry under the pointer (list row or grid cell) */
-    if (my >= CT_Y && my < CT_Y + CT_H && mx >= CT_X && mx < win_x + WIN_W) {
+    if (my >= CT_Y && my < CT_Y + CT_H && mx >= CT_X && mx < win_x + win_w) {
         if (view == V_ICONS) {
             unsigned char c = (mx - CT_X) / CELL_W;
             unsigned char r = (my - CT_Y) / CELL_H;
@@ -444,7 +458,7 @@ static void on_frame(void)
 
 /* a co-resident window: on_repaint = draw, on_event = the View toggle, menu = the
    "View" title (shown in the top bar while we are focused). */
-static gb_win_t fmwin = { DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, draw, on_event, fm_menu };
+static gb_win_t fmwin = { DEF_X, DEF_Y, DEF_W, DEF_H, on_frame, draw, on_event, fm_menu };
 
 void main(void)
 {

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -21,12 +21,16 @@
 #define NP_MAX    1024
 #define DEF_X     2            /* initial window position (the window is draggable) */
 #define DEF_Y     14
-#define WIN_W     66
-#define WIN_H     158
+#define DEF_W     66           /* default size; the window is resizeable (#81) */
+#define DEF_H     158
+#define MIN_W     30
+#define MIN_H     72
 #define TITLE_H   14
 #define LINE_H    10
-#define MAX_LINES 13
-#define WRAP      40
+#define MAX_LINES ((win_h - TITLE_H - 13) / LINE_H)   /* visible text rows (runtime) */
+#define WRAP      ((win_w - 4) * 2 / 3)               /* chars per wrapped line (runtime) */
+#define MAXWRAP   52           /* line[] cap = max WRAP (80-col window) */
+#define MAXVIS    18           /* names[] cap = max MAX_LINES */
 /* text origin, relative to the live (draggable) window position */
 #define TX_COL    (win_x + 2)
 #define TX_Y0     (win_y + TITLE_H)
@@ -41,8 +45,9 @@
 
 static unsigned char win_x = DEF_X;      /* live window position (draggable) */
 static unsigned char win_y = DEF_Y;
+static unsigned char win_w = DEF_W, win_h = DEF_H;   /* live size (resizeable, #81) */
 static char buf[NP_MAX];
-static char line[WRAP + 2];
+static char line[MAXWRAP];
 static unsigned int len, cur;            /* text length, insertion index */
 static unsigned char view_first;         /* first visible display row */
 static unsigned char dirty, status;      /* 0 none, 1 saved, 2 failed */
@@ -88,7 +93,7 @@ static void cursor_at(unsigned char col, unsigned char row)
 
 static void status_line(void)
 {
-    gb_text(TX_COL, win_y + WIN_H - 11,
+    gb_text(TX_COL, win_y + win_h - 11,
             status == 1 ? "saved" :
             status == 2 ? "SAVE FAILED" :
                           "Click text to place caret. Ctrl-Q=quit");
@@ -127,8 +132,9 @@ static void render(unsigned char only)
 
     pos_of(cur, &currow, &curcol);
     if (only == 0xFF) {
-        gb_window(win_x, win_y, WIN_W, WIN_H, dirty ? "NOTEPAD *" : "NOTEPAD");
+        gb_window(win_x, win_y, win_w, win_h, dirty ? "NOTEPAD *" : "NOTEPAD");
         status_line();
+        gb_draw_grip(win_x, win_y, win_w, win_h);   /* resize grip (#81) */
     }
     for (i = 0; i <= len; i++) {                  /* <= len: flush the last line */
         if (i == len || buf[i] == '\n' ||
@@ -138,7 +144,7 @@ static void render(unsigned char only)
                 if (only == 0xFF || scr == only) {
                     line[col] = 0;
                     if (only != 0xFF)             /* clear just this line first */
-                        gb_fill(win_x + 1, TX_Y0 + scr * LINE_H, WIN_W - 2, LINE_H, 0);
+                        gb_fill(win_x + 1, TX_Y0 + scr * LINE_H, win_w - 2, LINE_H, 0);
                     gb_text(TX_COL, TX_Y0 + scr * LINE_H, line);
                 }
             }
@@ -260,8 +266,8 @@ static void do_new(void)
 /* do_load: list directory entries in a popup; open the one clicked. */
 static void do_load(void)
 {
-    const char *names[MAX_LINES];
-    static char store[MAX_LINES][14];
+    const char *names[MAXVIS];
+    static char store[MAXVIS][14];
     char *p;
     unsigned char n = 0, i, sel;
 
@@ -371,9 +377,17 @@ static void on_frame(void)
             draw(); gb_curshow();                /* cancelled -> repaint */
             return;
         }
+        if (gb_in_grip(win_x, win_y, win_w, win_h, mx, my)) {  /* resize grip (#81) */
+            if (gb_drag_resize(win_x, win_y, &win_w, &win_h, MIN_W, MIN_H)) {
+                gb_wm_setsize(win_w, win_h);     /* commit size + damage clip */
+                gb_restore_parent();             /* repaint the stack */
+                draw(); gb_curshow();
+            }
+            return;
+        }
         if (my >= win_y && my < win_y + TITLE_H &&  /* title bar -> drag the window */
-            mx >= win_x + 5 && mx < win_x + WIN_W) {
-            if (gb_drag_window(&win_x, &win_y, WIN_W, WIN_H)) {
+            mx >= win_x + 5 && mx < win_x + win_w) {
+            if (gb_drag_window(&win_x, &win_y, win_w, win_h)) {
                 gb_wm_setpos(win_x, win_y);      /* move our hit rect to follow */
                 gb_restore_parent();             /* repaint the stack (incl. our window) */
             }
@@ -425,14 +439,14 @@ static void on_frame(void)
 /* a co-resident window (issue #45): on_repaint redraws it, on_event = the top-bar
    File click, menu = the File title the kernel shows while we are focused. */
 static const gb_win_t npwin = {
-    DEF_X, DEF_Y, WIN_W, WIN_H, on_frame, np_repaint, on_menu, file_menu
+    DEF_X, DEF_Y, DEF_W, DEF_H, on_frame, np_repaint, on_menu, file_menu
 };
 
 void main(void)
 {
     unsigned char n;
 
-    win_x = DEF_X; win_y = DEF_Y;
+    win_x = DEF_X; win_y = DEF_Y; win_w = DEF_W; win_h = DEF_H;
     gb_wm_add(&npwin);                           /* register FIRST: captures our file arg
                                                    (per-window) + takes focus, so the load
                                                    below targets OUR file, not a sibling's */

--- a/apps/viewer/main.c
+++ b/apps/viewer/main.c
@@ -13,18 +13,22 @@
 #define TX_COL    4      /* text start: byte column inside the window         */
 #define TX_Y0     26     /* first text line (pixels), below the title bar     */
 #define LINE_H    11     /* line pitch (pixels)                               */
-#define MAX_LINES 14     /* visible lines (no scrolling yet)                  */
-#define WRAP      44     /* characters per line before a forced wrap          */
+#define MAX_LINES ((win_h - 16) / LINE_H)       /* visible text rows (runtime) */
+#define WRAP      ((win_w - 9) * 2 / 3)          /* chars per line (runtime)    */
+#define MAXWRAP   48     /* line[] cap = max WRAP at 80-col                    */
 
 #define WIN_X     2
 #define WIN_Y     14
-#define WIN_W     76
-#define WIN_H     180
+#define DEF_W     76     /* default size; the window is resizeable (#81)      */
+#define DEF_H     180
+#define MIN_W     30
+#define MIN_H     72
 #define TITLE_H   14
 
 static char filebuf[VIEW_MAX];
-static char line[WRAP + 1];
+static char line[MAXWRAP];
 static unsigned int filen;       /* bytes loaded (for repaint) */
+static unsigned char win_w = DEF_W, win_h = DEF_H;   /* live size (resizeable) */
 
 /* render: lay out n bytes of filebuf as wrapped text lines in the window. */
 static void render(unsigned int n)
@@ -58,11 +62,12 @@ static void render(unsigned int n)
 /* paint the whole window (title + text). */
 static void v_draw(void)
 {
-    gb_window(WIN_X, WIN_Y, WIN_W, WIN_H, "VIEWER");
+    gb_window(WIN_X, WIN_Y, win_w, win_h, "VIEWER");
     if (filen == 0)
         gb_text(TX_COL, TX_Y0, "(file is empty or could not be read)");
     else
         render(filen);
+    gb_draw_grip(WIN_X, WIN_Y, win_w, win_h);   /* resize grip (#81) */
 }
 
 /* on_repaint: redraw the window when the WM restacks us. */
@@ -79,12 +84,20 @@ static void on_frame(void)
     unsigned char flags = gb_flags();
     if (flags & GB_QUIT) { gb_wm_close(); return; }
     if (!(flags & GB_CLICK)) return;
+    if (gb_in_grip(WIN_X, WIN_Y, win_w, win_h, gb_mx(), gb_my())) {  /* resize grip (#81) */
+        if (gb_drag_resize(WIN_X, WIN_Y, &win_w, &win_h, MIN_W, MIN_H)) {
+            gb_wm_setsize(win_w, win_h);
+            gb_restore_parent();
+            gb_curhide(); v_draw(); gb_curshow();
+        }
+        return;
+    }
     if (gb_my() >= WIN_Y && gb_my() < WIN_Y + TITLE_H &&
         gb_mx() >= WIN_X && gb_mx() < WIN_X + 5)
         gb_wm_close();                     /* close gadget */
 }
 
-static const gb_win_t vwin = { WIN_X, WIN_Y, WIN_W, WIN_H, on_frame, v_repaint, 0, 0 };
+static const gb_win_t vwin = { WIN_X, WIN_Y, DEF_W, DEF_H, on_frame, v_repaint, 0, 0 };
 
 void main(void)
 {

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -135,6 +135,7 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_exit                 ; GB_EXIT        #8090 (leave -> AMSDOS)
                 jp    k_copy_end             ; GB_COPYEND     #8093 (restore target ctx)
                 jp    k_on_bar               ; GB_ONBAR       #8096 (HL = bar handler, #77)
+                jp    k_wm_setsize           ; GB_WMSETSIZE   #8099 (A = w, L = h, #81)
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -1538,6 +1539,45 @@ k_wm_setpos
                 ret
 sp_x            db    0
 sp_y            db    0
+
+; k_wm_setsize (GB_WMSETSIZE, #81): A = new w, L = new h. Resize the focused window's
+; rect (top-left stays put). Damage clip = its (x,y) covering max(old,new) size, so the
+; following gb_restore_parent repaints any area a shrink vacated.
+k_wm_setsize
+                ld    (ss_w),a
+                ld    a,l
+                ld    (ss_h),a
+                ld    a,(WM_FOCUS)
+                call  wm_entry                    ; HL = entry (+0 page)
+                inc   hl                            ; +1 x
+                ld    a,(hl)
+                ld    (clip_x),a                  ; clip x = window x (unchanged)
+                inc   hl                            ; +2 y
+                ld    a,(hl)
+                ld    (clip_y),a
+                inc   hl                            ; +3 w
+                ld    b,(hl)                       ; old w
+                ld    a,(ss_w)                     ; clip w = max(old, new)
+                cp    b
+                jr    nc,kss_w
+                ld    a,b
+kss_w
+                ld    (clip_w),a
+                ld    a,(ss_w)
+                ld    (hl),a                       ; commit new w
+                inc   hl                            ; +4 h
+                ld    b,(hl)                       ; old h
+                ld    a,(ss_h)
+                cp    b
+                jr    nc,kss_h
+                ld    a,b
+kss_h
+                ld    (clip_h),a
+                ld    a,(ss_h)
+                ld    (hl),a                       ; commit new h
+                ret
+ss_w            db    0
+ss_h            db    0
 
 ; damage_axis: B = old, A = new, C = size -> D = min(old,new), E = span =
 ; max(old,new) + size - min. The 1-D damage extent of a move. Preserves HL.

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -2371,6 +2371,15 @@ wel_img         incbin "../assets/WELCOME.TXT"  ; a sample text file to open in 
 wel_imgend
                 include "../lib/cursor_data.asm" ; cur_spr_data..cur_spr_end -> DEFAULT.SPR
                 include "../lib/cursor_hand_data.asm" ; cur_hand_data..end -> HAND.SPR
+                                                ; ICONED + CHELLO ride in the ABOVE-kernel
+                                                ; region too: the low #0100 app window
+                                                ; (#0100..#7FFF, 32K) overflowed once the
+                                                ; resizeable windows grew the apps, so the
+                                                ; two least-coupled binaries moved up here.
+ied_img         incbin "../build/ICONED.RAW"    ; packaged on the disk as ICONED.APP
+ied_imgend
+chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.APP
+chl_imgend
                 org   #0100                     ; --- app binaries, low region ---
 dtp_img         incbin "../build/DESKTOP.RAW"   ; packaged on the disk as DESKTOP.APP
 dtp_imgend
@@ -2380,12 +2389,8 @@ vwr_img         incbin "../build/VIEWER.RAW"    ; packaged on the disk as VIEWER
 vwr_imgend
 npd_img         incbin "../build/NOTEPAD.RAW"   ; packaged on the disk as NOTEPAD.APP
 npd_imgend
-ied_img         incbin "../build/ICONED.RAW"    ; packaged on the disk as ICONED.APP
-ied_imgend
 clk_img         incbin "../build/CLOCK.RAW"     ; packaged on the disk as CLOCK.APP
 clk_imgend
-chl_img         incbin "../build/CHELLO.RAW"    ; C-app spike, packaged as CHELLO.APP
-chl_imgend
                 save  "GBKERN.BIN",GB_KERNEL,kern_end-GB_KERNEL,DSK,"build/gbkern.dsk"
                 save  "DESKTOP.APP",dtp_img,dtp_imgend-dtp_img,DSK,"build/gbkern.dsk"
                 save  "FILEMGR.APP",app_img,app_imgend-app_img,DSK,"build/gbkern.dsk"

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -124,6 +124,19 @@ void gb_wm_add(const gb_win_t *desc);
 void gb_wm_open(const char *name);
 void gb_wm_close(void);
 void gb_wm_setpos(unsigned char x, unsigned char y);  /* move our hit rect (drag) */
+/* Resizeable windows (#81). A window with a resize grip (bottom-right corner) draws
+ * it with gb_draw_grip in its frame; a press there (gb_in_grip) runs gb_drag_resize,
+ * which keeps the top-left fixed and pulls the bottom-right corner. After the drag,
+ * call gb_wm_setsize so click-to-focus + the restack use the new size, then redraw.
+ * Apps reflow content to win_w/win_h; fixed-layout apps (e.g. ICONED) skip it. */
+#define GRIP_W 2          /* grip size: 2 bytes (8px) x 6px */
+#define GRIP_H 6
+void gb_wm_setsize(unsigned char w, unsigned char h);
+void gb_draw_grip(unsigned char x, unsigned char y, unsigned char w, unsigned char h);
+unsigned char gb_in_grip(unsigned char x, unsigned char y, unsigned char w,
+                         unsigned char h, unsigned char mx, unsigned char my);
+unsigned char gb_drag_resize(unsigned char x, unsigned char y, unsigned char *w,
+                             unsigned char *h, unsigned char minw, unsigned char minh);
 void gb_wm_launch(void);              /* open current dir entry co-resident (+ arg) */
 /* gb_wm_launch_as: open app `app` (an 8.3 name) as a co-resident window, with the
  * current dir entry as its file arg (so a data file auto-opens). The File Manager

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -41,6 +41,7 @@
         .globl  _gb_wm_open
         .globl  _gb_wm_close
         .globl  _gb_wm_setpos
+        .globl  _gb_wm_setsize
         .globl  _gb_wm_launch
         .globl  _gb_wm_launch_as
         .globl  _gb_time
@@ -279,6 +280,10 @@ _gb_wm_close:
 ;; (call after dragging so click-to-focus follows the window).
 _gb_wm_setpos:
         jp      0x8066          ; GB_WMSETPOS
+;; void gb_wm_setsize(u8 w, u8 h);   A=w, L=h -> resize the focused window's hit rect
+;; (call after a resize-drag so click-to-focus + restack use the new size, #81).
+_gb_wm_setsize:
+        jp      0x8099          ; GB_WMSETSIZE
 ;; void gb_wm_launch(void);   open the current dir entry's app as a co-resident
 ;; window with the file as its launch arg (the non-blocking gb_launch).
 _gb_wm_launch:

--- a/lib/gb/gbwin.c
+++ b/lib/gb/gbwin.c
@@ -59,3 +59,68 @@ unsigned char gb_drag_window(unsigned char *x, unsigned char *y,
     *y = oy;
     return 1;
 }
+
+/* gb_draw_grip: the resize grip in a window's bottom-right corner (#81) - a small
+ * white box with a black edge. Apps that resize draw it in their frame. */
+void gb_draw_grip(unsigned char x, unsigned char y, unsigned char w, unsigned char h)
+{
+    unsigned char gx = (unsigned char)(x + w - GRIP_W);
+    unsigned char gy = (unsigned char)(y + h - GRIP_H);
+    gb_fill(gx, gy, GRIP_W, GRIP_H, 1);
+    gb_frame(gx, gy, GRIP_W, GRIP_H, 2);
+}
+
+/* gb_in_grip: is (mx,my) on the grip? The hit area is a touch larger than the glyph,
+ * so it's easy to grab with the joystick pointer. */
+unsigned char gb_in_grip(unsigned char x, unsigned char y, unsigned char w,
+                         unsigned char h, unsigned char mx, unsigned char my)
+{
+    return (unsigned char)(mx >= (unsigned char)(x + w - GRIP_W - 1) && mx < x + w &&
+                           my >= (unsigned char)(y + h - GRIP_H - 1) && my < y + h);
+}
+
+/* gb_drag_resize: the caller detected a press on the resize grip; run a resize drag.
+ * Top-left (x,y) stays put; the bottom-right corner follows the pointer, clamped to
+ * [minw..]/[minh..] and the screen. Like gb_drag_window, the window is lifted and an
+ * outline shown only once the pointer moves; on release *w,*h get the new size and it
+ * returns 1 (0 if it never resized). (#81) */
+unsigned char gb_drag_resize(unsigned char x, unsigned char y,
+                             unsigned char *w, unsigned char *h,
+                             unsigned char minw, unsigned char minh)
+{
+    unsigned char ow = *w, oh = *h, nw, nh, mx, my, f, lifted = 0;
+    unsigned char wmax = (unsigned char)(80 - x);
+    unsigned char hmax = (unsigned char)(200 - y);
+
+    for (;;) {
+        f = gb_poll();
+        if (!(f & GB_FIRE))
+            break;
+        mx = gb_mx();
+        my = gb_my();
+        nw = (mx >= x) ? (unsigned char)(mx - x + 1) : minw;
+        nh = (my >= y) ? (unsigned char)(my - y + 1) : minh;
+        if (nw < minw) nw = minw;
+        if (nh < minh) nh = minh;
+        if (nw > wmax) nw = wmax;
+        if (nh > hmax) nh = hmax;
+        if (nw == ow && nh == oh)
+            continue;
+        gb_curhide();
+        if (!lifted) { gb_fill(x, y, *w, *h, 0); lifted = 1; }   /* lift the window */
+        else gb_frame(x, y, ow, oh, 0);                          /* erase old outline */
+        ow = nw;
+        oh = nh;
+        gb_frame(x, y, ow, oh, 3);                               /* outline at new size */
+        gb_curshow();
+    }
+
+    if (!lifted)
+        return 0;
+    gb_curhide();
+    gb_frame(x, y, ow, oh, 0);
+    gb_curshow();
+    *w = ow;
+    *h = oh;
+    return 1;
+}


### PR DESCRIPTION
Every window except the Icon Editor now has a bottom-right resize grip; dragging it resizes the window (top-left anchored).

## What is in this PR
- **Core**: `k_wm_setsize` (GB_WMSETSIZE) commits a window's new rect + damage clip; `gb_drag_resize`/`gb_draw_grip`/`gb_in_grip` helpers in app-linked `gbwin.c` (no resident kernel cost), mirroring the existing window-drag.
- **File Manager**: resizeable; content/scrollbar reflow to the new size.
- **Notepad**: `WRAP`/`MAX_LINES` become runtime; text re-wraps to the new margins on resize.
- **Viewer**: fixed top-left; resize re-flows the wrapped text.
- **Clock**: the analog face rescales - `relayout()` recomputes centre, radius and hand lengths from the live rect.
- **ICONED**: intentionally left fixed-size.
- **Kernel packaging**: the low #0100 app-image window overflowed 32K once the apps grew, so ICONED + CHELLO moved into the above-kernel image region.

## Fixes during review
- FM scrollbar down-button rendered mid-window at all sizes: the summed-macro `CT_Y + CT_H` form is miscompiled by SDCC (TITLE_H should cancel); replaced with a flat `CT_BOT` macro everywhere the sum appeared (draw + hit-tests).
- A grow left the scroll position past the new max; `clamp_top()` re-pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)