### PR TITLE
Icons: move the file->icon mapping from the kernel into the File Manager (#103)

### DIFF
--- a/apps/filemgr/main.c
+++ b/apps/filemgr/main.c
@@ -229,13 +229,80 @@ static char *name83(const char *e)
    extension; gb_dir* return name only). */
 static char *fullname(void) { return name83(gb_entname()); }
 
+/* DEFAULT.IST slot order (matches the packicons line in tools/build_kernel.sh).
+   The file -> icon mapping lives here now, not in the kernel (#103). */
+#define ICON_CLOCK 2
+#define ICON_GEOBENCH 4
+#define ICON_BASIC 5
+#define ICON_BINARY 6
+#define ICON_PICTURE 7
+#define ICON_TEXT 8
+#define ICON_FOLDER 9
+#define ICON_APP 10
+#define ICON_NOTEPAD 11
+#define ICON_ICONED 12
+#define ICON_FNT 13
+#define ICON_IST 14
+#define ICON_DESKTOP 15
+#define ICON_FILEMGR 16
+#define ICON_PAINT 17
+#define ICON_FRACTAL 18
+
+/* name_is: does the name part (before '.') of "NAME.EXT" equal want? */
+static unsigned char name_is(const char *name, const char *want)
+{
+    unsigned char i = 0;
+    while (want[i]) { if (name[i] != want[i]) return 0; i++; }
+    return (unsigned char)(name[i] == '.' || name[i] == 0);
+}
+/* ext_of: the (uppercase, <=3 char) extension of "NAME.EXT" into ext[4]. */
+static void ext_of(const char *name, char *ext)
+{
+    const char *e = name;
+    unsigned char i;
+    while (*e && *e != '.') e++;
+    if (*e != '.') { ext[0] = 0; return; }
+    e++;
+    for (i = 0; i < 3 && e[i] && e[i] != ' '; i++) ext[i] = e[i];
+    ext[i] = 0;
+}
+static unsigned char ext_eq(const char *ext, const char *want)
+{
+    return (unsigned char)(ext[0] == want[0] && ext[1] == want[1] && ext[2] == want[2]);
+}
+
+/* entry_icon: the current entry (name + gb_isdir) -> its DEFAULT.IST slot. */
+static unsigned char entry_icon(const char *name)
+{
+    char ext[4];
+    if (gb_isdir()) return ICON_FOLDER;
+    if (name_is(name, "GBKERN")) return ICON_GEOBENCH;   /* the kernel binary */
+    ext_of(name, ext);
+    if (ext_eq(ext, "BAS")) return ICON_BASIC;
+    if (ext_eq(ext, "SCR") || ext_eq(ext, "PIC")) return ICON_PICTURE;
+    if (ext_eq(ext, "TXT") || ext_eq(ext, "CFG")) return ICON_TEXT;
+    if (ext_eq(ext, "FNT")) return ICON_FNT;
+    if (ext_eq(ext, "IST")) return ICON_IST;
+    if (ext_eq(ext, "APP")) {
+        if (name_is(name, "NOTEPAD")) return ICON_NOTEPAD;
+        if (name_is(name, "ICONED"))  return ICON_ICONED;
+        if (name_is(name, "CLOCK"))   return ICON_CLOCK;
+        if (name_is(name, "DESKTOP")) return ICON_DESKTOP;
+        if (name_is(name, "FILEMGR")) return ICON_FILEMGR;
+        if (name_is(name, "PAINT"))   return ICON_PAINT;
+        if (name_is(name, "FRACTAL")) return ICON_FRACTAL;
+        return ICON_APP;
+    }
+    return ICON_BINARY;
+}
+
 static void draw_list_view(void)
 {
     unsigned char i, y;
     char *name = dir_seek(top);
     for (i = 0; i < LVIS && name; i++) {
         y = CT_Y + i * ROW_H;
-        gb_blite(CT_X, y + 1);              /* type icon (8 cols x 16 lines) */
+        gb_icon_half(entry_icon(fullname()), CT_X, y + 1);  /* half-height type icon (#103) */
         gb_text(CT_X + 9, y + 6, fullname());   /* NAME.EXT (icon view is name only) */
         name = gb_dirn();
     }
@@ -256,7 +323,7 @@ static void draw_icons_view(void)
             if (!name) return;
             cx = CT_X + c * CELL_W;
             cy = CT_Y + r * CELL_H;
-            gb_blite_full(cx + (CELL_W - 8) / 2, cy + 1);  /* full icon, uncut (#88) */
+            gb_icon(entry_icon(fullname()), cx + (CELL_W - 8) / 2, cy + 1);  /* full icon (#103) */
             draw_name(cx, cy + 34, name);                   /* name below the 32px icon */
             if (nsel == (unsigned char)idx + 1)
                 gb_frame(cx, cy, CELL_W, CELL_H - 1, 3);

--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -98,7 +98,7 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    gb_open_window         ; GB_WINDOW #800F
                 jp    gb_fs_dir_first        ; GB_DIR1   #8012
                 jp    gb_fs_dir_next         ; GB_DIRN   #8015
-                jp    gb_blit_entry          ; GB_BLITE  #8018
+                jp    k_vsync                ; GB_BLITE  #8018 (removed: mapping->FM, #103)
                 jp    k_curshow              ; GB_CURSHOW #801B
                 jp    k_poll                 ; GB_POLL    #801E
                 jp    k_frame                ; GB_FRAME   #8021
@@ -142,7 +142,8 @@ WM_FR_ARG       equ   14           ;   11-byte 8.3 file arg, captured at gb_wm_a
                 jp    k_copy_end             ; GB_COPYEND     #8093 (restore target ctx)
                 jp    k_on_bar               ; GB_ONBAR       #8096 (HL = bar handler, #77)
                 jp    k_wm_setsize           ; GB_WMSETSIZE   #8099 (A = w, L = h, #81)
-                jp    gb_blit_entry_full     ; GB_BLITEFULL   #809C (B=x C=y, full icon #88)
+                jp    k_vsync                ; GB_BLITEFULL   #809C (removed: mapping->FM, #103)
+                jp    k_icon_half            ; GB_ICONHALF    #809F (A=slot B=x C=y, #103)
 
 ; ---------------------------------------------------------------------------
 kernel_main
@@ -650,16 +651,16 @@ fe_end
                 ret
 dir_namebuf     defs  14
 
-; --- gb_blit_entry: half-height type icon for the current entry ----------
-; B = byte col, C = line. Picks the icon by fs_ent_name's extension, reads the
-; bitmap + size from the .IST in PAGE_DATA, and blits its middle band.
-gb_blit_entry
+; --- k_icon_half (GB_ICONHALF): half-height (middle-band) blit of icon A=slot at
+; B=x, C=y. The file->slot mapping now lives in the File Manager (#103); the kernel
+; only blits a given slot (it owns PAGE_DATA where the .IST lives). The grid view
+; uses k_icon (full icon), the list view uses this (compact 16px middle band).
+k_icon_half
+                ld    (be_slot),a            ; save the slot (A is reused below)
                 ld    a,b
                 ld    (be_x),a
                 ld    a,c
                 ld    (be_y),a
-                call  ext_to_icon            ; A = slot (reads resident fs_ent_name)
-                ld    (be_slot),a
                 call  to_data
                 ld    a,(be_slot)
                 call  icon_geom              ; sets bm_src/bm_w/bm_h/bm_x/bm_y
@@ -670,17 +671,6 @@ be_y            db    0
 be_slot         db    0
 ig_w            db    0
 ig_h            db    0
-
-; gb_blit_entry_full (GB_BLITEFULL): like gb_blit_entry, but the FULL icon (all
-; rows) instead of the half-height middle band - the File Manager's icon-grid view
-; uses it so tall art (e.g. the geobench lollipop) isn't cut. B = x, C = y. picks
-; the slot by the current entry, then hands to k_icon's full blit. ext_to_icon
-; clobbers B (cmp_name), so save x,y across it.
-gb_blit_entry_full
-                push  bc
-                call  ext_to_icon            ; A = slot for the current entry
-                pop   bc
-                jp    k_icon                  ; full blit: A = slot, B = x, C = y
 
 ; icon_geom: A = slot -> from the .IST directory (DATA_ICONS) set up a
 ; half-height blit (middle band) at (be_x, be_y). PAGE_DATA must be mapped.
@@ -729,111 +719,8 @@ ig_done
                 ld    (bm_y),a
                 ret
 
-; ext_to_icon: A = icon slot for the current entry (fs_ent_name + fs_ent_attr).
-; Table-driven (#95, was a long chain of inline cmp_ext / cmp_name8 checks): a
-; folder check, the kernel-name special case, then an ext table ({3 chars, slot};
-; APP's slot #FF means "look the name up in the app-name table"), else binary.
-ext_to_icon
-                ld    a,(fs_ent_attr)         ; directory -> folder (slot 9)
-                and   #10
-                jr    nz,eti_folder
-                ld    hl,name_kernel          ; the kernel binary -> geobench icon (slot 4)
-                call  cmp_name
-                jr    z,eti_geo
-                ld    hl,ext_table            ; scan {3-char ext, slot byte}
-eti_el          ld    a,(hl)
-                or    a
-                jr    z,eti_bin               ; 0 terminator -> binary default
-                call  cmp_ext                 ; 3 chars at HL vs ext; HL preserved
-                jr    z,eti_eh
-                inc   hl                        ; next entry (3 ext + 1 slot)
-                inc   hl
-                inc   hl
-                inc   hl
-                jr    eti_el
-eti_eh          inc   hl                        ; HL -> the slot byte
-                inc   hl
-                inc   hl
-                ld    a,(hl)
-                inc   a                          ; #FF (the .APP sentinel) -> 0
-                jr    z,eti_appname
-                dec   a                          ; restore the real slot
-                ret
-eti_bin         ld    a,6
-                ret
-eti_folder      ld    a,9
-                ret
-eti_geo         ld    a,4
-                ret
-; .APP name sub-dispatch: scan {8-char name, slot}, else the generic app icon (10).
-eti_appname     ld    hl,appname_table
-eti_al          ld    a,(hl)
-                or    a
-                jr    z,eti_appdef
-                call  cmp_name                ; 8 chars at HL vs name; HL preserved
-                jr    z,eti_ah
-                ld    bc,9                      ; next entry (8 name + 1 slot)
-                add   hl,bc
-                jr    eti_al
-eti_ah          ld    de,8                      ; HL -> the slot byte
-                add   hl,de
-                ld    a,(hl)
-                ret
-eti_appdef      ld    a,10
-                ret
-
-; cmp_ext: Z if the 3 chars at HL == fs_ent_name+8. HL preserved. Clobbers A, DE.
-cmp_ext
-                push  hl
-                ld    de,fs_ent_name+8
-                ld    a,(de)
-                cp    (hl)
-                jr    nz,cmpe_x
-                inc   hl
-                inc   de
-                ld    a,(de)
-                cp    (hl)
-                jr    nz,cmpe_x
-                inc   hl
-                inc   de
-                ld    a,(de)
-                cp    (hl)
-cmpe_x          pop   hl
-                ret
-; cmp_name: Z if the 8 chars at HL == fs_ent_name[0..7]. HL preserved. Clobbers A,B,DE.
-cmp_name
-                push  hl
-                ld    de,fs_ent_name
-                ld    b,8
-cmpn_l          ld    a,(de)
-                cp    (hl)
-                jr    nz,cmpn_x
-                inc   hl
-                inc   de
-                djnz  cmpn_l
-cmpn_x          pop   hl
-                ret
-
-; ext table: {3-char ext, slot}. APP -> #FF = sentinel for the app-name table.
-ext_table       db    "BAS",5
-                db    "SCR",7
-                db    "PIC",7
-                db    "TXT",8
-                db    "CFG",8
-                db    "FNT",13
-                db    "IST",14
-                db    "APP",#FF
-                db    0
-; app-name sub-table: {8-char name, slot}. (GBKERN handled separately above.)
-appname_table   db    "NOTEPAD ",11
-                db    "ICONED  ",12
-                db    "CLOCK   ",2
-                db    "DESKTOP ",15
-                db    "FILEMGR ",16
-                db    "PAINT   ",17     ; PAINT.APP   (app not built yet, #100)
-                db    "FRACTAL ",18     ; FRACTAL.APP (app not built yet, #100)
-                db    0
-name_kernel     db    "GBKERN  "
+; (file -> icon-slot mapping moved to the File Manager, #103 - the kernel now
+; only blits a given slot via k_icon / k_icon_half; the .IST lives in PAGE_DATA.)
 
 ; --- config (C kernel module) --------------------------------------------
 ; cfg_boot: seed defaults, load GEOBENCH.CFG into the transfer area, then run the

--- a/lib/gb/gb.h
+++ b/lib/gb/gb.h
@@ -39,8 +39,8 @@ void gb_frame(unsigned char col, unsigned char line,     /* rectangle outline   
               unsigned char w, unsigned char h, unsigned char pen);
 void gb_icon(unsigned char slot, unsigned char col,      /* full icon blit       */
              unsigned char line);
-void gb_blite(unsigned char col, unsigned char line);    /* current entry's icon */
-void gb_blite_full(unsigned char col, unsigned char line); /* ...full height (grid) */
+void gb_icon_half(unsigned char slot, unsigned char col,   /* half-height (16px) blit */
+                  unsigned char line);                     /* by slot, for list views */
 void gb_curshow(void);                                   /* draw the pointer     */
 void gb_curhide(void);                                   /* lift the pointer     */
 unsigned char gb_poll(void);          /* frame poll -> flags; caches cursor pos   */

--- a/lib/gb/gblib.s
+++ b/lib/gb/gblib.s
@@ -16,8 +16,7 @@
         .globl  _gb_fill
         .globl  _gb_frame
         .globl  _gb_icon
-        .globl  _gb_blite
-        .globl  _gb_blite_full
+        .globl  _gb_icon_half
         .globl  _gb_curshow
         .globl  _gb_curhide
         .globl  _gb_poll
@@ -166,18 +165,18 @@ _gb_icon:
         ld      hl, (sv_ret)
         jp      (hl)
 
-;; void gb_blite(u8 col, u8 line);   A=col, L=line -> B=col C=line
-_gb_blite:
-        ld      b, a
+;; void gb_icon_half(u8 slot, u8 col, u8 line);   half-height (middle band) blit of a
+;; given slot. A=slot, L=col, [SP+2]=line -> A=slot B=col C=line. (#103)
+_gb_icon_half:
+        ld      b, l            ; B = col (A still holds slot)
+        pop     hl
+        ld      (sv_ret), hl
+        pop     hl              ; L=line, H=overshoot
+        dec     sp
         ld      c, l
-        jp      0x8018          ; GB_BLITE
-
-;; void gb_blite_full(unsigned char col, unsigned char line);  current entry's icon,
-;; FULL height (the grid view, so tall art isn't cut)
-_gb_blite_full:
-        ld      b, a
-        ld      c, l
-        jp      0x809C          ; GB_BLITEFULL
+        call    0x809F          ; GB_ICONHALF
+        ld      hl, (sv_ret)
+        jp      (hl)
 
 ;; void gb_curshow(void); / gb_curhide(void);
 _gb_curshow:


### PR DESCRIPTION
The mapping (policy) was kernel-resident but FM-only; move it to the FM. Kernel keeps only blit-by-slot (k_icon full, new k_icon_half for the list); ext_to_icon + tables + by-entry blits removed. -227B resident (headroom 279->506). FM does entry_icon() in C (keyed off fullname() since gb_dir* drop the ext). Adding an icon mapping is now an FM-only change. User-verified: all icon types render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)