### PR TITLE
Viewer: bigger buffer so larger .PIC images load (fixes penguin.PIC)

### DIFF
--- a/apps/viewer/main.c
+++ b/apps/viewer/main.c
@@ -10,7 +10,8 @@
  * skipped), so this doubles as a quick "peek" at anything on the disk. */
 #include "gb.h"
 
-#define VIEW_MAX  6144   /* file buffer size; also the load cap passed to gb_fs_load */
+#define VIEW_MAX  12288  /* file buffer + load cap. Big enough for a ~200x200 .PIC
+                            (a full-screen 320x200 is 16K - won't fit the 16K bank). */
 #define TX_COL    (unsigned char)(win_x + 2)     /* text/image start: byte col in window */
 #define TX_Y0     (unsigned char)(win_y + 12)    /* first text line / image top (rows)  */
 #define LINE_H    11     /* line pitch (pixels)                               */

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -41,7 +41,8 @@ python3 tools/packicons.py build/PAINT.IST \
 tools/build_capp.sh apps/desktop build/DESKTOP.RAW # DESKTOP (C/SDCC) -> build/DESKTOP.RAW
 DATA_LOC=0x6500 tools/build_capp.sh apps/filemgr build/FILEMGR.RAW # FILEMGR: higher data-loc
                                    # for code room now it sorts (a ~2.6K listing cache, #118)
-tools/build_capp.sh apps/viewer build/VIEWER.RAW   # VIEWER (C/SDCC) -> build/VIEWER.RAW
+DATA_LOC=0x4D00 tools/build_capp.sh apps/viewer build/VIEWER.RAW # VIEWER: low data-loc for a
+                                   # big file buffer (12K) so larger .PIC images fit the bank
 DATA_LOC=0x6800 DIALOGS=1 PROMPT=1 tools/build_capp.sh apps/notepad build/NOTEPAD.RAW # NOTEPAD:
                                    # code-heavy, so a higher data-loc gives it ~1.9K code room
                                    # (#97); shared File popup + name prompt (gbdlg/gbprompt, #114)


### PR DESCRIPTION
Opening `penguin.PIC` (200x200, 10 KB) gave **"file is empty or could not be read"**:
the Viewer's `VIEW_MAX` buffer was 6144 B, so `gb_fs_load` refused the larger file.

Bump the buffer to 12 KB and drop the Viewer's data-loc to 0x4D00 (its code is only
~3 KB) so the buffer still fits the 16 KB app bank. ~200x200 pictures now view; a
full-screen 320x200 (16 KB) still won't fit the bank - that needs the streaming /
scrolling view. Verified: penguin.PIC renders in the Viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)