### PR TITLE
Robustness: build-time guards against silent memory overflow

### DIFF
--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -2459,6 +2459,17 @@ md_last         dw    0
                 include "../lib/fs_amsdos.asm"
                 include "../lib/bank.asm"
 kern_end                                        ; GBKERN.BIN = #8000..kern_end only.
+
+; --- STABILITY GUARD: the resident kernel must not eat the stack -----------------
+; The CPC runs on the UniDOS stack, which grows DOWN from HIMEM (&A288) toward
+; kern_end - the only stack space is the gap between them. If the kernel grows into
+; the reserve the stack smashes the resident image on a deep call + interrupt (a
+; silent crash). This assert turns that into a LOUD build failure so a too-big
+; kernel is caught here, not in the field. (Reclaim, or move scratch out, to fix.)
+HIMEM           equ   #A288        ; UniDOS HIMEM (stack top); see docs/AMSDOS notes
+STACK_RESERVE   equ   192          ; min bytes kept free below HIMEM for the stack
+                assert HIMEM-kern_end>=STACK_RESERVE,"GBKERN too big: <192B stack left under HIMEM - reclaim resident bytes"
+
 ; --- scratch buffers live in LOW RAM (always the main bank, below the stack) -----
 ; They used to sit just above kern_end, but as the kernel grew they landed in the
 ; UniDOS stack's path: HIMEM &A288 grows DOWN toward kern_end, so a 512-byte sector
@@ -2486,6 +2497,10 @@ cfont_img       incbin "../build/CLASSIC.FNT"   ; alternate 8x8 font (FONT=CLASS
 cfont_imgend
 icon_img        incbin "../build/DEFAULT.IST"   ; packaged on the disk as DEFAULT.IST
 icon_imgend
+                ; STABILITY GUARD: the icon set loads into PAGE_DATA at DATA_ICONS and
+                ; must stay below GBFAT_LOAD (the FAT module shares PAGE_DATA) - else a
+                ; save/delete/copy overwrites the end of the set (garbled icons, #88).
+                assert icon_imgend-icon_img<=GBFAT_LOAD-DATA_ICONS-#200,"DEFAULT.IST too big: would collide with GBFAT in PAGE_DATA - fewer icons or raise GBFAT_LOAD"
 wel_img         incbin "../assets/WELCOME.TXT"  ; a sample text file to open in VIEWER
 wel_imgend
                 include "../lib/cursor_data.asm" ; cur_spr_data..cur_spr_end -> DEFAULT.SPR

--- a/tools/build_capp.sh
+++ b/tools/build_capp.sh
@@ -33,6 +33,27 @@ mkdir -p "$work"
 "$SDCC" -mz80 --fomit-frame-pointer -I "$GB" -c "$GB/gbwin.c" -o "$work/gbwin.rel"
 "$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x6200 \
     "$work/crt0.rel" "$work/main.rel" "$work/gbwin.rel" "$work/gblib.rel" -o "$work/app.ihx"
+# STABILITY GUARD: the app must fit its 16K page - code below the data-loc (#6200),
+# data+bss below the kernel (#8000). A silent overflow corrupts memory at runtime
+# (it bit NOTEPAD once); turn it into a loud build failure here.
+python3 - "$work/app.map" "$APP" <<'PY'
+import sys, re
+mapf, app = sys.argv[1], sys.argv[2]
+area = {}
+for line in open(mapf):
+    m = re.match(r'^(_CODE|_DATA|_BSS|_INITIALIZED|_GSINIT)\s+([0-9A-Fa-f]{8})\s+([0-9A-Fa-f]{8})', line)
+    if m:
+        area[m.group(1)] = (int(m.group(2), 16), int(m.group(3), 16))
+code_end = sum(area.get('_CODE', (0, 0)))
+top = max((s + sz) for s, sz in area.values()) if area else 0
+errs = []
+if code_end > 0x6200: errs.append('code ends 0x%04X > data-loc 0x6200' % code_end)
+if top > 0x8000:      errs.append('data/bss ends 0x%04X > kernel 0x8000' % top)
+if errs:
+    sys.stderr.write('FIT ERROR (%s): %s - shrink it or move --data-loc\n' % (app, '; '.join(errs)))
+    sys.exit(1)
+PY
+
 "$MAKEBIN" -p "$work/app.ihx" "$work/app.bin"
 
 # makebin emits a flat image from #0000; the app lives at #4000 -> strip low 16K.


### PR DESCRIPTION
A stability pass. The recurring crash class is silent overflow - a memory region quietly grows into its neighbour (hit twice this session: NOTEPAD code->data, GBFAT->icon set). Added build-time asserts so these fail LOUDLY at build time, not in the field:

- kernel must leave >=192B stack below HIMEM
- DEFAULT.IST must fit below GBFAT_LOAD in PAGE_DATA
- each app: code < data-loc (#6200), data/bss < kernel (#8000)

Zero resident cost (build-time asserts). Each verified to fire when violated; all pass currently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)