### PR TITLE
Fix floppy bugs: Disk B won't open; ICONED can't load .IST (#110)

### DIFF
--- a/apps/iconed/main.c
+++ b/apps/iconed/main.c
@@ -49,10 +49,12 @@
 #define MENU_COL  10           /* "File" title column in the top bar (matches notepad) */
 #define MENU_END  16
 
-/* BUFSZ holds the whole file. gb_fs_load copies in WHOLE 512-byte sectors, so this
-   must be >= the file rounded up to a sector or the load overflows into the globals
-   after it (DEFAULT.IST is 2876 -> 6 sectors = 3072). 4096 = 8 sectors. */
-#define BUFSZ     4096
+/* BUFSZ holds the whole file. gb_fs_load copies in WHOLE 512-byte sectors and is
+   ALSO passed as fs_load_max, so a file bigger than BUFSZ is refused (the load is
+   not partial) - so this must cover the largest icon set (#110). The icon-set
+   ceiling is DATA_MODTOP-DATA_ICONS-#200 = 6656 -> 13 sectors; 7168 = 14 sectors
+   covers any DEFAULT.IST. (Was 4096, which the now-5216-byte DEFAULT.IST exceeds.) */
+#define BUFSZ     7168
 #define CUR_W     4            /* cursor: 4 bytes/row x 16 rows, phase = 64 bytes */
 #define CUR_H     16
 #define PHASE     64

--- a/lib/fs.asm
+++ b/lib/fs.asm
@@ -43,10 +43,10 @@ fs_init
                 jr    nc,fsi_set
                 xor   a                          ; card present -> boot drive 0 (Disk C)
 fsi_set
-                call  fs_set_drive               ; select the boot drive, then capture its
-                ld    hl,(fs_p_load)             ; loader as fs_sys_load: app binaries/
-                ld    (fs_sys_load),hl           ; modules always load from the boot drive,
-                ret                               ; regardless of a window's browse drive
+                ld    (fs_boot_drive),a           ; remember the boot drive NUMBER: app
+                call  fs_set_drive               ; binaries + modules always load from it
+                ret                               ; (fs_load_sys), regardless of a window's
+                                                 ; browse drive (#65/#110)
                 ; (fs_set_drive falls through below for the GB_SETDRIVE path)
 
 ; fs_set_drive: A = drive (0 = IDE/Disk C, 1 = floppy A, 2 = floppy B). Point the
@@ -82,7 +82,9 @@ fsd_floppy
                 ld    (fs_p_delete),hl
                 ret
 fs_cur_drive    defb  0
-fs_sys_load     defw  D0_LOAD       ; the boot drive's loader (fs_init captures it)
+fs_boot_drive   defb  0            ; #110: boot drive number; fs_load_sys loads apps/modules
+                                   ; from it regardless of a window's browse drive
+fls_browse      defb  0            ; fs_load_sys scratch: browse drive to restore
 
 ; fs_dir_first / fs_dir_next / fs_load_file: route to the selected backend.
 fs_dir_first
@@ -98,8 +100,16 @@ fs_load_file
 ; fs_load_sys: like fs_load_file but always from the BOOT drive (where app binaries
 ; and the GBFAT module live), regardless of the active browse drive (#65).
 fs_load_sys
-                ld    hl,(fs_sys_load)
-                jp    (hl)
+                ld    a,(fs_cur_drive)            ; save the active browse drive
+                ld    (fls_browse),a
+                ld    a,(fs_boot_drive)           ; load from the boot drive (where the app
+                call  fs_set_drive               ; binaries + GBFAT module live), NOT the
+                call  fs_load_file               ; window's browse drive - #110: a floppy-B
+                push  af                          ; window must still load apps off floppy A
+                ld    a,(fls_browse)             ; (CF result preserved across the restore)
+                call  fs_set_drive               ; restore the browse drive
+                pop   af
+                ret
 ; fs_save_file: save fs_save_len bytes from (fs_save_src) to fs_req_name. The
 ; AMSDOS backend creates the file if absent and allocates/frees 1KB blocks as the
 ; size changes (single extent, <=16KB). CF set = saved, NC = failed (disk/dir

--- a/lib/fs_albireo.asm
+++ b/lib/fs_albireo.asm
@@ -206,13 +206,13 @@ ade_skip
 ; CF set = loaded, NC = not found.
 fsalb_load_file
                 call  alb_ensure_mount
-                jr    nc,alf_nf
+                jp    nc,alf_nf                   ; jp: alf_nf is out of jr range (#110)
                 call  alb_setname_req
                 ld    a,ALBC_FILEOPEN
                 call  alb_sendcmd
                 call  alb_waitint
                 cp    ALB_INT_SUCCESS
-                jr    nz,alf_nf                   ; missing / is a directory
+                jp    nz,alf_nf                   ; missing / is a directory
                 ld    a,ALBC_BYTEREAD
                 call  alb_sendcmd
                 ld    a,#FF
@@ -230,6 +230,19 @@ alf_loop
                 or    a
                 jr    z,alf_eof
                 ld    e,a                          ; E = chunk length
+                ld    d,0                           ; #110: refuse if this chunk would push
+                ld    hl,(fs_ent_size)             ; the total past fs_load_max (the caller's
+                add   hl,de                        ; buffer) - the chip doesn't give the size
+                ld    bc,(fs_load_max)             ; up front, so guard mid-stream like the IDE
+                or    a                             ; backend does up front
+                sbc   hl,bc
+                jr    z,alf_inbounds               ; total == max: ok
+                jr    c,alf_inbounds               ; total <  max: ok
+                pop   af                            ; total > max: too big -> abort the load
+                jr    alf_toobig
+alf_inbounds
+                ld    bc,ALB_DAT                    ; restore BC = data port (the cmp used it)
+                ld    a,e                           ; A = chunk length
                 ld    hl,(fs_load_dst)
                 call  alb_inira                    ; A bytes -> (fs_load_dst)
                 ld    d,0
@@ -260,6 +273,12 @@ alf_done
                 call  alb_waitint
                 scf
                 ret
+alf_toobig                                         ; #110: file > buffer -> close + fail (NC)
+                ld    a,ALBC_FILECLOSE
+                call  alb_sendcmd
+                xor   a
+                out   (c),a
+                call  alb_waitint
 alf_nf
                 or    a
                 ret

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -39,7 +39,8 @@ tools/build_capp.sh apps/filemgr build/FILEMGR.RAW # FILEMGR (C/SDCC) -> build/F
 tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VIEWER.RAW
 DATA_LOC=0x6800 tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD: code-heavy,
                                    # so a higher data-loc gives it ~1.9K code room (#97)
-tools/build_capp.sh apps/iconed build/ICONED.RAW   # ICONED (C/SDCC) -> build/ICONED.RAW
+DATA_LOC=0x5C00 tools/build_capp.sh apps/iconed build/ICONED.RAW # ICONED: lower data-loc so
+                                   # its 7KB icon-set buffer (BUFSZ) fits below #8000 (#110)
 tools/build_capp.sh apps/clock  build/CLOCK.RAW    # CLOCK  (C/SDCC) -> build/CLOCK.RAW
 tools/build_capp.sh apps/chello build/CHELLO.RAW   # C app (SDCC) -> build/CHELLO.RAW
 tools/build_cfgmod.sh build/GBCFG.RAW              # config-parser C kernel module -> build/GBCFG.RAW


### PR DESCRIPTION
Fixes the two floppy-version bugs in #110 (confirmed fixed by the user on the floppy Albireo build).

## A) Disk B wouldn't open a File Manager
`fs_load_sys` (loads app binaries + the GBFAT module) jumped straight to the captured boot loader, which on a floppy boot is `fsam_load_file` — and every `fsam_*` routine reads the **global `fsam_unit`**. Opening Disk B sets `fsam_unit=1` (via `gb_set_drive(2)`) before `gb_wm_open` loads `FILEMGR.APP`, so the app was sought on floppy B (where it isn't) → window never opened. Fix: `fs_init` records the boot **drive number** (`fs_boot_drive`); `fs_load_sys` switches to it around the load and restores the window's browse drive after (preserving CF). Albireo was immune (boot loader = the card).

## B) Double-clicking DEFAULT.IST opened ICONED but showed nothing
ICONED's `BUFSZ` was 4096 but `DEFAULT.IST` is now 5216 B (ceiling 6656). `gb_fs_load` passes `BUFSZ` as `fs_load_max`, so the bounded backend refused the oversized file → empty. Bump `BUFSZ`→7168 and lower ICONED's data-loc to `0x5C00` so the buffer fits. Also add the missing `fs_load_max` guard to `fsalb_load_file` (it silently overflowed on Albireo — why the bug didn't show there).

Builds clean both variants; Albireo boots with Disk C intact.

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
