### PR TITLE
Document RAM detection above 576K (Yarek, up to 1MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,12 @@ We deliberately cherry-pick from both ancestors rather than cloning either one.
 ## Target hardware
 
 - **Amstrad CPC** (464 / 664 / 6128, and CPC+) with **128K+ RAM** (the banked app
-  model needs the expansion banks; 512K is typical and fine).
+  model needs the expansion banks; 512K is typical and fine). Larger expansions
+  are **detected and reported** up to 1MB — the boot probe walks both the 8
+  DK'tronics banks (port `&7F`) and the **Yarek / CPC4MB** upper-bank ports
+  (`&7E…`), so the top bar shows the true total (e.g. **1088K** on a CPC464 with a
+  1MB Yarek). The app-page pool draws from the detected banks; the space beyond
+  what the windows use is free headroom (issue #138).
 - Mode 1 (320×200, 4 colours) for the desktop.
 - **Joystick / keyboard-driven software pointer.** An **AMX mouse works too** — it
   plugs into the joystick port and reports as a joystick (movement + buttons), so


### PR DESCRIPTION
Documents the shipped Phase 1 RAM detection (PR #139): the boot probe walks the DK'tronics and Yarek upper-bank ports and reports the true total (e.g. 1088K on a CPC464 with a 1MB Yarek), and the app-page pool draws from the detected banks.

Docs-only. Part of #138. The further work (a RAM disc in the Yarek banks) was prototyped and parked as too complex / headroom-hungry — preserved on a local branch, not part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)