### PR TITLE
Refresh README and project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Workbench**, reimagined for 8-bit Z80 hardware.
 > **Status:** a working **banked multi-app micro-OS** for 128K+ CPCs. A resident
 > Z80 **kernel** owns the machine and exposes a fixed jump-table API; the
 > **apps are written in C** (SDCC) and run co-resident in expansion-bank pages,
-> reaching the kernel through a small `libgb`. The desktop, a scrolling file
-> manager, a text editor, an icon editor, a paint app, an image/text viewer and a
-> clock all work: double-click a drive to browse it, double-click a file to open it
-> in its app. Build with `tools/build_kernel.sh`.
+> reaching the kernel through `libgb`. The shipped target is the **Albireo card**
+> plus the **AMSDOS floppy fallback**; the tree also carries a bootable floppy
+> pair (`QA/GEOBENCH.DSK` + `QA/COMPANION.DSK`). The desktop, file manager,
+> Notepad, ICONED, Paint, Viewer, Clock, Telnet, Xaos, Settings, and the saver
+> set all build from `tools/build_kernel.sh`.
 
 ## Visual target
 
@@ -89,9 +90,11 @@ What works today:
   `SOLID`) and a centred **wallpaper** (`.PIC`) from the system folder, a **Colours**
   editor for the 4 Mode-1 pens + the screen border (`INKS=`) with a **live** preview
   — `-`/`+` recolours the whole desktop instantly — and a **Screensaver** section
-  (**Module** picker + idle **Timeout**). A **Reload** action re-applies
-  font/icons/cursor/backdrop on the running desktop with no reboot; Save persists it
-  all. The icon-set picker can **filter by icon count**. Launches from the System menu.
+  (**Module** picker + idle **Timeout**). Media settings are now stored as
+  **drive-qualified names** such as `A:DARKER` or `C:XMATRIX`, so Settings can
+  browse either floppy or Albireo content without ambiguity. Invalid media now
+  falls back safely to `SOLID` / `NONE` at boot instead of blocking startup. The
+  icon-set picker can **filter by icon count**. Launches from the System menu.
 - **Screensavers** — self-contained apps shipped with a `.SAV` extension. The
   desktop's idle timer (global, so it fires over any app) launches the configured
   module after the timeout; any pointer move / click / key returns to the desktop.
@@ -158,38 +161,41 @@ GEOBENCH borrows SymbOS's banked-app shape, scaled down:
   screen and the firmware stay in always-resident RAM; apps and the kernel's data
   buffers (font, icons) live in bank pages and are swapped in as needed.
 - **Resident kernel (`kernel/`, Z80 asm).** Boots the machine (Mode 1, palette,
-  RAM probe, clock, top bar), owns the storage + screen + input + cursor, and
-  exposes a **fixed jump-table API** at `#8000` (`lib/gbapp.inc` documents every
-  entry). It loads app binaries off disk into bank pages and runs them there.
+  RAM probe, clock, top bar), owns storage + screen + input + cursor, and
+  exposes a **fixed jump-table API** at `#8000`. The kernel source has now been
+  split by subsystem (`boot.asm`, `assets.asm`, `modules.asm`, `app_pool.asm`,
+  `input_api.asm`, `clock.asm`, `memdetect.asm`, `api_table.inc`,
+  `lowram.inc`) so resident responsibilities and low-RAM contracts are easier to
+  reason about without changing the generated image.
 - **Apps in C (`apps/`, SDCC).** Each app is a single `main.c` compiled to run at
   `#4000` in a bank page. It reaches the kernel only through **`libgb`**
   (`lib/gb/` — `gb.h` + asm trampolines that map the C calling convention onto the
   jump table). The desktop launches the file manager, which opens each file in its
   app (Notepad, ICONED, Paint, Viewer, ...); an app returns to its caller by `return`.
 - **Storage backends.** A dispatcher (`lib/fs.asm`) selects the card backend at
-  build time. The shipped card runs the CH376 **Albireo** kernel (`GBALB`), which also
-  carries the AMSDOS-over-**floppy** fallback (it boots floppy drive A when no card is
-  present). The **M4 board** (`GBM4`) and FAT16/FAT32 **IDE** (SYMBiFACE/Cyboard)
-  backends are **archived** — frozen in the tree but not built or shipped (see
-  [`docs/ARCHIVED.md`](docs/ARCHIVED.md); M4 is parked on an unresolved >8 KB-picture
-  blank on real hardware, IDE was superseded by Albireo for real CPC cards). Rebuild
-  either for recovery with `-DSTORAGE_M4=1` / `STORAGE=ide`. These screen-independent
-  drivers can be **offloaded to a loadable upper ROM** (`GEOBENCH.ROM`) to free
-  resident `#8000` RAM — see *Optional: the GEOBENCH ROM* below.
+  build time. The shipped path is the CH376 **Albireo** kernel (`GBALB`), which also
+  carries the AMSDOS-over-**floppy** fallback. The **M4 board** and FAT16/FAT32
+  **IDE** backends are **archived** — source kept in-tree, not built or shipped
+  by default (see [`docs/ARCHIVED.md`](docs/ARCHIVED.md)). The screen-independent
+  driver path can still be **offloaded to a loadable upper ROM** (`GBALB.ROM`)
+  to free resident `#8000` RAM — see *Optional: the GEOBENCH ROM* below.
 
 ## Building, deploying and running
 
 The kernel is assembled with **RASM**; the apps are compiled with **SDCC**
-(`sdcc`, `sdasz80`, `makebin` on `PATH`). One script builds the whole distribution
-(it needs `iDSK` to add the floppy loader — set `IDSK=` if it is not on the default
-path; without it the floppy still boots via `RUN"GBKERN`):
+(`sdcc`, `sdasz80`, `makebin` on `PATH`). In practice development happens inside
+the project distrobox, where those tools plus `mtools`/`dosfstools` already
+exist. One script builds the whole distribution; app and module helper scripts
+cache unchanged outputs, so a repeat full build does **not** rebuild every app
+unnecessarily. `iDSK` is only needed to inject the convenience `GB.BAS` loader
+into the floppy images; without it the floppy still boots via `RUN"GBKERN`:
 
 ```bash
 bash tools/build_kernel.sh
 ```
 
-This stages these outputs (the loose files and the floppy are committed under `QA/`, so you
-can grab them ready-built):
+This stages these outputs (the staged media under `QA/` are committed, so you
+can test or deploy without rebuilding first):
 
 - **`QA/CARD/`** — the loose card distribution. Copy its contents onto an Albireo
   card. The card root holds the loader `GB.BAS`, the kernel `GBALB.BIN`, and
@@ -198,11 +204,13 @@ can grab them ready-built):
 - **`QA/GEOBENCH.IMG`** — a ready-to-flash **Albireo card image**: a partitioned FAT16
   disk the CH376 auto-detects. Built by `tools/build_card_img.sh`; a 32 MB local
   artifact, rebuilt every build and not committed.
-- **`QA/GEOBENCH.DSK`** — a single bootable floppy image.
+- **`QA/GEOBENCH.DSK`** — the bootable **Main** floppy image.
+- **`QA/COMPANION.DSK`** — the **Companion** floppy with the larger apps, extra
+  savers, and sample pictures for drive B.
 
-Boot with **`RUN"GB`**: the loader `GB.BAS` is a one-line `RUN"GBALB` (on a floppy it
-runs `RUN"GBKERN`), which then drives the Albireo card or falls back to the AMSDOS
-floppy. On a floppy you can also `RUN"GBKERN` directly.
+Boot with **`RUN"GB`**: the loader `GB.BAS` is a one-line `RUN"GBALB` on the card,
+or `RUN"GBKERN` on the floppy. The kernel then drives the Albireo card or falls
+back to the AMSDOS floppy path. On a floppy you can also `RUN"GBKERN` directly.
 
 ```bash
 1984 --memory=128 --disk-a=QA/GEOBENCH.DSK --autostart=GB     # floppy in an emulator
@@ -325,7 +333,7 @@ desktop — the windowed/fullscreen choice is specifically about coaxing *legacy
 ```
 geobench/
 ├── README.md
-├── kernel/            # resident OS kernel (gbkern.asm) + the jump-table API
+├── kernel/            # resident OS kernel (entry file + split subsystem asm/includes)
 ├── lib/               # kernel libraries: screen, text/font, input, cursor,
 │   │                  #   fs (AMSDOS + FAT16), banking, icon/cursor bitmaps
 │   ├── gbapp.inc      #   the app ABI (jump-table addresses, memory model)
@@ -342,11 +350,11 @@ geobench/
 │   ├── xaos/          #   fixed-point Mandelbrot generator (.PIC export)
 │   ├── viewer/        #   text + .PIC image viewer
 │   ├── clock/         #   analog clock window
-│   └── settings/      #   control panel: font/icons/cursor + desktop colours (INKS=)
-├── rom/               # GEOBENCH.ROM: the offloaded low-level drivers + boot banner,
-│                      #   as a 16K loadable upper ROM (built per card by build_rom.sh)
+│   └── settings/      #   control panel: config/media picker + desktop colours
+├── rom/               # per-backend upper ROMs (GBALB.ROM shipped; IDE ROM archived)
+│                      #   for driver offload + the boot banner
 ├── assets/            # icon/cursor/paint source PNGs + sample files (WELCOME.TXT)
-├── docs/              # architecture, development, references
+├── docs/              # architecture, development, archive notes, review docs
 └── tools/            # host-side build/asset tooling (build_kernel.sh, build_rom.sh, ...)
 ```
 
@@ -361,9 +369,9 @@ Done:
 4. ✅ **Banked app model + app API** — separate-binary apps over a kernel API.
 5. ✅ **Apps in C** — the whole app layer moved from assembly to C over `libgb`.
 6. ✅ **Storage write layer** — FAT16/FAT32 + Albireo read/write (save/delete/copy).
-7. ✅ **Apps** — Notepad (editor), ICONED (icon/cursor editor), Paint (`.PIC`),
-   Clock, the image/text Viewer, and a **Settings** control panel (font / icon set /
-   cursor + a live desktop-colours editor).
+7. ✅ **Apps** — Notepad, ICONED, Paint, Clock, Viewer, Telnet, Xaos, and a
+   **Settings** control panel (font / icon set / cursor / drive-qualified
+   backdrop-wallpaper-saver settings + a live desktop-colours editor).
 8. ✅ **Unified menu system (`gb_doc`)** — one File / Edit / View menu framework for
    every app (New/Load/Save/Save As, a shared cross-app clipboard, **Fullscreen**, a
    navigable Open/Save dialog in a paged module); the desktop's System menu and the
@@ -378,6 +386,9 @@ Done:
    not shipped): a >8 KB-picture blank on real M4 hardware — an M4ROM interrupt/timing
    divergence the emulator can't reproduce — is unresolved, so the shipped card is Albireo +
    floppy only. See [`docs/ARCHIVED.md`](docs/ARCHIVED.md).
+11. ✅ **Kernel source split + build cache** — the resident kernel contracts now
+   live in dedicated source files with checked ABI/low-RAM maps, and the full
+   build reuses unchanged app/module outputs instead of recompiling everything.
 
 Next:
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -49,8 +49,10 @@ System → "Activate screensaver" runs it on demand. Each is a full-screen windo
 | ant      | `ANT.SAV`      | Langton's ant on an 80×50 grid (4-state rule, all four pens) — inspired by xscreensaver. **Albireo card only** |
 | lightning | `LIGHTN.SAV`  | midpoint-displacement forked lightning bolts that flash and re-strike — ported from xscreensaver. **Albireo card only** |
 
-The Settings **Module** picker lists every `.SAV` in `/GBENCH`, so a new
-screensaver appears there automatically once it is built and staged.
+The Settings **Module** picker lists every `.SAV` in the system media folder for
+the selected drive, so a new screensaver appears there automatically once it is
+built and staged. Saver names in `GEOBENCH.CFG` may be drive-qualified
+(`A:XMATRIX`, `C:CATCLK`) for mixed floppy/card setups.
 
 ## App contract
 
@@ -59,4 +61,6 @@ window (`gb_wm_add` for a legacy window, or `gb_wm_managed` for kernel-drawn
 chrome), then returns to the opener. The kernel's master loop then drives it:
 it polls input and calls the focused window's frame / repaint / event handlers;
 the app reads input with `gb_flags`/`gb_mx`/`gb_my` and calls `gb_wm_close` to
-quit. See `lib/gb/gb.h` for the full API.
+quit. Settings and saver apps should keep persistent config/media policy in the
+app layer and treat the kernel as a provider of storage, WM, and reload
+primitives. See `lib/gb/gb.h` for the full API.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # GEOBENCH Architecture
 
-The core is built: a banked, resident kernel running separate-binary C apps. This
-doc is the deeper design rationale; the README's "How it works" is the quick
-summary. Some sections below (legacy launching, the plus, networking) are still
-forward-looking.
+This is the current system shape, not a speculative design note. The quick
+summary lives in the top-level README; this file describes the actual runtime
+boundaries and the places where the current implementation is intentionally
+constrained.
 
 ## Layer cake
 
@@ -17,31 +17,51 @@ GEOBENCH is organised as layers, lowest (closest to hardware) at the bottom:
 │  libgb  C bindings -> the kernel jump table,  │  ← lib/gb/ (gb.h + trampolines,
 │         window + dialog helpers               │     gbwin.c, gbdlg.c/gbprompt.c)
 ├─────────────────────────────────────────────┤
-│  kernel/   boot · banking · screen · text ·   │  ← resident; Z80 asm
-│            input · cursor · fs · loader · API  │
+│  kernel/   boot · API table · banking · fs ·  │  ← resident; Z80 asm
+│            assets · modules · input · WM       │
 ├─────────────────────────────────────────────┤
 │  Amstrad CPC hardware  (Z80, CRTC, gate array, AMSDOS)│
 └─────────────────────────────────────────────┘
 ```
 
 Each layer only calls **down** through documented entry points. Apps never touch
-video, storage or input hardware directly — they go through the kernel API
-(`lib/gbapp.inc`), reached from C via `libgb`. The desktop is itself an app; it's
-the first one booted and the one apps return to.
+video, storage or input hardware directly. They go through the kernel ABI in
+`lib/gbapp.inc`, reached from C via `libgb`. The desktop is itself an app; it is
+the first one booted and the one other apps return to.
 
 ## Memory model
 
 128K+ only (the banked app model needs the expansion banks). The gate-array
 RAM-config port pages a 16K block into the `#4000–#7FFF` window:
 
-- The **kernel is resident** (in always-mapped RAM at `#8000+`), kept small. So
-  are the stack, the screen, and the firmware.
+- The **kernel is resident** in always-mapped RAM at `#8000+`. So are the stack,
+  the screen, fixed low-RAM contracts, and the firmware.
 - The kernel's **data buffers** (font, icon set, directory scratch) live in a
   bank page (`PAGE_DATA`); a service swaps that page in, touches the buffer, and
   restores the caller's page.
 - **Apps are loaded into bank pages** (`PAGE_APP0+`) at `#4000` and run there.
   They nest: desktop -> filemgr -> (notepad/paint/viewer/...), each in its own
   page; the launcher keeps the caller's page on the stack and restores it on quit.
+
+## Kernel source layout
+
+The resident binary is still one assembled image, but the source is now split by
+subsystem so responsibilities are explicit:
+
+- `kernel/gbkern.asm` — top-level assembly order and build flags.
+- `kernel/api_table.inc` — the fixed kernel jump table.
+- `kernel/lowram.inc` / `kernel/lowram.tsv` — absolute low-RAM ownership and the
+  checked manifest used by `tools/check_lowram_map.py`.
+- `kernel/boot.asm` — boot path, desktop launch, return-to-BASIC path.
+- `kernel/assets.asm` — font/icon/cursor/backdrop/wallpaper reload helpers.
+- `kernel/config_module.asm` — `GBCFG.MOD` boot-time parse/load path.
+- `kernel/modules.asm` — shared paged-module runners (`GBUI`, `GBNET`, config).
+- `kernel/app_pool.asm` — bank-page allocation/free for apps and borrowed pages.
+- `kernel/input_api.asm` — pointer/keyboard polling and top-bar dispatch.
+- `kernel/clock.asm` / `kernel/memdetect.asm` — RTC/timekeeping and RAM probe.
+
+The split is meant to keep the generated kernel image stable while making future
+size work safer.
 
 ## Execution model
 
@@ -53,74 +73,68 @@ Cooperative and single-foreground-app to start:
 - A vblank interrupt drives lightweight housekeeping (pointer, cursor blink,
   timers) regardless of who has the foreground.
 
-Preemptive multitasking — the Amiga's signature — is explicitly *not* a v1 goal.
+Preemptive multitasking is explicitly out of scope. GEOBENCH is cooperative and
+single-foreground by design.
 
 ## The system API
 
-Applications reach system services through a fixed **jump table** at `#8000` —
-each entry a 3-byte `jp`, so addresses stay stable as the kernel grows.
-`lib/gbapp.inc` is the authority; C apps call it through `libgb` (`lib/gb/`).
-What's there today:
+Applications reach system services through a fixed **jump table** at `#8000`.
+Each entry is a 3-byte `jp`, so slot addresses stay stable as the kernel grows.
+`lib/gbapp.inc` is the authority; `tools/check_abi_table.py` verifies the
+exported table against the kernel source. C apps call the table through `libgb`.
+Current service groups:
 
 - **Drawing** — text (`gb_text`), filled rects (`gb_fill`), outlines
   (`gb_frame`), icons (`gb_icon`/`gb_blite`), windows (`gb_window`).
 - **Input + cursor** — `gb_poll` (pointer position + click/quit/fire),
   `gb_curshow`/`gb_curhide`.
-- **Files** — directory iteration (`gb_dir1`/`gb_dirn`), load a file
-  (`gb_fs_load`). Write is still to come.
-- **Apps** — launch by name (`gb_run`) or by file type (`gb_launch`).
+- **Files** — directory iteration, load/save/delete/copy, drive selection, and
+  system-file loading through the active storage backend.
+- **Apps / WM** — open/close windows, managed chrome, app launch, fullscreen,
+  focus/z-order, drag-and-drop, clipboard, top-bar integration.
+- **Modules / services** — config parsing, UI/file dialogs, networking, media
+  reload, backdrop/wallpaper helpers, RTC/time, RAM total.
 
-Keeping this an explicit, stable jump table is what lets apps be separate
-binaries — written in C — without linking against private kernel internals.
+Keeping this explicit jump table is what lets apps stay as separate C binaries
+without linking against private kernel internals.
 
-## Launching legacy AMSDOS software
+## Storage and distribution shape
 
-GEOBENCH sits *on top of* AMSDOS/UniDOS, so the desktop should be able to launch
-the CPC's existing catalogue — `.BIN` binaries and `.BAS` programs — from an
-icon (see the README's "Running existing AMSDOS software"). The user picks
-**fullscreen** or **windowed**; these are very different problems.
+The shipped runtime target is:
 
-### Fullscreen (the tractable case)
+- **Albireo / CH376 card** as the primary storage path.
+- **AMSDOS floppy** as the fallback path and as the bootable disk-pair format.
 
-The safe, always-works path. Most CPC software assumes it **owns the machine**:
-full memory, its own video mode, direct hardware access. So GEOBENCH steps
-aside rather than trying to contain it:
+The archived storage backends still exist in source but are not built by the
+default workflow:
 
-1. The desktop **parks its state** — ideally persisting enough to disk/spare
-   bank to fully reconstruct itself, since the launched program may clobber all
-   of RAM and the video mode.
-2. Control transfers to the program via the normal firmware path (`RUN"PROG"`
-   for BASIC; RSX / CAS / AMSDOS load-and-execute for `.BIN`).
-3. The program runs as if GEOBENCH weren't there.
-4. **Return is the hard part of even this case:** most CPC programs exit by
-   reset or by returning to BASIC, not by calling back into us. Likely options:
-   require a reset-and-reload of the desktop, install a return hook where the
-   firmware allows it, or simply accept "exit = reboot to desktop." To be
-   decided.
+- **M4** is parked on an unresolved real-hardware timing/load issue.
+- **IDE** is kept as a recovery target, not a shipped one.
 
-### Windowed (the research problem)
+See [`ARCHIVED.md`](ARCHIVED.md) for the exact support boundary.
 
-Genuinely running an *uncooperative* legacy program inside a desktop window is
-the hard, best-effort case and **will not work for every title**. The only
-realistic mechanism on real hardware is to **intercept the program's firmware
-output** (TXT/GRA VDU calls) and redirect it into a window region instead of the
-real screen — which only works for programs that:
+The default media layout is intentionally simple:
 
-- go through the **firmware** for text/graphics rather than writing the
-  framebuffer directly,
-- **don't switch video mode** out from under the desktop,
-- **don't claim memory** the desktop needs (including the firmware workspace /
-  screen RAM the desktop is using),
-- **don't take over interrupts** or otherwise assume exclusive control.
+- card: `QA/CARD/` with `GB.BAS`, `GBALB.BIN`, `GEOBENCH.CFG`, and `GBENCH/`
+- floppy: `QA/GEOBENCH.DSK` (Main) plus `QA/COMPANION.DSK` (drive-B extras)
 
-That basically limits windowed mode to well-behaved BASIC programs and
-firmware-only software. Anything that bangs the hardware (most games, most demos)
-cannot be contained and must fall back to fullscreen. The desktop should
-**detect or heuristically guess** when windowing is unsafe and fall back to (or
-warn and offer) fullscreen.
+## Settings and media contracts
 
-Native GEOBENCH apps sidestep all of this by cooperating with the windowing
-layer from the start — the above is purely about coaxing *legacy* binaries in.
+`GEOBENCH.CFG` is the user-visible configuration contract. The important current
+rules are:
+
+- backdrop, wallpaper, and saver names may be **drive-qualified** (`A:NAME`,
+  `B:NAME`, `C:NAME`) so the Settings app can point at either floppy or Albireo
+  content explicitly;
+- backdrop and wallpaper are treated as mutually exclusive desktop background
+  sources;
+- invalid configured media falls back safely to `SOLID` / `NONE` during boot so
+  the machine still reaches the desktop;
+- screensavers are just full-screen `.SAV` apps launched by the desktop idle
+  timer.
+
+The intent is to keep policy in apps or modules and keep the resident kernel at
+the level of asset reload, storage, and window-manager primitives.
 
 ## Hardware notes
 
@@ -132,20 +146,23 @@ layer from the start — the above is purely about coaxing *legacy* binaries in.
 - **AMSDOS:** file I/O goes through firmware vectors. Note that USB/FAT-drive
   AMSDOS shifts some CAS IN vectors — see the sibling `n4c-nettools` notes.
 
+## Known architectural limits
+
+- **128K+ only.** The app model depends on banked memory.
+- **Cooperative execution only.** No preemptive multitasking.
+- **Flat-ish content layout.** Nested subdirectories deeper than one level are
+  not a supported storage workflow today; see [`File_Manager_Issue.md`](File_Manager_Issue.md).
+- **Legacy AMSDOS launching** is still a roadmap item, not a supported feature.
+
 ## Booting and distribution
 
-One image works on any machine. `bash tools/build_kernel.sh` stages (and ships under
-`QA/`):
+`bash tools/build_kernel.sh` stages (and ships under `QA/`):
 
-- **`QA/CARD/`** — for an IDE or Albireo card: the BASIC loader `GB.BAS`, both per-card
-  kernels `GBIDE.BIN` (FAT16/FAT32 over IDE) and `GBALB.BIN` (CH376/Albireo),
-  `GEOBENCH.CFG`, and a `GEOBENCH/` subfolder holding everything the kernel loads at
-  boot (apps, modules, fonts, icons, cursor). The card root stays clean next to
-  SymBOS/CP/M/UniDOS files.
-- **`QA/GEOBENCH.IMG`** — a ready-to-flash card image: one partitioned **FAT16** disk
-  (MBR partition at sector 32) that boots on **both** backends — the SYMBiFACE IDE reads
-  the partition table, the Albireo CH376 auto-detects the FAT. Rebuilt every build
-  (`tools/build_card_img.sh`); a local artifact, not committed.
+- **`QA/CARD/`** — for the Albireo card: `GB.BAS`, `GBALB.BIN`,
+  `GEOBENCH.CFG`, and a `GBENCH/` subfolder holding the kernel-loaded payload
+  (apps, modules, fonts, icons, cursor, media).
+- **`QA/GEOBENCH.IMG`** — a ready-to-flash **Albireo** FAT16 card image, rebuilt
+  by `tools/build_card_img.sh`; local artifact, not committed.
 - **`QA/GEOBENCH.DSK`** — the **Main** flat bootable floppy: the OS (kernel/loader/modules/
   fonts/icons/cursor/config), the core apps (Desktop, Notepad, Clock, File Manager, Viewer,
   Settings, Iconed), the default `CIRCLE.SAV` saver, the `LOGO.PIC` wallpaper and the
@@ -159,17 +176,16 @@ One image works on any machine. `bash tools/build_kernel.sh` stages (and ships u
   `GBNET.MOD`, `PAINT.IST`) load from A — no duplicates on the Companion. (The Albireo card
   is unaffected — it already ships everything on one volume.)
 
-`RUN"GB` runs `GB.BAS`, which probes the bus (an IDE register read-back, then a CH376
-`CHECK_EXIST`) and `RUN"`s the matching kernel. The kernel then loads from `/GEOBENCH`
-(the IDE backend walks the FAT subdirectory; the Albireo backend prefixes its CH376
-path), falling back to a flat root on floppies.
+`RUN"GB` runs `GB.BAS`. On card media it `RUN"`s `GBALB`; on floppy media it
+`RUN"`s `GBKERN`. The kernel then loads from `/GBENCH` on card media and from the
+flat root on floppies.
 
 The loader is **BASIC, not machine code**, on purpose: under UniDOS (CP/M-based) a
 `RUN"`-loaded binary that returns triggers a warm-boot, the firmware CAS goes to tape,
 and the DOS's RSXs/BIOS are unreachable from a loaded binary — whereas a BASIC program
-runs with the DOS fully active, so its `RUN"GBIDE` simply works.
+runs with the DOS fully active, so its `RUN"GBALB` or `RUN"GBKERN` simply works.
 
-### The GEOBENCH ROM (driver offload + boot banner, #152)
+### The GEOBENCH ROM (driver offload + boot banner)
 
 The screen-independent low-level drivers — the FAT read/write core, the AMSDOS floppy
 reader, the IDE backend and the CH376/Albireo backend — can run from a **16K loadable
@@ -186,20 +202,7 @@ both the resident stubs and the ROM agree on (the FAT core at `#1C00`, the CH376
 to use the stubs; without the ROM the plain kernel runs every driver resident, so the ROM
 is optional.
 
-The same image is a standard CPC **background ROM** (type-1 header at `#C000`): the
-firmware initialises it at cold boot and it prints a `GEOBENCH <commit>` banner before
-BASIC's prompt, like M4 or SymbOS. The offload dispatch table lives just past the header.
-
-## Open questions
-
-- Relocatable app binaries vs fixed load address + banking?
-- Icon / resource file format on disk.
-- How much of the desktop is "just an app" vs privileged.
-- Minimum viable target: commit to 128K, or keep 64K alive?
-- Launching legacy software: how does the desktop **survive a fullscreen
-  takeover and reload itself** on return (reset-and-reload vs return hook)?
-- Windowed legacy mode: is **firmware output interception** worth building, and
-  how does the desktop **decide a program is safe to window** vs force
-  fullscreen?
-
-These get answered as the kernel and graphics library take shape.
+The same image is a standard CPC **background ROM** (type-1 header at `#C000`):
+the firmware initialises it at cold boot and it prints a `GEOBENCH <commit>`
+banner before BASIC's prompt. The offload dispatch table lives just past the
+header.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,6 +16,15 @@ it's the host-side workflow.
   (the driver-offload ROM) needs only `rasm`.
 - **Emulators:** see below.
 
+The intended host environment is the project distrobox:
+
+```bash
+distrobox enter my-distrobox
+```
+
+That container is where `gh`, the CPC toolchain, and the image-build
+dependencies are expected to exist.
+
 ## Emulators
 
 We develop against two emulators with distinct roles:
@@ -50,11 +59,32 @@ cap32 and 1984 both accept a `.dsk` slot file. Two quick paths:
 ../caprice32/cap32 -i bin/PROG.BIN -o 0x4000
 
 # Or boot a disk image and autorun a file:
-../caprice32/cap32 --autocmd 'RUN"PROG' build/geobench.dsk
+../caprice32/cap32 --autocmd 'RUN"GB' QA/GEOBENCH.DSK
 ```
 
-1984 has its own invocation (see `../1984/INSTALL.md` / `1984.conf.example`);
-the build artifacts (`.bin` / `.dsk`) are the same.
+1984 has its own invocation. For GEOBENCH the common paths are:
+
+```bash
+bash tools/build_kernel.sh
+../1984/1984 --config=/dev/null --6128 --memory=512 --disk-a=QA/GEOBENCH.DSK --disk-b=QA/COMPANION.DSK --autostart=GB
+../1984/1984 --config=/dev/null --6128 --memory=512 --disk-a=QA/GEOBENCH.DSK --autostart=GB --screenshot-at=2200:/tmp/boot.ppm --exit-after=2200
+```
+
+The boot splash prints the build commit below the progress bar; use that to
+cross-check media against the source tree under test.
+
+### Incremental build behavior
+
+`tools/build_kernel.sh` still stages the full distribution, but the expensive C
+app and module builds are cached. The helper scripts write `*.stamp` metadata
+next to their outputs and skip recompilation when the output, toolchain, build
+flags, and transitive source dependencies are unchanged. Re-running the full
+build should therefore:
+
+- rebuild only the touched apps/modules;
+- always rebuild the packaged media (`QA/GEOBENCH.DSK`, `QA/COMPANION.DSK`,
+  `QA/CARD/`, `QA/GEOBENCH.IMG`);
+- refresh the boot-splash build id from the current git commit.
 
 ## Static Contract Checks
 
@@ -75,12 +105,15 @@ failures visible until the ranges are actually moved or retired.
 
 ## Icon and font sets (GEOBENCH.CFG)
 
-`GEOBENCH.CFG` selects a named set: `ICONS=<name>` loads `<name>.IST`, `FONT=<name>`
-loads `<name>.FNT`; both fall back to `DEFAULT` if absent. Sets ship as files on
-the disk (and are `incbin`/`save`d onto `build/gbkern.dsk` in `kernel/gbkern.asm`).
+`GEOBENCH.CFG` selects named resources. `ICONS=<name>` loads `<name>.IST`,
+`FONT=<name>` loads `<name>.FNT`, `CURSOR=<name>` loads `<name>.SPR`,
+`BACKDROP=<drive:name|SOLID>`, `WALLPAPER=<drive:name|NONE>`, and
+`SAVER=<drive:name|NONE>` identify optional desktop media. Missing font/icon/
+cursor settings fall back to `DEFAULT`; invalid background media falls back to
+`SOLID` / `NONE` during boot so the machine still starts.
 
 Build a set, then package it (add an `incbin` + a `save "<NAME>.<EXT>",...,DSK`
-line in `gbkern.asm`, and copy it to the IDE image in the deploy step):
+line in the pack assembly or stage it into the card distribution as appropriate):
 
 - **Font** (`.FNT`): from an 8×8 `.asm` font source — `tools/packfont.py
   build/NAME.FNT lib/font.asm` (ships `CLASSIC.FNT`, the 8×8 ROM font). The 6×8
@@ -102,7 +135,7 @@ line in `gbkern.asm`, and copy it to the IDE image in the deploy step):
      edit only takes effect after `regen_icons.sh` updates those `.asm` files.
   2. **Ship a custom selectable set**: edit a set visually with
      `tools/iconedit.py assets/iconsets/MYSET.IST` (tracked, unlike `build/`), and
-     `stage_dist.sh` / `build_ide_img.sh` copy every `assets/iconsets/*.IST` onto
+     `stage_dist.sh` copies every `assets/iconsets/*.IST` onto
      the card automatically. Select it with `ICONS=MYSET` in `GEOBENCH.CFG`. See
      `assets/iconsets/README.md`.
 - **Pictures** (`.PIC`): convert a PNG to a 4-colour Mode-1 picture with

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -37,4 +37,11 @@ contracts and boot/assets/module boundaries now live in `api_table.inc`,
 `lowram.inc`, `boot.asm`, `assets.asm`, `config_module.asm`, `modules.asm`, and
 `app_pool.asm`; input polling lives in `input_api.asm`; clock/RTC and RAM probing
 live in `clock.asm` and `memdetect.asm`. Continue splitting `gbkern.asm` by
-subsystem while keeping the generated kernel image unchanged.
+ subsystem while keeping the generated kernel image unchanged.
+
+Current documentation anchors:
+
+- `../lib/gbapp.inc` — app-visible ABI contract.
+- `lowram.tsv` — fixed low-RAM ownership map.
+- `../docs/KERNEL_ARCHITECTURE_REVIEW.md` — architecture review and further
+  resident-size recommendations.

--- a/tools/README.md
+++ b/tools/README.md
@@ -10,6 +10,7 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
 - **`build_kernel.sh`** — the one-shot build. Assembles the shipped **`GBALB`** (Albireo)
   kernel, packs the apps, and stages the distribution into `QA/`: the loose card files
   (`QA/CARD/`), the floppy (`QA/GEOBENCH.DSK`), and the card image (`QA/GEOBENCH.IMG`).
+  It also rebuilds `QA/COMPANION.DSK` for the drive-B extras.
   The M4 and IDE backends are archived (frozen, not built — see `docs/ARCHIVED.md`);
   rebuild for recovery with `EXTRA_RASM="-DSTORAGE_M4=1"` or `STORAGE=ide`. `FAT16=1` and
   `EXTRA_RASM=...` tune the variant (e.g. `EXTRA_RASM="-DGB_ROM_REQ=1"` for the
@@ -23,12 +24,13 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
   (the archived IDE backend). Bakes the git commit into the banner
   (`rom/gitcommit.inc`, generated).
 - **`stage_dist.sh <out>`** — stages the Albireo card distribution (the `RUN"GBALB`
-  `GB.BAS` loader + `GBALB.BIN` + the `GEOBENCH/` payload) into a directory.
+  `GB.BAS` loader + `GBALB.BIN` + the `GBENCH/` payload) into a directory.
 - **`build_capp.sh <app_dir> <out.RAW>`** — builds a single C app against `libgb`,
-  for iterating on one app. App/module helper scripts write `*.RAW.stamp` metadata
-  beside their outputs so a repeated full build can reuse unchanged binaries.
+  for iterating on one app. App/module helper scripts write `*.stamp` metadata
+  beside their outputs so a repeated full build can reuse unchanged binaries and
+  skip recompiling untouched apps/modules.
 - **`check_abi_table.py`** — verifies the `kernel/gbkern.asm` jump-table comments
-  match the exported `lib/gbapp.inc` slot addresses.
+  match the exported `lib/gbapp.inc` slot addresses through `kernel/api_table.inc`.
 - **`check_lowram_map.py`** — validates the fixed low-RAM ownership map in
   `kernel/lowram.tsv` for accidental range overlaps.
 - **`deploy_ide.sh`** — *(archived)* copy the staged distribution onto a real/emulated IDE
@@ -66,7 +68,7 @@ helper they call.
 
 ## Conventions
 
-- Output binaries (`*.BIN`, `*.RAW`, `*.dsk`, `QA/GEOBENCH.IMG`) are build artifacts
-  and gitignored — except the small staged `QA/` distribution, which is committed
-  ready-to-deploy. Regenerate everything with `build_kernel.sh`.
+- Output binaries under `build/` are local artifacts. The staged `QA/`
+  distribution is committed, including the `.dsk` media, so every shipped change
+  should rebuild those images before commit.
 - Any text/data file destined for the CPC must use **CR+LF** line endings.


### PR DESCRIPTION
Closes #254

## Summary
- update the top-level README to reflect the current shipped storage targets, media layout, settings behavior, and kernel split
- refresh the architecture and development docs around the Albireo+floppy support boundary, distrobox workflow, build cache, and checked contracts
- align the kernel/apps/tools READMEs with the current source layout and staging process

## Verification
- ran `git diff --check`
- reviewed the edited docs against the current tree and build scripts
