### PR TITLE
input: accept either joystick fire button as a click (#124)

### DIFF
--- a/lib/input.asm
+++ b/lib/input.asm
@@ -84,21 +84,20 @@ input_poll
                 ld    (in_quit),a
                 ret
 
-; read_joystick: directions -> in_joy_dirs; fire 1 = select, fire 2 = quit.
+; read_joystick: directions -> in_joy_dirs; EITHER fire button -> select/click.
+; A generic Atari-style joystick's single fire reads as the CPC's Fire 2, while the
+; CPC's own sticks / the emulator's gamepad use Fire 1 - so accept both, else real
+; hardware can't click (#124). Quit stays on ESC (see input_poll), not a fire button.
 read_joystick
                 call  KM_GET_JOYSTICK
                 ld    c,a
                 and   #0F                     ; bits 0..3 = DIR_* directions
                 ld    (in_joy_dirs),a
-                bit   JOY_FIRE1,c
-                jr    z,rj_fire2
-                ld    a,1
-                ld    (in_fire),a
-rj_fire2
-                bit   JOY_FIRE2,c
+                ld    a,c
+                and   #30                     ; bit5 (fire1) | bit4 (fire2) = either fire
                 ret   z
                 ld    a,1
-                ld    (in_quit),a
+                ld    (in_fire),a
                 ret
 
 ; joy_to_delta: held directions -> a per-frame delta, with the acceleration ramp


### PR DESCRIPTION
Fixes #124.

**Diagnosis:** `read_joystick` (lib/input.asm) maps **Fire 1 (bit 5) -> click** and
**Fire 2 (bit 4) -> quit**. A generic **Atari-style joystick's single fire button
reads as the CPC's Fire 2**, so on real hardware the fire press was treated as a
quit (which the desktop ignores) -> "nothing happens". The 1984 emulator's gamepad
uses Fire 1, which is why it worked there and not on hardware.

**Fix:** treat **either** fire bit (4 or 5) as select/click, whatever the stick
wires it to. Quit stays on **ESC** (already handled in `input_poll`). Cursor
movement is unchanged, and the emulator click path (Fire 1) still works.

> NOT MERGED YET - needs **real-hardware verification** with the joystick (I can't
> drive a joystick fire headlessly; the emulator pointer is gamepad-only). Deployed
> to GEOBENCH.IMG for testing. If clicking + double-click now work on the real CPC,
> merge; if not, the next suspect is the click **edge** detection or the joystick
> sitting on a different port/bit.