### PR TITLE
Per-app data-loc; NOTEPAD gets a higher one (#97)

### DIFF
--- a/tools/build_capp.sh
+++ b/tools/build_capp.sh
@@ -14,6 +14,11 @@ cd "$(dirname "$0")/.."
 APP="${1:-apps/chello}"
 OUT="${2:-build/CHELLO.RAW}"
 GB="lib/gb"                                 # shared libgb (gb.h, gblib.s, crt0.s)
+# DATA_LOC: where this app's data starts (code is #4000.. below it, data ..#7FFF
+# above). The default 0x6200 is a 50/50 split; a code-heavy/data-light app (NOTEPAD)
+# can pass a higher value to trade its spare data room for code room. Per-app so a
+# data-heavy app (VIEWER) keeps the low split. (#97)
+DATA_LOC="${DATA_LOC:-0x6200}"
 
 SDCC="${SDCC:-sdcc}"
 BIN="$(dirname "$(command -v "$SDCC")")"   # sdasz80 / makebin sit beside sdcc
@@ -31,14 +36,14 @@ mkdir -p "$work"
 # the notepad's return - SDCC's epilogue is `ld sp,<fp>`).
 "$SDCC" -mz80 --fomit-frame-pointer -I "$GB" -c "$APP/main.c" -o "$work/main.rel"
 "$SDCC" -mz80 --fomit-frame-pointer -I "$GB" -c "$GB/gbwin.c" -o "$work/gbwin.rel"
-"$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc 0x6200 \
+"$SDCC" -mz80 --no-std-crt0 --code-loc 0x4000 --data-loc "$DATA_LOC" \
     "$work/crt0.rel" "$work/main.rel" "$work/gbwin.rel" "$work/gblib.rel" -o "$work/app.ihx"
-# STABILITY GUARD: the app must fit its 16K page - code below the data-loc (#6200),
-# data+bss below the kernel (#8000). A silent overflow corrupts memory at runtime
-# (it bit NOTEPAD once); turn it into a loud build failure here.
-python3 - "$work/app.map" "$APP" <<'PY'
+# STABILITY GUARD: the app must fit its 16K page - code below its data-loc, data+bss
+# below the kernel (#8000). A silent overflow corrupts memory at runtime (it bit
+# NOTEPAD once); turn it into a loud build failure here.
+python3 - "$work/app.map" "$APP" "$DATA_LOC" <<'PY'
 import sys, re
-mapf, app = sys.argv[1], sys.argv[2]
+mapf, app, dloc = sys.argv[1], sys.argv[2], int(sys.argv[3], 16)
 area = {}
 for line in open(mapf):
     m = re.match(r'^(_CODE|_DATA|_BSS|_INITIALIZED|_GSINIT)\s+([0-9A-Fa-f]{8})\s+([0-9A-Fa-f]{8})', line)
@@ -47,10 +52,10 @@ for line in open(mapf):
 code_end = sum(area.get('_CODE', (0, 0)))
 top = max((s + sz) for s, sz in area.values()) if area else 0
 errs = []
-if code_end > 0x6200: errs.append('code ends 0x%04X > data-loc 0x6200' % code_end)
-if top > 0x8000:      errs.append('data/bss ends 0x%04X > kernel 0x8000' % top)
+if code_end > dloc:  errs.append('code ends 0x%04X > data-loc 0x%04X' % (code_end, dloc))
+if top > 0x8000:     errs.append('data/bss ends 0x%04X > kernel 0x8000' % top)
 if errs:
-    sys.stderr.write('FIT ERROR (%s): %s - shrink it or move --data-loc\n' % (app, '; '.join(errs)))
+    sys.stderr.write('FIT ERROR (%s): %s - shrink it or raise DATA_LOC\n' % (app, '; '.join(errs)))
     sys.exit(1)
 PY
 

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -26,7 +26,8 @@ python3 tools/packicons.py build/DEFAULT.IST \
 tools/build_capp.sh apps/desktop build/DESKTOP.RAW # DESKTOP (C/SDCC) -> build/DESKTOP.RAW
 tools/build_capp.sh apps/filemgr build/FILEMGR.RAW # FILEMGR (C/SDCC) -> build/FILEMGR.RAW
 tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VIEWER.RAW
-tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD (C/SDCC) -> build/NOTEPAD.RAW
+DATA_LOC=0x6800 tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD: code-heavy,
+                                   # so a higher data-loc gives it ~1.9K code room (#97)
 tools/build_capp.sh apps/iconed build/ICONED.RAW   # ICONED (C/SDCC) -> build/ICONED.RAW
 tools/build_capp.sh apps/clock  build/CLOCK.RAW    # CLOCK  (C/SDCC) -> build/CLOCK.RAW
 tools/build_capp.sh apps/chello build/CHELLO.RAW   # C app (SDCC) -> build/CHELLO.RAW


### PR DESCRIPTION
Closes #97. build_capp.sh takes a DATA_LOC env (default 0x6200) so the 16K code/data split matches each app. NOTEPAD (code-heavy) builds at 0x6800: code room 358B -> ~1894B (room for copy/paste etc.), data still well under the kernel. VIEWER keeps the low split. Fit guard uses the per-app data-loc. No .RAW size change; NOTEPAD verified rendering unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)