### PR TITLE
Notepad: fix caret hit-test + complete the editor (#86)

### DIFF
--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -63,6 +63,18 @@ static char wtitle[18];                   /* fbase + " *" when dirty (window tit
 static unsigned char blink_ctr, caret_vis, cur_scr, cur_col;  /* caret blink (#86) */
 #define BLINK_FRAMES 16                   /* ~3 Hz caret blink at 50 fps */
 
+/* arrow-key caret nav (#86): the pointer PLACES the caret, the keyboard arrows
+   NUDGE it. We read the cursor keys straight off the matrix (KM_TEST_KEY) rather
+   than re-arming them globally - re-arming would re-flood every app on pointer
+   moves (the very thing disarm_joy_keys prevents). */
+#define A_UP      0
+#define A_DOWN    1
+#define A_LEFT    2
+#define A_RIGHT   3
+#define REP_DELAY 14                      /* frames held before a key auto-repeats */
+#define REP_RATE  3                       /* frames between repeats */
+static unsigned char arr_prev, arr_rep, arr_bits;
+
 /* the kernel-drawn top-bar menu: one title "File" at MENU_COL */
 static const unsigned char file_menu[] = { 1, MENU_COL, 'F','i','l','e',0,0,0,0 };
 
@@ -405,6 +417,97 @@ static unsigned char cursor_over(void)
                            my >= win_y && my < win_y + win_h);
 }
 
+/* read_arrows: matrix state of the four cursor keys -> arr_bits (bit0 up, 1 down,
+   2 left, 3 right). KM_TEST_KEY (&BB1E): A = key number (72..75 = U/D/L/R), returns
+   NZ when pressed. We talk to the matrix directly so the keys stay globally disarmed
+   (no char-buffer flood) yet still reach us. Only A + arr_bits cross each call, so a
+   KM_TEST_KEY register clobber can't corrupt the accumulator. */
+static void read_arrows(void) __naked
+{
+__asm
+    xor  a
+    ld   (_arr_bits), a
+    ld   a, #72            ; cursor up
+    call #0xBB1E
+    jr   z, 1$
+    ld   a, (_arr_bits)
+    or   #0x01
+    ld   (_arr_bits), a
+1$: ld   a, #73            ; cursor down
+    call #0xBB1E
+    jr   z, 2$
+    ld   a, (_arr_bits)
+    or   #0x02
+    ld   (_arr_bits), a
+2$: ld   a, #74            ; cursor left
+    call #0xBB1E
+    jr   z, 3$
+    ld   a, (_arr_bits)
+    or   #0x04
+    ld   (_arr_bits), a
+3$: ld   a, #75            ; cursor right
+    call #0xBB1E
+    jr   z, 4$
+    ld   a, (_arr_bits)
+    or   #0x08
+    ld   (_arr_bits), a
+4$: ret
+__endasm;
+}
+
+/* move_caret: step the insertion point one cell in a direction. Up/Down keep the
+   display column via the wrap-aware pos_of/idx_of; Left/Right walk the buffer. */
+static void move_caret(unsigned char dir)
+{
+    unsigned char r, c;
+    if (dir == A_LEFT)  { if (cur) cur--; }
+    else if (dir == A_RIGHT) { if (cur < len) cur++; }
+    else {
+        pos_of(cur, &r, &c);
+        if (dir == A_UP) { if (r) cur = idx_of((unsigned char)(r - 1), c); }
+        else             cur = idx_of((unsigned char)(r + 1), c);   /* A_DOWN (clamps) */
+    }
+}
+
+/* move_redraw: move the caret, then repaint just the old + new caret lines (or the
+   whole window if the view scrolled), keeping the cursor solid + the blink reset. */
+static void move_redraw(unsigned char dir)
+{
+    unsigned char oldscr = cur_scr, oldvf = view_first;
+    move_caret(dir);
+    caret_vis = 1; blink_ctr = 0;
+    gb_curhide();
+    scroll_to_caret();
+    /* render() always (re)draws the caret at its current position, so repainting the
+       OLD caret line both erases the old underscore and paints the new one (which sits
+       on whatever line the caret moved to). A scroll needs the whole window. */
+    if (view_first != oldvf) render(0xFF);
+    else                     render(oldscr);
+    gb_curshow();
+}
+
+/* handle_arrows: edge-detect + auto-repeat the cursor keys. Returns 1 if an arrow
+   is engaged (caret moved or key held), so the caller skips typing/blink this frame. */
+static unsigned char handle_arrows(void)
+{
+    unsigned char now, fresh, act = 0, dir;
+    read_arrows();
+    now = arr_bits;
+    fresh = (unsigned char)(now & ~arr_prev);
+    if (fresh) { arr_rep = REP_DELAY; act = fresh; }      /* new press -> move now */
+    else if (now && now == arr_prev) {                    /* held -> maybe repeat */
+        if (--arr_rep == 0) { arr_rep = REP_RATE; act = now; }
+    }
+    arr_prev = now;
+    if (!act) return (unsigned char)(now ? 1 : 0);        /* held, not yet repeating */
+    if (act & 1) dir = A_UP;
+    else if (act & 2) dir = A_DOWN;
+    else if (act & 4) dir = A_LEFT;
+    else dir = A_RIGHT;
+    move_redraw(dir);
+    return 1;
+}
+
 /* np_repaint: kernel on_repaint - redraw the whole window (no input) when the WM
    restacks us behind/above another window. */
 static void np_repaint(void)
@@ -479,6 +582,8 @@ static void on_frame(void)
         return;
     }
 
+    if (handle_arrows()) return;                 /* arrow nudged the caret (#86 item 6) */
+
     edited = 0;                                  /* drain typed keys */
     n = 8;
     while (n--) {
@@ -527,7 +632,7 @@ void main(void)
     char raw[11];
 
     win_x = DEF_X; win_y = DEF_Y; win_w = DEF_W; win_h = DEF_H;
-    caret_vis = 1; blink_ctr = 0;
+    caret_vis = 1; blink_ctr = 0; arr_prev = 0; arr_rep = 0;
     gb_wm_add(&npwin);                           /* register FIRST: captures our file arg
                                                    (per-window) + takes focus, so the load
                                                    below targets OUR file, not a sibling's */

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -294,7 +294,7 @@ static unsigned char popup(unsigned char x, unsigned char y,
                                                       re-shows it exactly once */
 }
 
-static const char *const file_items[] = { "New", "Load", "Save" };
+static const char *const file_items[] = { "New", "Load", "Save", "Save As" };
 
 static void do_save(void)
 {
@@ -302,11 +302,81 @@ static void do_save(void)
     if (status == 1) dirty = 0;
 }
 
+/* ensure_ext: a name with no '.' gets a ".TXT" default (8.3, room permitting). */
+static char namebuf[16];
+static void ensure_ext(void)
+{
+    unsigned char i = 0, has = 0;
+    while (namebuf[i]) { if (namebuf[i] == '.') has = 1; i++; }
+    if (!has && i && i <= 8) {
+        namebuf[i++] = '.'; namebuf[i++] = 'T'; namebuf[i++] = 'X'; namebuf[i++] = 'T';
+        namebuf[i] = 0;
+    }
+}
+
+/* prompt_name: modal name-entry box. Types an uppercase 8.3 name into namebuf;
+   Enter (non-empty) -> 1, ESC/empty -> 0. Black-on-white, like the other dialogs. */
+static unsigned char prompt_name(const char *caption)
+{
+    unsigned char x = 12, y = 64, w = 52, h = 34;
+    unsigned char fl = 0, c, n = 0, done = 0, ok = 0, redraw = 1;
+    modal = 1;
+    namebuf[0] = 0;
+    while (gb_getkey()) ;                 /* drop the menu click's keys */
+    gb_curhide();
+    gb_fill(x, y, w, h, 1);               /* white box + black frame */
+    gb_frame(x, y, w, h, 2);
+    gb_textbw(x + 2, y + 3, caption);
+    gb_curshow();
+    while (!done) {
+        if (redraw) {
+            gb_curhide();
+            gb_fill(x + 2, y + 16, w - 4, 8, 1);   /* clear the field (white) */
+            gb_textbw(x + 2, y + 16, namebuf);
+            gb_curshow();
+            redraw = 0;
+        }
+        fl = gb_poll();
+        if (fl & GB_QUIT) { done = 1; break; }      /* ESC -> cancel */
+        while ((c = gb_getkey()) != 0) {
+            if (c == K_ENTER) { done = 1; ok = (unsigned char)(n > 0); break; }
+            else if ((c == K_BS || c == K_DEL) && n) { namebuf[--n] = 0; redraw = 1; }
+            else if (c >= 32 && c < 127 && n < 12) {
+                if (c >= 'a' && c <= 'z') c = (unsigned char)(c - 32);   /* 8.3 is upper */
+                namebuf[n++] = (char)c; namebuf[n] = 0; redraw = 1;
+            }
+        }
+    }
+    modal = 0;
+    if (fl & GB_QUIT) while (gb_poll() & GB_QUIT) ;
+    gb_curhide();
+    gb_fill(x, y, w, h, 0);               /* erase the dialog */
+    gb_curshow();
+    keycool = 4;
+    return ok;
+}
+
+/* set_file: namebuf "NAME[.EXT]" -> the current file name + title. */
+static void set_file(void)
+{
+    ensure_ext();
+    to_83(namebuf);
+    gb_set_name(name83);
+    fmt83(fbase, name83);
+}
+
 static void do_new(void)
 {
+    if (prompt_name("New file name:")) set_file();
+    else { gb_set_name("UNTITLEDTXT"); fmt83(fbase, "UNTITLEDTXT"); }
     len = 0; cur = 0; view_first = 0; dirty = 0; status = 0;
-    gb_set_name("UNTITLEDTXT");
-    fmt83(fbase, "UNTITLEDTXT");
+}
+
+static void do_saveas(void)
+{
+    if (!prompt_name("Save as:")) return;
+    set_file();
+    do_save();
 }
 
 /* is_binary: true if "NAME.EXT" has a known non-text extension (so Load skips it). */
@@ -358,10 +428,11 @@ static void do_load(void)
 /* run_menu: drop the File menu and dispatch the chosen item. */
 static void run_menu(void)
 {
-    unsigned char sel = popup(MENU_COL, 8, file_items, 3);
+    unsigned char sel = popup(MENU_COL, 8, file_items, 4);
     if (sel == 0) do_new();
     else if (sel == 1) do_load();
     else if (sel == 2) do_save();
+    else if (sel == 3) do_saveas();
 }
 
 /* confirm: "Save changes?" dialog -> 1 = YES, 0 = NO, 0xFF = cancelled (ESC). */

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -18,7 +18,10 @@
  * visible. */
 #include "gb.h"
 
-#define NP_MAX    1024
+#define NP_MAX    4096           /* editable text capacity (was 1024); fits the app's
+                                    #6000-#7FFF data window with room to spare */
+#define NP_BUF    (NP_MAX + 512)  /* +1 sector of slack: gb_fs_load copies whole 512B
+                                    sectors, so the buffer outruns the load cap */
 #define DEF_X     2            /* initial window position (the window is draggable) */
 #define DEF_Y     14
 #define DEF_W     66           /* default size; the window is resizeable (#81) */
@@ -38,6 +41,7 @@
 #define K_ENTER   0x0D
 #define K_BS      0x08
 #define K_DEL     0x7F
+#define K_TAB     0x09
 #define K_QUIT    0x11           /* Ctrl-Q */
 
 #define MENU_COL  10             /* "File" title column in the top bar */
@@ -46,7 +50,7 @@
 static unsigned char win_x = DEF_X;      /* live window position (draggable) */
 static unsigned char win_y = DEF_Y;
 static unsigned char win_w = DEF_W, win_h = DEF_H;   /* live size (resizeable, #81) */
-static char buf[NP_MAX];
+static char buf[NP_BUF];
 static char line[MAXWRAP];
 static unsigned int len, cur;            /* text length, insertion index */
 static unsigned char view_first;         /* first visible display row */
@@ -54,6 +58,10 @@ static unsigned char dirty, status;      /* 0 none, 1 saved, 2 failed */
 static unsigned char want_menu, modal, close_menu; /* File clicked / modal / close it */
 static unsigned char keycool;            /* frames to flush keys after a click or fire */
 static unsigned char prev_total;         /* display-row count at the last full draw */
+static char fbase[14];                    /* "NAME.EXT" of the open file (title base) */
+static char wtitle[18];                   /* fbase + " *" when dirty (window title) */
+static unsigned char blink_ctr, caret_vis, cur_scr, cur_col;  /* caret blink (#86) */
+#define BLINK_FRAMES 16                   /* ~3 Hz caret blink at 50 fps */
 
 /* the kernel-drawn top-bar menu: one title "File" at MENU_COL */
 static const unsigned char file_menu[] = { 1, MENU_COL, 'F','i','l','e',0,0,0,0 };
@@ -88,7 +96,30 @@ static unsigned int idx_of(unsigned char trow, unsigned char tcol)
 
 static void cursor_at(unsigned char col, unsigned char row)
 {
-    gb_fill(TX_COL + (col * 3) / 2, TX_Y0 + row * LINE_H + 7, 2, 2, 3);
+    if (caret_vis)                       /* skipped on the blink-off phase (#86) */
+        gb_fill(TX_COL + (col * 3) / 2, TX_Y0 + row * LINE_H + 7, 2, 2, 3);
+}
+
+/* fmt83: 11-byte space-padded 8.3 name -> "NAME.EXT" display string. */
+static void fmt83(char *dst, const char *n11)
+{
+    unsigned char i, j = 0;
+    for (i = 0; i < 8 && n11[i] != ' '; i++) dst[j++] = n11[i];
+    if (n11[8] != ' ') {
+        dst[j++] = '.';
+        for (i = 8; i < 11 && n11[i] != ' '; i++) dst[j++] = n11[i];
+    }
+    dst[j] = 0;
+}
+
+/* win_title: the window title = the file name, with " *" appended when unsaved. */
+static const char *win_title(void)
+{
+    unsigned char i = 0, j = 0;
+    while (fbase[i]) wtitle[j++] = fbase[i++];
+    if (dirty) { wtitle[j++] = ' '; wtitle[j++] = '*'; }
+    wtitle[j] = 0;
+    return wtitle;
 }
 
 static void status_line(void)
@@ -132,7 +163,7 @@ static void render(unsigned char only)
 
     pos_of(cur, &currow, &curcol);
     if (only == 0xFF) {
-        gb_window(win_x, win_y, win_w, win_h, dirty ? "NOTEPAD *" : "NOTEPAD");
+        gb_window(win_x, win_y, win_w, win_h, win_title());
         status_line();
         gb_draw_grip(win_x, win_y, win_w, win_h);   /* resize grip (#81) */
     }
@@ -158,12 +189,14 @@ static void render(unsigned char only)
         }
     }
     scr = currow - view_first;
+    cur_scr = scr; cur_col = curcol;     /* remember for the blink redraw (#86) */
     cursor_at(curcol, scr);
 }
 
 /* draw: full repaint (scroll to the caret, then render everything). */
 static void draw(void)
 {
+    caret_vis = 1; blink_ctr = 0;        /* caret solid right after any redraw (#86) */
     scroll_to_caret();
     render(0xFF);
     prev_total = count_lines();
@@ -261,9 +294,28 @@ static void do_new(void)
 {
     len = 0; cur = 0; view_first = 0; dirty = 0; status = 0;
     gb_set_name("UNTITLEDTXT");
+    fmt83(fbase, "UNTITLEDTXT");
 }
 
-/* do_load: list directory entries in a popup; open the one clicked. */
+/* is_binary: true if "NAME.EXT" has a known non-text extension (so Load skips it). */
+static unsigned char is_binary(const char *name)
+{
+    static const char bin[9][4] = { "APP","BIN","IST","SPR","FNT","RAW","IMG","SNA","DSK" };
+    const char *e = name;
+    char ext[4];
+    unsigned char i, k;
+    while (*e && *e != '.') e++;
+    if (*e != '.') return 0;             /* no extension -> treat as text */
+    e++;
+    for (i = 0; i < 3 && e[i] && e[i] != ' '; i++) ext[i] = e[i];
+    ext[i] = 0;
+    for (k = 0; k < 9; k++)
+        if (bin[k][0] == ext[0] && bin[k][1] == ext[1] && bin[k][2] == ext[2])
+            return 1;
+    return 0;
+}
+
+/* do_load: list the (text) directory entries in a popup; open the one clicked. */
 static void do_load(void)
 {
     const char *names[MAXVIS];
@@ -273,10 +325,12 @@ static void do_load(void)
 
     p = gb_dir1();
     while (p && n < MAX_LINES) {
-        for (i = 0; i < 13 && p[i]; i++) store[n][i] = p[i];
-        store[n][i] = 0;
-        names[n] = store[n];
-        n++;
+        if (!is_binary(p)) {             /* skip .APP/.BIN/... - text files only (#86) */
+            for (i = 0; i < 13 && p[i]; i++) store[n][i] = p[i];
+            store[n][i] = 0;
+            names[n] = store[n];
+            n++;
+        }
         p = gb_dirn();
     }
     if (!n) return;
@@ -284,6 +338,7 @@ static void do_load(void)
     if (sel == 0xFF) return;
     to_83(store[sel]);
     gb_set_name(name83);
+    fmt83(fbase, name83);                /* title -> the opened file's name */
     len = gb_fs_load(buf, NP_MAX);
     cur = 0; view_first = 0; dirty = 0; status = 0;
 }
@@ -341,6 +396,15 @@ static unsigned char try_close(void)
     return (unsigned char)(status == 1);
 }
 
+/* cursor_over: is the pointer inside our window? (so the blink only lifts the
+   pointer when it actually sits over the text - no per-blink pointer flicker.) */
+static unsigned char cursor_over(void)
+{
+    unsigned char mx = gb_mx(), my = gb_my();
+    return (unsigned char)(mx >= win_x && mx < win_x + win_w &&
+                           my >= win_y && my < win_y + win_h);
+}
+
 /* np_repaint: kernel on_repaint - redraw the whole window (no input) when the WM
    restacks us behind/above another window. */
 static void np_repaint(void)
@@ -370,6 +434,11 @@ static void on_frame(void)
     if (flags & GB_FIRE) keycool = 4;           /* fire held -> flush its 'Z'/'X' */
     if (flags & GB_CLICK) {
         unsigned char my = gb_my(), mx = gb_mx();
+        /* text area bottom, precomputed flat: TX_Y0 + MAX_LINES*LINE_H is the summed
+           (win_y+TITLE_H)+(win_h-...) form SDCC miscompiles - cf. the FM CT_BOT fix
+           (#81). vis is a single win_h macro; TX_Y0 + a runtime value is safe. */
+        unsigned char vis = MAX_LINES;
+        unsigned char txbot = (unsigned char)(TX_Y0 + vis * LINE_H);
         keycool = 4;
         if (my >= win_y && my < win_y + TITLE_H &&  /* close gadget (title-bar left) */
             mx >= win_x && mx < win_x + 5) {
@@ -393,7 +462,7 @@ static void on_frame(void)
             }
             return;
         }
-        if (my >= TX_Y0 && my < TX_Y0 + MAX_LINES * LINE_H && mx >= TX_COL) {
+        if (my >= TX_Y0 && my < txbot && mx >= TX_COL) {
             unsigned int nc = idx_of(view_first + (my - TX_Y0) / LINE_H,
                                      ((mx - TX_COL) * 2) / 3);
             if (nc != cur) {                     /* redraw only if the caret moved */
@@ -418,11 +487,13 @@ static void on_frame(void)
         if (c == K_QUIT) { gb_wm_close(); return; }
         if (c == K_BS || c == K_DEL) { del_back(); edited = 1; }
         else if (c == K_ENTER) { ins('\n'); edited = 1; }
+        else if (c == K_TAB) { ins(' '); ins(' '); ins(' '); ins(' '); edited = 1; }
         else if (c >= 32 && c < 127) { ins((char)c); edited = 1; }
         /* other keys (arrows etc.) are ignored - no redraw */
     }
     if (edited) {
         unsigned char t = count_lines(), oldvf = view_first, cr, cc;
+        caret_vis = 1; blink_ctr = 0;            /* caret solid while typing (#86) */
         gb_curhide();
         scroll_to_caret();
         pos_of(cur, &cr, &cc);
@@ -433,6 +504,14 @@ static void on_frame(void)
             render(cr - view_first);             /* just the caret's line */
         }
         gb_curshow();
+    } else if (++blink_ctr >= BLINK_FRAMES) {    /* idle -> blink the caret (#86) */
+        unsigned char co = cursor_over();
+        blink_ctr = 0;
+        caret_vis ^= 1;
+        if (co) gb_curhide();
+        if (caret_vis) cursor_at(cur_col, cur_scr);
+        else render(cur_scr);                    /* repaint the line -> caret erased */
+        if (co) gb_curshow();
     }
 }
 
@@ -445,12 +524,20 @@ static const gb_win_t npwin = {
 void main(void)
 {
     unsigned char n;
+    char raw[11];
 
     win_x = DEF_X; win_y = DEF_Y; win_w = DEF_W; win_h = DEF_H;
+    caret_vis = 1; blink_ctr = 0;
     gb_wm_add(&npwin);                           /* register FIRST: captures our file arg
                                                    (per-window) + takes focus, so the load
                                                    below targets OUR file, not a sibling's */
-    len = gb_fs_load(buf, NP_MAX);              /* the file we were launched with */
+    gb_get_name(raw);                            /* the file name we were launched with */
+    len = gb_fs_load(buf, NP_MAX);              /* ...and its contents (0 if none) */
+    fmt83(fbase, raw);                           /* show it in the title bar (#86) */
+    if (!fbase[0]) {                             /* opened blank -> Untitled */
+        fmt83(fbase, "UNTITLEDTXT");
+        gb_set_name("UNTITLEDTXT");
+    }
     cur = len; view_first = 0; dirty = 0; status = 0;
     want_menu = 0; modal = 0;
     for (n = 64; n; n--) if (!gb_getkey()) break;   /* drop buffered keys */

--- a/apps/notepad/main.c
+++ b/apps/notepad/main.c
@@ -106,10 +106,18 @@ static unsigned int idx_of(unsigned char trow, unsigned char tcol)
     return len;
 }
 
+/* The underscore cursor sits in the inter-line gap (row +8, below the 8px glyph)
+   so the blink can erase just its cell without ever nicking a character. */
 static void cursor_at(unsigned char col, unsigned char row)
 {
-    if (caret_vis)                       /* skipped on the blink-off phase (#86) */
-        gb_fill(TX_COL + (col * 3) / 2, TX_Y0 + row * LINE_H + 7, 2, 2, 3);
+    gb_fill(TX_COL + (col * 3) / 2, TX_Y0 + row * LINE_H + 8, 2, 2, 3);
+}
+
+/* caret_erase: clear just the cursor cell (blink-off) - no line repaint, so the
+   text doesn't flash every blink. Glyph-safe because the cursor is in the gap. */
+static void caret_erase(void)
+{
+    gb_fill(TX_COL + (cur_col * 3) / 2, TX_Y0 + cur_scr * LINE_H + 8, 2, 2, 0);
 }
 
 /* fmt83: 11-byte space-padded 8.3 name -> "NAME.EXT" display string. */
@@ -583,6 +591,7 @@ static unsigned char handle_arrows(void)
    restacks us behind/above another window. */
 static void np_repaint(void)
 {
+    caret_vis = 1; blink_ctr = 0;        /* show the cursor solid after a restack */
     gb_curhide();
     render(0xFF);
     gb_curshow();
@@ -686,7 +695,7 @@ static void on_frame(void)
         caret_vis ^= 1;
         if (co) gb_curhide();
         if (caret_vis) cursor_at(cur_col, cur_scr);
-        else render(cur_scr);                    /* repaint the line -> caret erased */
+        else caret_erase();                      /* erase just the cell - no line flash */
         if (co) gb_curshow();
     }
 }

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -884,8 +884,11 @@ icon_init
                 ld    hl,KCFG_ICONNAME       ; fs_req_name = the config icon name
                 ld    de,fs_req_name
                 call  copy11
-                ld    hl,#1000               ; .IST <= 4K (12 icons = 3136B + headroom)
-                ld    (fs_load_max),hl
+                ld    hl,GB_KERNEL-DATA_ICONS-#200   ; cap = ALL the free icon region, from
+                ld    (fs_load_max),hl               ; DATA_ICONS up to the kernel (#8000),
+                                                     ; less a sector. Derived from the layout
+                                                     ; so it never needs hand-tuning: ~#3A00
+                                                     ; (~57 icons), the physical ceiling.
                 ld    hl,DATA_ICONS
                 ld    (fs_load_dst),hl
                 ld    hl,def_ist             ; fall back to DEFAULT.IST if missing

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -750,7 +750,12 @@ eti_geo         ld    a,4
                 ret
 eti_folder      ld    a,9
                 ret
-eti_app         ld    a,10                     ; GEOBENCH app (.APP) -> app icon (slot 10)
+eti_app         ld    hl,name_notepad8         ; NOTEPAD.APP -> its own icon (slot 11)
+                call  cmp_name8
+                jr    z,eti_np
+                ld    a,10                     ; other GEOBENCH apps (.APP) -> app icon (10)
+                ret
+eti_np          ld    a,11
                 ret
 
 cmp_name8                                      ; Z if name_geobench == fs_ent_name[0..7]
@@ -785,6 +790,7 @@ ext_scr         db    "SCR"
 ext_txt         db    "TXT"
 ext_app         db    "APP"
 name_geobench   db    "GEOBENCH"
+name_notepad8   db    "NOTEPAD "      ; 8-char name field of NOTEPAD.APP (icon #86)
 
 ; --- config (C kernel module) --------------------------------------------
 ; cfg_boot: seed defaults, load GEOBENCH.CFG into the transfer area, then run the
@@ -878,7 +884,7 @@ icon_init
                 ld    hl,KCFG_ICONNAME       ; fs_req_name = the config icon name
                 ld    de,fs_req_name
                 call  copy11
-                ld    hl,#0C00               ; .IST <= 3K
+                ld    hl,#1000               ; .IST <= 4K (12 icons = 3136B + headroom)
                 ld    (fs_load_max),hl
                 ld    hl,DATA_ICONS
                 ld    (fs_load_dst),hl

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -91,6 +91,10 @@ void gb_menu(const void *def);
  * does New / Save As / open a file chosen from a picker. */
 void gb_set_name(const char *name11);
 
+/* gb_get_name: copy this window's 11-byte launch name (the file it was opened with,
+ * space-padded 8.3, no dot) into dst - e.g. to show it in a title bar. */
+void gb_get_name(char *dst11);
+
 /* Draggable-window background repaint (issue #43). An app registers a full-repaint
  * handler (redraws its whole window/desktop, no input) with gb_on_repaint; when a
  * child app moves a window, it calls gb_restore_parent first, and the kernel runs

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -33,6 +33,7 @@
         .globl  _gb_on_event
         .globl  _gb_menu
         .globl  _gb_set_name
+        .globl  _gb_get_name
         .globl  _gb_on_repaint
         .globl  _gb_restore_parent
         .globl  _gb_flags
@@ -251,6 +252,16 @@ _gb_menu:
 ;; void gb_set_name(const char *name11);   11-byte 8.3 name in HL -> current file
 _gb_set_name:
         jp      0x8051          ; GB_SETNAME
+
+;; void gb_get_name(char *dst11);   copy this window's 11-byte launch name into dst
+;; (GB_GETARG returns HL = the name in low RAM, always mapped). For the title bar.
+_gb_get_name:
+        push    hl              ; HL = dst (first arg)
+        call    0x802A          ; GB_GETARG -> HL = name ptr
+        pop     de              ; DE = dst
+        ld      bc, #11
+        ldir
+        ret
 
 ;; void gb_on_repaint(void (*handler)(void));   handler in HL -> kernel stores it
 ;; at this app's nesting slot, for repainting behind a moved window (#43)

--- a/tools/build_capp.sh
+++ b/tools/build_capp.sh
@@ -31,7 +31,7 @@ mkdir -p "$work"
 # the notepad's return - SDCC's epilogue is `ld sp,<fp>`).
 "$SDCC" -mz80 --fomit-frame-pointer -I "$GB" -c "$APP/main.c" -o "$work/main.rel"
 "$SDCC" -mz80 --fomit-frame-pointer -I "$GB" -c "$GB/gbwin.c" -o "$work/gbwin.rel"
-"$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x6000 \
+"$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x6200 \
     "$work/crt0.rel" "$work/main.rel" "$work/gbwin.rel" "$work/gblib.rel" -o "$work/app.ihx"
 "$MAKEBIN" -p "$work/app.ihx" "$work/app.bin"
 

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -19,7 +19,7 @@ python3 tools/packicons.py build/DEFAULT.IST \
     lib/icon_floppy.asm lib/icon_ide.asm lib/icon_clock.asm lib/icon_trash.asm \
     lib/icon_geobench.asm lib/icon_basic.asm lib/icon_binary.asm \
     lib/icon_picture.asm lib/icon_text.asm lib/icon_folder.asm \
-    lib/icon_app.asm  # icon set (slot 9 = folder, slot 10 = .APP)
+    lib/icon_app.asm lib/icon_notepad.asm  # slot 9=folder, 10=.APP, 11=NOTEPAD.APP
 tools/build_capp.sh apps/desktop build/DESKTOP.RAW # DESKTOP (C/SDCC) -> build/DESKTOP.RAW
 tools/build_capp.sh apps/filemgr build/FILEMGR.RAW # FILEMGR (C/SDCC) -> build/FILEMGR.RAW
 tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VIEWER.RAW


### PR DESCRIPTION
Closes #86. Rounds out the Notepad editor.

## Fixes
- **Caret click accuracy** - the text hit-test bound `TX_Y0 + MAX_LINES*LINE_H` is the summed-macro `(win_y+TITLE_H)+(win_h-...)` form SDCC miscompiles (same class as the FM scrollbar #81); precomputed flat into a local, so clicks near the window bottom place the caret correctly.

## Completions
- **Bigger files** - `NP_MAX` 1024 -> 4096 (+512B sector slack on the buffer).
- **Filename in the title bar** - new `gb_get_name()` libgb wrapper over `GB_GETARG`; the title shows `NAME.EXT` (plus ` *` when unsaved). New/Load/Save As keep it current.
- **Load filter** - the Load picker lists text files only (skips APP/BIN/IST/SPR/FNT/RAW/IMG/SNA/DSK).
- **Tab** inserts 4 spaces.
- **Blinking underscore cursor** - blinks on a ~1.5 Hz timer; the off-phase erases just the cursor cell (in the inter-line gap) so the text never flashes.
- **Arrow-key caret movement** - the pointer places the caret, the keyboard cursor keys nudge it. Read straight off the matrix via `KM_TEST_KEY` (no global re-arm, so no per-app key flood), edge-detected with auto-repeat; Left/Right walk the buffer, Up/Down keep the display column.
- **Save As / New-with-name** - the File menu gains Save As; New prompts for a name; a modal name-entry dialog with a `.TXT` default extension.

## Build
- Raised the shared app `--data-loc` from 0x6000 to 0x6200. The new code pushed Notepad's `_CODE` past the 8K mark into the data region - a code/data split issue, the 16K page still fits. Now code has 8.7K and data tops out ~0x757E, clear of the kernel at 0x8000. Other apps are unaffected.

Verified in 1984 (128/512K): renders, no crash; caret placement, blink, arrow nav and Save As exercised; text no longer flashes on blink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
