### PR TITLE
FAT16 support + FDC-probe hang fix: GEOBENCH boots on real CPC hardware (#130)

### DIFF
--- a/kernel/gbkern.asm
+++ b/kernel/gbkern.asm
@@ -24,6 +24,9 @@
                 ifndef STORAGE_ALBIREO
 STORAGE_ALBIREO equ   0
                 endif
+                ifndef SPIKE                  ; #130: -DSPIKE=1 builds a minimal storage spike -
+SPIKE           equ   0                       ; load DESKTOP.APP right after fs_init, report, hang
+                endif
 
 ; Config transfer area - resident low RAM (stays main RAM under banking, so the
 ; paged-in GBCFG module can reach it). The kernel fills text/len, runs the
@@ -172,6 +175,34 @@ kernel_main
                                               ; gb_getkey (the keyboard is the joystick)
                 call  set_palette            ; GEOBENCH 4-pen palette
                 call  fs_init                ; pick storage backend (floppy here)
+                if SPIKE
+                ; #130 SPIKE harness (-DSPIKE=1): isolate the storage read - run the real
+                ; boot's pre-load setup, load DESKTOP.APP into a plain low buffer (no banking),
+                ; then HANG on the border (WHITE = loaded, RED = not found). Never reboots.
+                call  input_init             ; faithful context: the same setup the real boot
+                di                            ; runs between fs_init and its first load, so the
+                call  mem_detect             ; mount lands correctly
+                ei
+                call  bank_normal            ; mem_detect leaves the bank config dirty
+                ld    hl,spike_name
+                ld    de,fs_req_name
+                ld    bc,11
+                ldir
+                ld    hl,#3F00
+                ld    (fs_load_max),hl
+                ld    hl,#4000               ; plain low buffer (no bank paging)
+                ld    (fs_load_dst),hl
+                call  fs_load_file
+                jr    nc,spike_fail
+                ld    bc,#1A1A               ; WHITE held = DESKTOP.APP loaded OK in isolation
+                call  SCR_SET_BORDER
+spike_hang      jr    spike_hang
+spike_fail
+                ld    bc,#0606               ; RED held = file not found / load refused
+                call  SCR_SET_BORDER
+                jr    spike_hang
+spike_name      db    "DESKTOP APP"  ; #130 SPIKE: the file to test-load from the card
+                endif
                 call  input_init             ; enable the SymbiFace mouse if present
                 di                            ; probe RAM BEFORE PAGE_DATA is filled
                 call  mem_detect             ; (it pokes every bank's #4000)
@@ -2394,7 +2425,10 @@ kern_end                                        ; GBKERN.BIN = #8000..kern_end o
 ; kernel is caught here, not in the field. (Reclaim, or move scratch out, to fix.)
 HIMEM           equ   #A288        ; UniDOS HIMEM (stack top); see docs/AMSDOS notes
 STACK_RESERVE   equ   256          ; min bytes kept free below HIMEM for the stack (#95)
+                if SPIKE                     ; #130: the throwaway spike hangs early (tiny stack)
+                else
                 assert HIMEM-kern_end>=STACK_RESERVE,"GBKERN too big - reclaim resident bytes (see #104)"
+                endif
 
 ; --- scratch buffers live in LOW RAM (always the main bank, below the stack) -----
 ; They used to sit just above kern_end, but as the kernel grew they landed in the

--- a/lib/fs_amsdos.asm
+++ b/lib/fs_amsdos.asm
@@ -304,7 +304,9 @@ fdr_loop
                 ret
 
 ; ---------------------------------------------------------------------------
-; fsam_send: write A as a command byte (wait RQM=1, DIO=0).
+; fsam_send: write A as a command byte (wait RQM=1, DIO=0). Reached only after
+; fsam_present confirms an FDC, so the wait stays unbounded (a present FDC answers
+; in microseconds); no-controller machines are caught by fsam_present's pre-check.
 fsam_send
                 push  de                             ; preserve caller's track/sector
                 ld    e,a
@@ -339,6 +341,18 @@ frcv_wait
 ; recalibrates and tries a READ ID; a normal result (ST0 IC bits 7-6 == 00)
 ; means a disk is in the drive. CF set = present.
 fsam_present
+                ld    bc,FSAM_MSR                     ; #130b: bounded FDC-presence probe FIRST, so a
+                ld    d,0                             ; machine with no disc controller (e.g. a stock
+fsp_probe                                            ; 464) reports "absent" instead of hanging. An
+                in    a,(c)                           ; idle FDC's status reads #80 (RQM=1, DIO=0);
+                and   #C0                             ; a missing controller floats high -> #C0 (#00).
+                cp    #80
+                jr    z,fsp_have
+                dec   d                              ; ~256 reads is ample - a present FDC is ready
+                jr    nz,fsp_probe                   ; at once; absence just needs to be bounded
+                or    a                              ; no FDC within the bound -> absent (CF clear)
+                ret
+fsp_have
                 call  fsam_motor_on                  ; motor + recalibrate the unit
                 ld    a,#4A                          ; READ ID
                 call  fsam_send

--- a/lib/fs_fat32_core.asm
+++ b/lib/fs_fat32_core.asm
@@ -40,24 +40,65 @@ fdf_logd        ld    a,b
                 call  acc_add16
                 call  acc_store_fat
 
-                ld    hl,fs_secbuf+#24        ; sectors per FAT (FAT32, 32-bit)
+                ld    hl,(fs_secbuf+#16)      ; #130: 16-bit sectors/FAT - nonzero => FAT16
+                ld    a,h
+                or    l
+                jr    z,fdf_fat32
+                ld    (fatsz_tmp),hl          ; FAT16: fatsz = this word (zero-extended to 32)
+                xor   a
+                ld    (fatsz_tmp+2),a
+                ld    (fatsz_tmp+3),a
+                inc   a                        ; a = 1
+                ld    (fs_is_fat16),a
+                jr    fdf_havefatsz
+fdf_fat32
+                ld    hl,fs_secbuf+#24        ; FAT32: sectors per FAT (32-bit)
                 ld    de,fatsz_tmp
                 ld    bc,4
                 ldir
-                ld    a,(fs_secbuf+#10)       ; data_lba = fat_lba + numFATs*fatsz
-                ld    (fs_numfat),a
-                ld    b,a                       ; (acc still holds fat_lba)
+                xor   a
+                ld    (fs_is_fat16),a
+fdf_havefatsz
+                ld    a,(fs_secbuf+#10)       ; acc += numFATs*fatsz -> FAT32 data start, or
+                ld    (fs_numfat),a           ; FAT16 fixed-root-dir start (acc still = fat_lba)
+                ld    b,a
 fdf_dl          push  bc
                 ld    hl,fatsz_tmp
                 call  acc_add
                 pop   bc
                 djnz  fdf_dl
-                call  acc_store_data
 
+                ld    a,(fs_is_fat16)
+                or    a
+                jr    nz,fdf_root16
+                call  acc_store_data          ; FAT32: data starts right after the FATs
                 ld    hl,fs_secbuf+#2C        ; root directory start cluster
                 ld    de,fs_dir_clus
                 ld    bc,4
                 ldir
+                ret
+fdf_root16                                     ; FAT16: the fixed root dir sits here; data follows
+                ld    hl,acc                  ; fs_root_lba = fat_lba + numFATs*fatsz
+                ld    de,fs_root_lba
+                ld    bc,4
+                ldir
+                ld    hl,(fs_secbuf+#11)      ; root entry count (16-bit)
+                ld    de,15                    ; root_secs = (entries+15) >> 4
+                add   hl,de                    ; (32 bytes/entry, 512/sector -> /16)
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                srl   h
+                rr    l
+                ld    a,l
+                ld    (fs_root_secs),a
+                ld    e,a                       ; data_lba = root_lba + root_secs
+                ld    d,0
+                call  acc_add16
+                call  acc_store_data
                 ret
 
 ; fs_dir_rewind: position at the first sector of the root directory cluster.
@@ -65,8 +106,16 @@ fs_dir_rewind
                 xor   a
                 ld    (fs_dir_sic),a
                 ld    (fs_ent_idx),a
-                ld    hl,fs_dir_clus
+                ld    a,(fs_is_fat16)         ; #130
+                or    a
+                jr    nz,fdr_fat16
+                ld    hl,fs_dir_clus          ; FAT32: root is a cluster chain
                 call  clus_first_lba
+                call  save_dir_lba
+                jp    fs_read_sector
+fdr_fat16                                      ; FAT16: fixed root dir region, sector 0
+                ld    hl,fs_root_lba
+                call  lbatmp_from_var
                 call  save_dir_lba
                 jp    fs_read_sector
 save_dir_lba                                    ; remember the dir sector now in secbuf
@@ -79,6 +128,9 @@ save_dir_lba                                    ; remember the dir sector now in
 ; fs_dir_step: advance to the next directory sector (within the cluster, else
 ; follow the FAT to the next cluster). CF set = sector loaded, NC = end of chain.
 fs_dir_step
+                ld    a,(fs_is_fat16)         ; #130
+                or    a
+                jr    nz,fds_fat16
                 ld    a,(fs_dir_sic)
                 inc   a
                 ld    b,a
@@ -107,14 +159,35 @@ fds_load
 fds_end
                 or    a
                 ret
+fds_fat16                                      ; #130 FAT16: walk the fixed root region in order
+                ld    a,(fs_dir_sic)
+                inc   a
+                ld    (fs_dir_sic),a
+                ld    b,a
+                ld    a,(fs_root_secs)         ; sic >= root_secs -> end of root directory
+                cp    b
+                jr    z,fds_end
+                jr    c,fds_end
+                ld    hl,fs_root_lba
+                call  lbatmp_from_var
+                ld    a,(fs_dir_sic)
+                call  lba_add_a
+                call  save_dir_lba
+                call  fs_read_sector
+                scf
+                ret
 
 ; fs_fat_next: HL -> 4-byte cluster variable. Replace it with the next cluster
 ; in the FAT32 chain. CF set = valid next cluster, NC = end-of-chain (>=EOC).
 fs_fat_next
                 ld    (fn_ptr),hl
                 call  acc_load                ; acc = cluster
-                call  acc_shl                  ; *4 -> FAT byte offset
-                call  acc_shl
+                call  acc_shl                  ; *2 (FAT16 byte offset)
+                ld    a,(fs_is_fat16)         ; #130
+                or    a
+                jr    nz,ffn_within
+                call  acc_shl                  ; *4 (FAT32 byte offset)
+ffn_within
                 ld    a,(acc)                  ; within = offset & 0x1FF
                 ld    (fn_within),a
                 ld    a,(acc+1)
@@ -129,17 +202,20 @@ fs_fat_next
                 ld    hl,(fn_within)           ; entry = secbuf + within
                 ld    de,fs_secbuf
                 add   hl,de
-                ld    a,(hl)
+                ld    a,(hl)                   ; low two bytes (FAT16 and FAT32 share these)
                 ld    (acc),a
                 inc   hl
                 ld    a,(hl)
                 ld    (acc+1),a
-                inc   hl
+                ld    a,(fs_is_fat16)         ; #130
+                or    a
+                jr    nz,ffn_eoc16
+                inc   hl                        ; FAT32: two more bytes (28-bit entry)
                 ld    a,(hl)
                 ld    (acc+2),a
                 inc   hl
                 ld    a,(hl)
-                and   #0F                       ; FAT32 entries are 28-bit
+                and   #0F
                 ld    (acc+3),a
                 ld    a,(acc+3)                ; end-of-chain if >= 0x0FFFFFF8
                 cp    #0F
@@ -147,6 +223,18 @@ fs_fat_next
                 ld    a,(acc+2)
                 cp    #FF
                 jr    c,fn_valid
+                ld    a,(acc+1)
+                cp    #FF
+                jr    c,fn_valid
+                ld    a,(acc)
+                cp    #F8
+                jr    c,fn_valid
+                or    a                         ; EOC -> NC
+                ret
+ffn_eoc16                                       ; #130 FAT16: clear high bytes, EOC if >= 0xFFF8
+                xor   a
+                ld    (acc+2),a
+                ld    (acc+3),a
                 ld    a,(acc+1)
                 cp    #FF
                 jr    c,fn_valid
@@ -411,4 +499,7 @@ fs_clshift      defb  0            ; log2(sectors per cluster)
 fs_dir_sic      defb  0            ; dir: sector within current cluster
 fs_ent_idx      defb  0            ; dir: entry index within current sector
 fs_numfat       defb  0            ; number of FAT copies
+fs_is_fat16     defb  0            ; #130: 1 = FAT16 volume (fixed root dir, 16-bit FAT), else FAT32
+fs_root_lba     defs  4            ; #130 FAT16: absolute LBA of the fixed root directory
+fs_root_secs    defb  0            ; #130 FAT16: root directory size in sectors
 fat_eoc         defb  #FF,#FF,#FF,#0F  ; FAT32 end-of-chain marker

--- a/lib/fs_fat32_core.asm
+++ b/lib/fs_fat32_core.asm
@@ -150,6 +150,7 @@ fds_nextclus
 fds_load
                 ld    hl,fs_dir_clus
                 call  clus_first_lba
+fds_addread                                    ; shared tail: lba_tmp += sic, then read it
                 ld    a,(fs_dir_sic)
                 call  lba_add_a
                 call  save_dir_lba
@@ -170,12 +171,7 @@ fds_fat16                                      ; #130 FAT16: walk the fixed root
                 jr    c,fds_end
                 ld    hl,fs_root_lba
                 call  lbatmp_from_var
-                ld    a,(fs_dir_sic)
-                call  lba_add_a
-                call  save_dir_lba
-                call  fs_read_sector
-                scf
-                ret
+                jr    fds_addread
 
 ; fs_fat_next: HL -> 4-byte cluster variable. Replace it with the next cluster
 ; in the FAT32 chain. CF set = valid next cluster, NC = end-of-chain (>=EOC).
@@ -217,12 +213,13 @@ ffn_within
                 ld    a,(hl)
                 and   #0F
                 ld    (acc+3),a
-                ld    a,(acc+3)                ; end-of-chain if >= 0x0FFFFFF8
+                ld    a,(acc+3)                ; FAT32: end-of-chain if >= 0x0FFFFFF8
                 cp    #0F
                 jr    c,fn_valid
                 ld    a,(acc+2)
                 cp    #FF
                 jr    c,fn_valid
+ffn_eoc_lo                                      ; shared low-word EOC test (FAT16 joins here)
                 ld    a,(acc+1)
                 cp    #FF
                 jr    c,fn_valid
@@ -231,18 +228,11 @@ ffn_within
                 jr    c,fn_valid
                 or    a                         ; EOC -> NC
                 ret
-ffn_eoc16                                       ; #130 FAT16: clear high bytes, EOC if >= 0xFFF8
-                xor   a
+ffn_eoc16                                       ; #130 FAT16: clear the high bytes -> a 16-bit
+                xor   a                         ; value, then EOC if >= 0xFFF8 via the shared test
                 ld    (acc+2),a
                 ld    (acc+3),a
-                ld    a,(acc+1)
-                cp    #FF
-                jr    c,fn_valid
-                ld    a,(acc)
-                cp    #F8
-                jr    c,fn_valid
-                or    a                         ; EOC -> NC
-                ret
+                jr    ffn_eoc_lo
 fn_valid
                 ld    hl,acc
                 ld    de,(fn_ptr)

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -63,7 +63,7 @@ tools/build_fatmod.sh                              # FAT16/IDE write module -> b
 # boots from disc. Add a card here (e.g. M4 "-DSTORAGE_M4=1") when its backend lands.
 build_variant() {                                # $1 = subdir name, $2 = rasm -D flag
     rm -f build/gbkern.dsk                       # save-to-DSK appends; start clean
-    "$RASM" kernel/gbkern.asm -eo $2             # incbins apps + font + icons -> .dsk + RAW
+    "$RASM" kernel/gbkern.asm -eo $2 ${EXTRA_RASM:-} # incbins apps + font + icons -> .dsk + RAW
     "$RASM" kernel/pack_apps.asm -eo             # 2nd pass: overflow apps -> same .dsk (#114)
     tools/stage_dist.sh "QA/$1"                  # loose files for the card's FAT drive
     cp build/gbkern.dsk "QA/$1/GEOBENCH.DSK"     # bootable floppy image


### PR DESCRIPTION
## Resolves #130 — GEOBENCH boots on real CPC hardware

Two root causes, both fixed and verified on the real 464 (Cyboard IDE, FAT16 card).

### 1. FAT16 read support (852a169)
Real UniDOS/SymbOS CF cards are **FAT16**, but the IDE reader was FAT32-only — it mis-parsed the FAT16 BPB (offset #2C as a FAT32 root cluster), read wild sectors, and rebooted. The emulator passed only because the old test image was a FAT32 superfloppy. `fs_mount` now detects FAT16 and handles the fixed root directory + 16-bit FAT entries (EOC >= 0xFFF8); FAT32 unchanged.

### 2. Bounded FDC presence probe (2ab80e6)
After the FAT16 fix the kernel launched the desktop but hung blank-blue on the floppy-less 464: the desktop drive probe (`fsam_present`) polled the FDC status register with no timeout, so `drive_poll()` never returned. A bounded pre-check now reports the drive absent if no controller answers, and boot continues. Byte-reclaimed (shared LBA-read tail + low-word EOC test) to keep the full 256-byte stack reserve.

### Verified
- Boots to the desktop on the **real 464** (Cyboard IDE + FAT16 card)
- Emulator with the same ROM/IDE config (UniDOS/UniTools/FATFS)
- The Albireo variant gets the FDC fix too (shared floppy backend)

### Follow-ups (separate)
- FAT16 **write** (gbfat module is still FAT32-only)
- 1MB iRAM1024 shows as **576K** (mem_detect only probes the first 512K)

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)