### PR TITLE
fs: optional FAT16-only IDE kernel (-81 B), FAT16=1 build

### DIFF
--- a/lib/fs_fat32_core.asm
+++ b/lib/fs_fat32_core.asm
@@ -10,7 +10,15 @@
 ; The includer MUST define before the include: the FS_IDE_* port equates and
 ; fs_secbuf (the 512-byte sector buffer address). Per-entry output fields
 ; fs_ent_name/attr/size and fs_req_name live in lib/fs.asm (resident only).
+;
+; FAT16_ONLY (#148): pass -DFAT16_ONLY=1 to omit the FAT32 read branches and
+; assume a FAT16 volume - real CPC IDE/SD cards are FAT16 (#130). Smaller
+; resident reader for the real-hardware GBIDE; the dev/test FAT32 images need a
+; full build. The paged write module (gbfat.asm) never sets it (keeps FAT32).
 ; ---------------------------------------------------------------------------
+                ifndef FAT16_ONLY
+FAT16_ONLY      equ   0
+                endif
 
 ; fs_mount: MBR/partition probe + FAT32 BPB -> fs_fat_lba, fs_data_lba, fs_spc,
 ; fs_clshift, fs_numfat, fs_dir_clus (root cluster). No directory scan.
@@ -41,6 +49,14 @@ fdf_logd        ld    a,b
                 call  acc_store_fat
 
                 ld    hl,(fs_secbuf+#16)      ; #130: 16-bit sectors/FAT - nonzero => FAT16
+       if FAT16_ONLY
+                ld    (fatsz_tmp),hl          ; FAT16 assumed: this word is fatsz
+                xor   a
+                ld    (fatsz_tmp+2),a
+                ld    (fatsz_tmp+3),a
+                inc   a
+                ld    (fs_is_fat16),a          ; = 1 (the runtime checks still read it)
+       else
                 ld    a,h
                 or    l
                 jr    z,fdf_fat32
@@ -57,6 +73,7 @@ fdf_fat32
                 call  copy4
                 xor   a
                 ld    (fs_is_fat16),a
+       endif
 fdf_havefatsz
                 ld    a,(fs_secbuf+#10)       ; acc += numFATs*fatsz -> FAT32 data start, or
                 ld    (fs_numfat),a           ; FAT16 fixed-root-dir start (acc still = fat_lba)
@@ -67,6 +84,7 @@ fdf_dl          push  bc
                 pop   bc
                 djnz  fdf_dl
 
+       if !FAT16_ONLY
                 ld    a,(fs_is_fat16)
                 or    a
                 jr    nz,fdf_root16
@@ -75,6 +93,7 @@ fdf_dl          push  bc
                 ld    de,fs_dir_clus
                 call  copy4
                 ret
+       endif
 fdf_root16                                     ; FAT16: the fixed root dir sits here; data follows
                 ld    hl,acc                  ; fs_root_lba = fat_lba + numFATs*fatsz
                 ld    de,fs_root_lba
@@ -198,11 +217,13 @@ fs_fat_next
                 ld    (fn_ptr),hl
                 call  acc_load                ; acc = cluster
                 call  acc_shl                  ; *2 (FAT16 byte offset)
+       if !FAT16_ONLY
                 ld    a,(fs_is_fat16)         ; #130
                 or    a
                 jr    nz,ffn_within
                 call  acc_shl                  ; *4 (FAT32 byte offset)
 ffn_within
+       endif
                 ld    a,(acc)                  ; within = offset & 0x1FF
                 ld    (fn_within),a
                 ld    a,(acc+1)
@@ -222,6 +243,11 @@ ffn_within
                 inc   hl
                 ld    a,(hl)
                 ld    (acc+1),a
+       if FAT16_ONLY
+                xor   a                         ; FAT16: the high two bytes are always 0
+                ld    (acc+2),a
+                ld    (acc+3),a
+       else
                 ld    a,(fs_is_fat16)         ; #130
                 or    a
                 jr    nz,ffn_eoc16
@@ -238,6 +264,7 @@ ffn_within
                 ld    a,(acc+2)
                 cp    #FF
                 jr    c,fn_valid
+       endif
 ffn_eoc_lo                                      ; shared low-word EOC test (FAT16 joins here)
                 ld    a,(acc+1)
                 cp    #FF
@@ -247,11 +274,13 @@ ffn_eoc_lo                                      ; shared low-word EOC test (FAT1
                 jr    c,fn_valid
                 or    a                         ; EOC -> NC
                 ret
+       if !FAT16_ONLY
 ffn_eoc16                                       ; #130 FAT16: clear the high bytes -> a 16-bit
                 xor   a                         ; value, then EOC if >= 0xFFF8 via the shared test
                 ld    (acc+2),a
                 ld    (acc+3),a
                 jr    ffn_eoc_lo
+       endif
 fn_valid
                 ld    hl,acc
                 ld    de,(fn_ptr)

--- a/tools/build_kernel.sh
+++ b/tools/build_kernel.sh
@@ -19,6 +19,15 @@ if [ "${STORAGE:-ide}" = "albireo" ]; then
     STORAGE_FLAG="-DSTORAGE_ALBIREO=1"
 fi
 
+# FAT16=1: build the IDE kernel FAT16-only (drops the FAT32 read branches, ~81 B
+# smaller resident). Real CPC IDE/SD cards are FAT16 (#130, #148); the dev/test
+# FAT32 images need the default full build. Albireo is unaffected (chip does FAT).
+FAT16_FLAG=""
+if [ "${FAT16:-0}" = "1" ]; then
+    FAT16_FLAG="-DFAT16_ONLY=1"
+    echo "FAT16=1: building a FAT16-only IDE kernel (no FAT32 read path)"
+fi
+
 mkdir -p build
 rm -f build/gbkern.dsk                        # save-to-DSK appends; start clean
 
@@ -81,7 +90,7 @@ build_variant() {                                # $1 = kernel name, $2 = rasm -
 }
 rm -rf QA; mkdir -p QA
 echo "Building both card kernels + the unified card distribution -> QA/"
-build_variant GBIDE ""
+build_variant GBIDE "$FAT16_FLAG"
 cp build/gbkern.dsk QA/GEOBENCH.DSK               # one bootable floppy image
 # Add a GB.BAS loader so the floppy also boots via RUN"GB (-> RUN"GBKERN; one kernel,
 # no card to detect). Must be a HEADERLESS ASCII file - RASM's DSK save adds an AMSDOS
@@ -102,7 +111,7 @@ echo "  QA/CARD: any IDE/Albireo card (RUN\"GB); QA/GEOBENCH.DSK: floppy (RUN\"G
 # Leave build/ as the STORAGE-selected variant (default IDE) so the --disk-a test
 # harness and deploy_ide.sh see a predictable build/gbkern.dsk + build/GBKERN.RAW.
 rm -f build/gbkern.dsk
-"$RASM" kernel/gbkern.asm -eo $STORAGE_FLAG >/dev/null
+"$RASM" kernel/gbkern.asm -eo $STORAGE_FLAG ${FAT16_FLAG:+$FAT16_FLAG} >/dev/null
 "$RASM" kernel/pack_apps.asm -eo >/dev/null      # 2nd pass: overflow apps -> .dsk (#114)
 "$RASM" kernel/pack_apps2.asm -eo >/dev/null     # 3rd pass: VIEWER + FILEMGR -> .dsk (#142)
 echo "Built QA/CARD (unified card deploy) + QA/GEOBENCH.DSK (floppy); build/ = ${STORAGE:-ide} variant"


### PR DESCRIPTION
Adds a `FAT16_ONLY` assembly flag that drops the FAT32 read branches from the IDE kernel (the binding GBIDE variant) and assumes FAT16 - real CPC cards are FAT16 (#130). Opt-in via `FAT16=1 bash tools/build_kernel.sh`; the default dev build (FAT16+FAT32) is byte-identical and the Albireo kernel is unaffected.

**Measured:** kern_end #A17A -> #A129, GBIDE slack 14 -> 95 B (81 B reclaimed).
**Live-verified:** a FAT16-only kernel boots from a FAT16 IDE card under UniDOS and loads DESKTOP.APP off the card, exercising the whole read path (mount, dir walk, fs_dir_step, fs_fat_next cluster chain, sector read). Default build + QA images unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)