### PR TITLE
File Manager: full-height grid icons + fix GBFAT/icon-set collision (#88)

### DIFF
--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -18,7 +18,7 @@
 #define DEF_X    4            /* window position */
 #define DEF_Y    26
 #define DEF_W    56            /* default size; the window is resizeable (#81) */
-#define DEF_H    130
+#define DEF_H    158           /* taller default so full icons still show ~3 rows (#88) */
 #define MIN_W    24            /* min size keeps the title + a couple of rows usable */
 #define MIN_H    62
 #define TITLE_H  14
@@ -43,7 +43,7 @@
 /* icons view */
 #define ICOLS    3
 #define CELL_W   (CT_W / ICOLS)          /* cell width (17) */
-#define CELL_H   28                      /* icon (16) + name (8) + gap */
+#define CELL_H   44                      /* full icon (32) + name (8) + gap (#88) */
 #define IVIS     (CT_H / CELL_H)         /* visible grid rows (4) */
 #define NAME_MAX (CELL_W * 4 / 6)        /* chars that fit a cell (6px font) */
 
@@ -256,8 +256,8 @@ static void draw_icons_view(void)
             if (!name) return;
             cx = CT_X + c * CELL_W;
             cy = CT_Y + r * CELL_H;
-            gb_blite(cx + (CELL_W - 8) / 2, cy + 1);   /* icon centered in the cell */
-            draw_name(cx, cy + 18, name);
+            gb_blite_full(cx + (CELL_W - 8) / 2, cy + 1);  /* full icon, uncut (#88) */
+            draw_name(cx, cy + 34, name);                   /* name below the 32px icon */
             if (nsel == (unsigned char)idx + 1)
                 gb_frame(cx, cy, CELL_W, CELL_H - 1, 3);
             idx++;

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -142,6 +142,7 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_copy_end             ; GB_COPYEND     #8093 (restore target ctx)
                 jp    k_on_bar               ; GB_ONBAR       #8096 (HL = bar handler, #77)
                 jp    k_wm_setsize           ; GB_WMSETSIZE   #8099 (A = w, L = h, #81)
+                jp    gb_blit_entry_full     ; GB_BLITEFULL   #809C (B=x C=y, full icon #88)
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -669,6 +670,17 @@ be_y            db    0
 be_slot         db    0
 ig_w            db    0
 ig_h            db    0
+
+; gb_blit_entry_full (GB_BLITEFULL): like gb_blit_entry, but the FULL icon (all
+; rows) instead of the half-height middle band - the File Manager's icon-grid view
+; uses it so tall art (e.g. the geobench lollipop) isn't cut. B = x, C = y. picks
+; the slot by the current entry, then hands to k_icon's full blit. ext_to_icon
+; clobbers B (cmp_name8), so save x,y across it.
+gb_blit_entry_full
+                push  bc
+                call  ext_to_icon            ; A = slot for the current entry
+                pop   bc
+                jp    k_icon                  ; full blit: A = slot, B = x, C = y
 
 ; icon_geom: A = slot -> from the .IST directory (DATA_ICONS) set up a
 ; half-height blit (middle band) at (be_x, be_y). PAGE_DATA must be mapped.

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -924,11 +924,11 @@ icon_init
                 ld    hl,KCFG_ICONNAME       ; fs_req_name = the config icon name
                 ld    de,fs_req_name
                 call  copy11
-                ld    hl,GB_KERNEL-DATA_ICONS-#200   ; cap = ALL the free icon region, from
-                ld    (fs_load_max),hl               ; DATA_ICONS up to the kernel (#8000),
-                                                     ; less a sector. Derived from the layout
-                                                     ; so it never needs hand-tuning: ~#3A00
-                                                     ; (~57 icons), the physical ceiling.
+                ld    hl,GBFAT_LOAD-DATA_ICONS-#200  ; cap = the free icon region: from
+                ld    (fs_load_max),hl               ; DATA_ICONS up to GBFAT_LOAD (the FAT
+                                                     ; write module also lives in PAGE_DATA),
+                                                     ; less a sector. ~#1A00 (~25 icons),
+                                                     ; derived so it never needs hand-tuning.
                 ld    hl,DATA_ICONS
                 ld    (fs_load_dst),hl
                 ld    hl,def_ist             ; fall back to DEFAULT.IST if missing

--- a/kernel/modules/gbfat.asm
+++ b/kernel/modules/gbfat.asm
@@ -18,7 +18,8 @@
 ; GBFAT.BIN (and copied onto the IDE volume).
 ; ---------------------------------------------------------------------------
 
-GBFAT_ORG       equ   #5000
+GBFAT_ORG       equ   #6000        ; in PAGE_DATA, above the font+icon set (#88: the
+                                   ; 15-icon set reached #534C and collided with #5000)
 GBFAT_LEN       equ   #1400
 GBFAT_NAME      equ   #1402
 GBFAT_RES       equ   #140D

--- a/lib/fs_ide_fat.asm
+++ b/lib/fs_ide_fat.asm
@@ -41,7 +41,8 @@ GBFAT_OP        equ   #140E        ; operation: 0 = save, 1 = delete (#62)
 GBFAT_DIR       equ   #140F        ; directory cluster (4 bytes) to operate in
 GBFAT_DATA      equ   #2200        ; staged data (<= GBFAT_MAX bytes)
 GBFAT_MAX       equ   #1C00        ; 7 KB staging cap (fits #2200..#3DFF in low RAM)
-GBFAT_LOAD      equ   #5000        ; module load address (above the font/icons)
+GBFAT_LOAD      equ   #6000        ; module load address, above the font+icon set in
+                                   ; PAGE_DATA (must match GBFAT_ORG in gbfat.asm; #88)
 
                 include "fs_fat32_core.asm"
 

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -40,6 +40,7 @@ void gb_frame(unsigned char col, unsigned char line,     /* rectangle outline   
 void gb_icon(unsigned char slot, unsigned char col,      /* full icon blit       */
              unsigned char line);
 void gb_blite(unsigned char col, unsigned char line);    /* current entry's icon */
+void gb_blite_full(unsigned char col, unsigned char line); /* ...full height (grid) */
 void gb_curshow(void);                                   /* draw the pointer     */
 void gb_curhide(void);                                   /* lift the pointer     */
 unsigned char gb_poll(void);          /* frame poll -> flags; caches cursor pos   */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -17,6 +17,7 @@
         .globl  _gb_frame
         .globl  _gb_icon
         .globl  _gb_blite
+        .globl  _gb_blite_full
         .globl  _gb_curshow
         .globl  _gb_curhide
         .globl  _gb_poll
@@ -170,6 +171,13 @@ _gb_blite:
         ld      b, a
         ld      c, l
         jp      0x8018          ; GB_BLITE
+
+;; void gb_blite_full(unsigned char col, unsigned char line);  current entry's icon,
+;; FULL height (the grid view, so tall art isn't cut)
+_gb_blite_full:
+        ld      b, a
+        ld      c, l
+        jp      0x809C          ; GB_BLITEFULL
 
 ;; void gb_curshow(void); / gb_curhide(void);
 _gb_curshow:


### PR DESCRIPTION
Follow-up to the per-type icons (#88): show full icons in the File Manager grid, and fix a memory collision the larger icon set exposed.

## Full-height grid icons
The icon-grid view blitted the half-height middle band (`gb_blite` skips the icon's top quarter), so tall art - the geobench lollipop, the clock - lost its top. Added a full-icon entry blit (`GB_BLITEFULL` / `gb_blite_full`): picks the slot by the current entry like `gb_blite`, then hands to `k_icon`'s full 32-row blit (single source of truth - still `ext_to_icon`). The grid uses it with a taller cell (`CELL_H` 28->44) and a slightly taller default window (`DEF_H` 130->158) so ~3 rows still show. List view keeps the compact half-height blit.

## Fix: GBFAT clobbering the icon set
The FAT write module loads into PAGE_DATA at `GBFAT_LOAD=#5000`, just above the font+icons. The 15-icon set now reaches `#534C`, overlapping it - so the first fs write (e.g. the View toggle's config save) overwrote icon slots 12-14, turning the `.FNT`/`.IST` icons to garbage. Move `GBFAT_ORG`/`GBFAT_LOAD` to `#6000` (above the set; the module is 1917B of code, its buffers are in low RAM) and cap the icon-set load at `GBFAT_LOAD - DATA_ICONS - #200` (~`#1A00`, ~25 icons) - the real PAGE_DATA ceiling for icons, not the kernel base the earlier cap wrongly used.

## Verify
- Grid: CLOCK shows the full clock (with base), tall art uncut; ~3 rows by default.
- Toggle View (or force a config save): icon slots 12-14 (`.FNT`/`.IST`) stay clean - confirmed headless and by the user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
