### PR TITLE
Refresh stale lower-level READMEs (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,32 +285,20 @@ We deliberately cherry-pick from both ancestors rather than cloning either one.
 - A small set of **bundled applications** to prove the platform is real.
 - A documented **application API** (the `libgb` jump table) so third parties can
   write GEOBENCH apps — in C.
-- **Launching existing software.** Because GEOBENCH sits on top of AMSDOS/UniDOS
-  rather than replacing it, the desktop should be able to run the CPC's existing
-  catalogue — pick a `.BIN` binary or a BASIC `.BAS` program and launch it, the
-  same way you would `RUN"PROG"` from BASIC today.
 
 ## Running existing AMSDOS software
 
-A core part of the "layer on top of DOS, don't replace it" philosophy (planned):
+GEOBENCH does **not** run ordinary AMSDOS `.BIN` binaries or BASIC `.BAS`
+programs. Those expect to own the whole machine under BASIC/AMSDOS, so the
+desktop does not attempt to launch or contain them: double-clicking a `.BIN` or
+`.BAS` in the File Manager shows an info note telling you to run it from BASIC
+instead (`RUN"PROG"`). GEOBENCH only runs its own apps — the C `.APP` programs and
+`.SAV` screensavers above — which cooperate with the kernel window manager.
 
-- **AMSDOS binaries (`.BIN`)** — hand the file off to the firmware loader and
-  transfer control, just as typing `RUN"GAME.BIN"` would.
-- **BASIC programs (`.BAS`)** — launched via the BASIC ROM, equivalent to
-  `RUN"PROG"`.
-
-When launching, the user chooses how the program runs:
-
-- **Fullscreen** — the program takes over the whole machine. The safe,
-  always-works mode: most CPC software assumes it **owns the machine**, so
-  GEOBENCH steps aside, hands over, and the user returns to the desktop on exit.
-- **Windowed** — where feasible, run a well-behaved program's output inside a
-  desktop window. The harder, best-effort mode; the desktop falls back to
-  fullscreen when a program can't be safely contained.
-
-GEOBENCH-native apps (the C apps above) always cooperate and run inside the
-desktop — the windowed/fullscreen choice is specifically about coaxing *legacy*
-`.BIN`/`.BAS` software into the environment.
+This was an early aspiration ("layer on top of DOS, launch the existing
+catalogue"), but coaxing software that assumes total machine ownership into a
+cooperative desktop proved out of scope, so it is a non-goal rather than a
+roadmap item.
 
 ## Non-goals (for now)
 
@@ -394,7 +382,6 @@ Next:
 
 - **Paint** follow-ups — resizable canvas and scrolling for pictures bigger than the
   screen (Fullscreen already centers the canvas + tools).
-- **Launching legacy `.BIN`/`.BAS`** software (see above).
 - **Drawers/folders** and richer desktop arrangement.
 - **Per-screensaver configuration** — the savers currently use baked-in defaults
   (there is no per-module setup panel yet); Settings only picks the module + idle

--- a/assets/iconsets/README.md
+++ b/assets/iconsets/README.md
@@ -13,9 +13,10 @@ tools/iconedit.py assets/iconsets/MYSET.IST     # tkinter editor (.IST and .SPR)
 
 `iconedit.py` opens an existing `.IST` or starts a new one; draw, then Save.
 
-A selectable desktop set must supply **every** slot the desktop draws (currently 26
-icons, including the Settings gear at slot 25) — the Settings app only lists `.IST`
-files whose header icon count is ≥ 26, so toolchests like `PAINT.IST` are excluded.
+A selectable desktop set must supply **every** slot the desktop draws (currently 25
+icons, since #198 dropped the duplicate `icon_iconset` slot) — the Settings app only
+lists `.IST` files whose header icon count is ≥ 25 (`MIN_IST_ICONS`), so toolchests
+like `PAINT.IST` are excluded.
 When a new desktop icon is added, append it to each tracked set with
 `tools/ist_append.py assets/iconsets/MYSET.IST lib/icon_<name>.asm` (`packicons.py`
 only regenerates `build/DEFAULT.IST`).

--- a/assets/pictures/README.md
+++ b/assets/pictures/README.md
@@ -21,7 +21,9 @@ CPC's AMSDOS/FAT expects, and the staging copies the file under its own name.
 
 ## Size
 
-Currently the Viewer caps a picture at ~10 KB of bitmap (≈ 200×200; `PENGUIN.PIC` is the
-200×200 sample). See issue #164 for the banked buffer that lifts this toward full-screen
-320×200. The floppy image (`QA/GEOBENCH.DSK`) only carries the pictures hardcoded in
+The Viewer holds a picture up to ~10 KB of bitmap (≈ 200×200; `PENGUIN.PIC` is the
+200×200 sample) in its in-window buffer. Larger pictures load into a borrowed 16 KB
+RAM bank (#164), so on a bare 128K machine — where every app bank is already in use —
+a big image shows an empty window, while a 256K+ expansion displays it. The floppy
+image (`QA/GEOBENCH.DSK`) only carries the pictures hardcoded in
 `kernel/pack_apps.asm`; the card carries everything in this folder.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -152,7 +152,10 @@ the level of asset reload, storage, and window-manager primitives.
 - **Cooperative execution only.** No preemptive multitasking.
 - **Flat-ish content layout.** Nested subdirectories deeper than one level are
   not a supported storage workflow today; see [`File_Manager_Issue.md`](File_Manager_Issue.md).
-- **Legacy AMSDOS launching** is still a roadmap item, not a supported feature.
+- **Legacy AMSDOS software is not run.** GEOBENCH does not launch ordinary
+  `.BIN`/`.BAS` programs (they assume total machine ownership); the File Manager
+  shows an info note pointing the user to BASIC. This is a non-goal, not a
+  pending feature.
 
 ## Booting and distribution
 

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -22,17 +22,17 @@ reference resources — not dependencies, and not vendored into this repo.
   into labelled, commented modules (graphics, sound, keyboard, etc.) plus the
   original ROM image for verification.
   **Why it matters:** GEOBENCH calls the firmware for screen, keyboard, and disk.
-  This is the authoritative reference for the **TXT/GRA VDU vectors** behind the
-  windowed-mode "intercept firmware output" idea, and for the CAS/AMSDOS paths
-  used to load and launch `.BIN` software. See `ARCHITECTURE.md` → "Launching
-  legacy AMSDOS software."
+  This is the authoritative reference for the **TXT/GRA VDU vectors** and the
+  CAS/AMSDOS file paths the kernel uses. (Note: GEOBENCH does **not** launch
+  legacy `.BIN`/`.BAS` software — that is a non-goal; see `ARCHITECTURE.md` →
+  "Known architectural limits.")
 
-## Locomotive BASIC (for launching `.BAS`)
+## Locomotive BASIC
 
 - **Bread80/Amstrad-CPC-BASIC-Source** — <https://github.com/Bread80/Amstrad-CPC-BASIC-Source>
   Reverse-engineered "unassembly" of the **Amstrad CPC BASIC 1.1 ROM** (1986) in
   documented, modular Z80 assembly, with the original ROM image for verification.
-  **Why it matters:** launching `.BAS` programs means handing off to the BASIC
-  ROM (`RUN"PROG"`-equivalent). This shows how BASIC enters/exits programs and
-  manages its workspace — relevant both to launching legacy BASIC and to
-  understanding what state the desktop must preserve across a takeover.
+  **Why it matters:** GEOBENCH boots from a `RUN"GB` BASIC loader and shares the
+  machine with the BASIC ROM, so this documents how BASIC enters/exits and manages
+  its workspace — and what state the desktop must preserve. (GEOBENCH does not
+  launch `.BAS` programs itself; running them is a non-goal.)

--- a/kernel/kc/README.md
+++ b/kernel/kc/README.md
@@ -4,72 +4,72 @@ The honest answer to "rewrite the kernel in C" (issue #30): you can't, fully.
 An irreducible **asm nucleus** must stay — the fixed jump table at `#8000`,
 banking / inter-bank trampolines, the hardware/firmware leaf routines, and the
 hot-path compositor. What *can* move to C is the branchy **logic**, and the
-resident region (`#8000`–`~#A67B`) is nearly full (~175 bytes free over the
-9676-byte kernel), so that logic lives in **paged bank modules** the nucleus
-calls through the trampoline — the SymbOS model.
+resident region around `#8000` is tight, so that logic lives in **paged bank
+modules** the nucleus loads and calls through the trampoline — the SymbOS model.
 
 This directory holds those modules. Each is pure logic: no I/O, no firmware
 calls, no globals if avoidable. The nucleus owns memory and devices and hands
-the module pointers.
+the module pointers (or a fixed low-RAM transfer area). The modules are loaded
+into a bank page and `call`ed exactly like an app; only one is live at a time, so
+several share the same low-RAM transfer/buffer overlays.
 
 ## Modules
 
-| File | Replaces | Role |
-|------|----------|------|
-| `kcfg.c` | `lib/config.asm` (`cfg_parse`/`cfg_keymatch`/`cfg_copyval`) | Parse `GEOBENCH.CFG` KEY=VALUE text into the `ICONS=`/`FONT=`/`CURSOR=` set names + the `INKS=` palette (4 pens + border, 5 inks). |
+| Built module | Sources | Build script | Role |
+|------|---------|--------------|------|
+| `GBCFG.MOD` | `kcfg.c` + `kcfg_mod.c` wrapper | `tools/build_cfgmod.sh` | Parse `GEOBENCH.CFG` KEY=VALUE text into the `ICONS=`/`FONT=`/`CURSOR=` set names, the `BACKDROP=` tile name (+ its `A:`/`B:` drive prefix), and the `INKS=` palette (4 pens + border). |
+| `GBUI.MOD` | `gbui_mod.c` dispatcher + `lib/gb/gbdlg.c`, `gbprompt.c`, `gbpick.c` | `tools/build_uimod.sh` | The shared `gb_doc` dialog/menu renderer (#142): File/Edit/View menus, the Open/Save file dialog, and prompts — paged so it isn't duplicated into every app bank. |
+| `GBNET.MOD` | `gbnet_mod.c` dispatcher + `w5100.c`, `net.c`, `udp.c`, `dns.c`, `gbnet_init.c` | `tools/build_netmod.sh` | The W5100S/Net4CPC socket driver behind a one-entry op-selector (#238): init, TCP connect/send/recv, UDP, and DNS resolve, used by `TELNET.APP`. |
+
+The `.c`/`.h` pairs `net`, `udp`, `dns`, `w5100` (plus `netinit.h`) are the
+network stack compiled into `GBNET.MOD`; `gbnet_init.c` reads `N4C.CFG`.
 
 ## Why C costs more here
 
-`kcfg.c` is **673 bytes** of Z80 (`tools/build_kmod.sh`); the asm it mirrors is
-~140 bytes. ~4.8× on a small routine — overhead-heavy at this size. That is the
-size argument for banking modules rather than keeping them resident, and the
-reason the migration is per-subsystem, not a big-bang rewrite.
+A C routine compiled with SDCC is roughly **4–5×** the size of the hand-written
+Z80 it mirrors (overhead-heavy at small sizes). That is the size argument for
+**banking** these modules rather than keeping the logic resident, and the reason
+the migration is per-subsystem, not a big-bang rewrite. Resident SDCC code is
+expensive; C belongs in a paged module unless the routine is tiny and cold.
 
 ## Verifying the logic
 
 `run_tests.sh` builds `kcfg.c` with the host `cc` and runs `test_kcfg.c`, which
-encodes every behavior of the original asm (defaults, comments, CR/LF vs LF,
-8-char value cap, key-at-line-start only, empty value, repeated keys). The C must
-pass these before the asm is retired — the migration is "prove parity, then
+encodes the parser's behavior (defaults, comments, CR/LF vs LF, value cap,
+key-at-line-start only, empty value, repeated keys, the `A:`/`B:` drive prefix).
+The C must pass these before the asm it replaced is retired — "prove parity, then
 delete the asm," not "rewrite and hope."
 
 ```
-kernel/kc/run_tests.sh        # host parity tests (no emulator)
-tools/build_kmod.sh kernel/kc/kcfg.c   # SDCC -mz80 + size report
+kernel/kc/run_tests.sh                 # host parity tests (no emulator)
+tools/build_kmod.sh kernel/kc/kcfg.c   # SDCC -mz80 + size report for one .c
 ```
 
 ## How it is wired into the kernel
 
-`kcfg_mod.c` is the loadable wrapper: built by `tools/build_cfgmod.sh` into
-`build/GBCFG.RAW` (crt0 first, so `_start` is at `#4000`), packaged on the disk
-as `GBCFG.BIN`, and loaded into a bank page + `call`ed exactly like an app. No
-inter-bank argument ABI was needed: the module reads/writes a **fixed resident
-transfer area in low RAM** (`#1000` text, `#1200` length, `#1202` ICONS out,
-`#120C` FONT out) which stays main RAM under banking, so `crt0` enters with a
-plain `call _main`.
+Each module is built crt0-first (so `_start` is at `#4000`), packaged on the disk
+with a `.MOD` extension, and loaded into a bank page + `call`ed like an app. No
+inter-bank argument ABI is needed: a module reads/writes a **fixed resident
+transfer area in low RAM** (which stays main RAM under banking), so `crt0` enters
+with a plain `call _main`. The cells are named in `kernel/lowram.inc`; for
+`GBCFG.MOD` the config text is at `KCFG_TEXT` (`#1000`), its length at `KCFG_LEN`
+(`#1200`), and the parsed outputs follow — `KCFG_ICONNAME`, `KCFG_FONTNAME`,
+`KCFG_CURSORNAME`, `KCFG_INKS`, `KCFG_BDPNAME`, and the backdrop drive byte
+`KCFG_BDDRIVE`.
 
-Boot flow (`kernel/gbkern.asm`):
-
-1. `cfg_boot` seeds the outputs with `DEFAULT`, `fs_load_file`s `GEOBENCH.CFG`
-   into the transfer area (length 0 if absent), then `run_cfgmod` pages
-   `GBCFG.BIN` into `PAGE_APP0` and calls it — the C parser fills the outputs.
-2. `font_init` / `icon_init` build `<FONT>.FNT` / `<ICONS>.IST` from the parsed
-   stems via `name_from_stem`, so `ICONS=`/`FONT=` select the set loaded (these
-   keys had gone dead when the monolithic desktop was slimmed into the kernel).
-
-Verified three ways in 1984 (`--memory=128`): no cfg → defaults → clean desktop;
-`ICONS=DEFAULT`/`FONT=DEFAULT` → identical (cfg load + parse + filename build all
-correct); `ICONS=NONE` → icons fail to load (the parsed value really selects the
-file). The resident kernel grew 9676 → **9839 bytes** for the boot glue, leaving
-~12 bytes under the `~#A67B` ceiling — proof that *further* migration must move
-logic into modules, not add resident asm.
+Boot flow for the config module lives in `kernel/config_module.asm` (split out of
+`gbkern.asm`): it seeds the outputs with `DEFAULT`, `fs_load_file`s
+`GEOBENCH.CFG` into the transfer area (length 0 if absent), then pages
+`GBCFG.MOD` into a bank and calls it — the C parser fills the outputs.
+`assets.asm` then builds `<FONT>.FNT` / `<ICONS>.IST` / `<CURSOR>.SPR` /
+`<BACKDROP>.BDP` from the parsed stems, so the config keys select what loads.
 
 ## Follow-ups
 
-- **DEFAULT fallback** when a configured `.FNT`/`.IST` is missing (today a bad
-  `ICONS=`/`FONT=` value loads nothing and draws garbage). Deferred because the
-  retry costs resident bytes we do not currently have — it pairs with trimming
-  the nucleus.
+- **DEFAULT fallback** when a configured `.FNT`/`.IST` is missing (a bad value
+  loads nothing and draws garbage). Deferred because the retry costs resident
+  bytes; it pairs with trimming the nucleus.
 - Retire `lib/config.asm` once nothing else references it (it is already
-  orphaned; left in place for this PR to keep the diff to the migration).
-- Next subsystem (directory parsing) follows the same module pattern.
+  orphaned — `GBCFG.MOD` is the live parser).
+- Continue moving branchy policy into paged modules following this pattern, per
+  `docs/KERNEL_ARCHITECTURE_REVIEW.md`.

--- a/lib/README.md
+++ b/lib/README.md
@@ -24,7 +24,7 @@ layers never poke video, storage or input registers directly.
 | `fs_m4.asm` | _Archived_ — file-level FAT over the M4 board (#174). Frozen, not built. See `docs/ARCHIVED.md`. |
 | `fs_rom_seam.asm`, `fs_*_lowram.inc` | #152 ROM offload: the seam that pages `GEOBENCH.ROM` in + the fixed low-RAM addresses the resident stubs and the ROM share. |
 | `bank.asm` | Expansion-RAM paging (the `#4000–#7FFF` window). |
-| `config.asm` | `GEOBENCH.CFG` (key=value) parser. |
+| `config.asm` | _Orphaned_ — the old resident `GEOBENCH.CFG` (key=value) parser. Superseded by the paged `GBCFG.MOD` (`kernel/kc/kcfg.c`); kept in-tree only until nothing references it. |
 | `icon_*.asm` | Icon bitmaps, packed into the `.IST` icon set at build time. |
 
 ## libgb (`gb/`)
@@ -36,6 +36,10 @@ The shared **C bindings** every GEOBENCH app links against:
 | `gb/gb.h` | C prototypes for the kernel API. |
 | `gb/gblib.s` | Asm trampolines mapping SDCC's calling convention onto the jump table. |
 | `gb/crt0.s` | C startup for a banked app (entry at `#4000`, initializer copy). |
+| `gb/gbdoc.c` | The `gb_doc` document framework: registers an app's buffer + new/open/save hooks and drives the shared File/Edit/View menus. |
+| `gb/gbwin.c` | Window chrome helpers an app links in (drag/resize against the kernel WM). |
+| `gb/gbdlg.c`, `gb/gbpick.c`, `gb/gbprompt.c` | Dialog/menu/file-picker/prompt renderers — compiled into the paged `GBUI.MOD`, not into every app bank. |
+| `gb/gbui_stub.c`, `gb/gbnet_stub.c` | Thin app-side stubs that call the paged `GBUI.MOD` / `GBNET.MOD` through the kernel. |
 
 ## Design constraints
 


### PR DESCRIPTION
Closes #256.

The #253/#255 work refreshed the top-level/docs files but left several lower-level READMEs describing a superseded state. This brings them current; **no code changes**.

- **kernel/kc/README.md** — now documents the three module families it actually hosts (`GBCFG.MOD` config, `GBUI.MOD` dialog renderer, `GBNET.MOD` net stack) instead of a single config PoC; drops stale resident-size figures; `GBCFG.BIN` -> `GBCFG.MOD`; notes `kcfg` parses `BACKDROP=` (+ the A:/B: drive prefix); current transfer cells; config boot flow now in `kernel/config_module.asm`.
- **lib/README.md** — marks `config.asm` orphaned (superseded by `GBCFG.MOD`); adds the libgb C framework (`gbdoc`/`gbwin`/`gbdlg`/`gbpick`/`gbprompt` + ui/net stubs).
- **assets/iconsets/README.md** — desktop set is 25 icons (`MIN_IST_ICONS`), not 26; drops the stale "Settings gear at slot 25" (Settings has no desktop icon, #221).
- **assets/pictures/README.md** — the #164 banked-bank path for large pictures shipped; describes current behaviour instead of the open issue.

Also corrects the dropped "run legacy AMSDOS software" claims: GEOBENCH does not launch `.BIN`/`.BAS` programs (FileMgr shows an info note, #236). Reframed as a non-goal in README.md, docs/ARCHITECTURE.md, and docs/REFERENCES.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)