### PR TITLE
README: document the MSX2 target + portable run_msx.sh (#292)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,21 @@
 
 # GEOBENCH
 
-A graphical desktop environment for the **Amstrad CPC** — a hybrid clone that
-borrows the best ideas from **Commodore GEOS** (C64/C128) and the **Amiga
-Workbench**, reimagined for 8-bit Z80 hardware.
+A graphical desktop environment for the **Amstrad CPC** and the **MSX2** — a
+hybrid clone that borrows the best ideas from **Commodore GEOS** (C64/C128) and
+the **Amiga Workbench**, reimagined for 8-bit Z80 hardware.
 
-> **Status:** a working **banked multi-app micro-OS** for 128K+ CPCs. A resident
-> Z80 **kernel** owns the machine and exposes a fixed jump-table API; the
-> **apps are written in C** (SDCC) and run co-resident in expansion-bank pages,
-> reaching the kernel through `libgb`. The shipped target is the **Albireo card**
-> plus the **AMSDOS floppy fallback**; the tree also carries a bootable floppy
-> pair (`QA/GEOBENCH.DSK` + `QA/COMPANION.DSK`). The desktop, file manager,
-> Notepad, ICONED, Paint, Viewer, Clock, Telnet, Xaos, Settings, and the saver
-> set all build from `tools/build_kernel.sh`.
+> **Status:** a working **banked multi-app micro-OS** for 128K+ CPCs, now also
+> building a full **MSX2 target**. A resident Z80 **kernel** owns the machine and
+> exposes a fixed jump-table API; the **apps are written in C** (SDCC) and run
+> co-resident in expansion-bank pages, reaching the kernel through `libgb`. The
+> shipped CPC target is the **Albireo card** plus the **AMSDOS floppy fallback**;
+> the tree also carries a bootable floppy pair (`QA/GEOBENCH.DSK` +
+> `QA/COMPANION.DSK`). The desktop, file manager, Notepad, ICONED, Paint, Viewer,
+> Clock, Telnet, Xaos, Settings, and the saver set all build from
+> `tools/build_kernel.sh`. The **MSX2 port** (issue #287) boots the same kernel
+> and app set (minus Telnet) under **MSX-DOS 2 / Nextor** on a V9938 in
+> **Screen 6** — see [The MSX2 target](#the-msx2-target).
 
 ## Visual target
 
@@ -280,6 +283,44 @@ We deliberately cherry-pick from both ancestors rather than cloning either one.
   — frozen in-tree, not shipped; see [`docs/ARCHIVED.md`](docs/ARCHIVED.md). Telnet
   uses Net4CPC/W5100S when running the Albireo kernel and M4ROM's TCP commands
   when running the M4 kernel.
+- **MSX2** (V9938, 128K VRAM) running **MSX-DOS 2 / Nextor** — see
+  [The MSX2 target](#the-msx2-target) below. Stock 128K RAM boots the desktop;
+  a memory-mapper expansion (512K typical) is recommended for multiple app
+  windows.
+
+## The MSX2 target
+
+The same OS, cross-built for the MSX2 (issue #287). It is **one source tree, two
+platforms**: the resident kernel assembles from the same `kernel/` sources under
+`-DPLATFORM_MSX`, and the apps compile from the same `main.c` files under
+`-DGB_MSX2` — the platform differences live in the kernel's video/input/storage
+back-ends, not in the apps.
+
+- **Runs under MSX-DOS 2 / Nextor** as a plain `GBMSX.COM` executable — no custom
+  boot ROM. Storage goes through BDOS file calls, so anything Nextor mounts
+  (Sunrise IDE, SD interfaces, …) works.
+- **Video:** V9938 **Screen 6** (512×212, 4 colours) — the closest analogue of the
+  CPC's Mode 1 — with a **hardware sprite pointer** and VDP-command drawing
+  (`GB_SETINK` palette mapping, `GB_LINE`).
+- **Input:** joystick / keyboard pointer, plus the standard **MSX mouse** (GTPAD).
+  The clock is 50/60 Hz aware.
+- **Ported so far:** Desktop, File Manager, Notepad, Settings, ICONED, Paint,
+  Viewer (with a Screen-6 `.PIC` pipeline), XAOS, Clock, and screensavers
+  (SQUARES, ANT). Telnet is CPC-only for now (its network hardware is
+  CPC-specific).
+
+Build and test in **openMSX** (emulating a Philips NMS 8250 with the Sunrise IDE
+Nextor extension and a 512K RAM expansion):
+
+```bash
+bash tools/fetch_msx_deps.sh       # one-time: Nextor system files + NMS 8250 ROMs
+bash tools/build_kernel_msx.sh     # GBMSX.COM + QA/MSX staging + bootable QA/GBMSX.IMG
+tools/run_msx.sh                   # interactive session
+MSX_SHOTS="25 40" tools/run_msx.sh # headless: screenshots into build/msx/
+```
+
+`run_msx.sh` uses a native `openmsx` from `$PATH`, the Flatpak
+(`org.openmsx.openMSX`) as a fallback, or an explicit `OPENMSX="…"` override.
 
 ## Goals
 
@@ -382,6 +423,10 @@ Done:
 11. ✅ **Kernel source split + build cache** — the resident kernel contracts now
    live in dedicated source files with checked ABI/low-RAM maps, and the full
    build reuses unchanged app/module outputs instead of recompiling everything.
+12. ✅ **MSX2 port (#287)** — the kernel and app set cross-build to a second
+   platform: `GBMSX.COM` under MSX-DOS 2 / Nextor, V9938 Screen 6, hardware
+   sprite pointer, MSX mouse, and an openMSX test harness
+   (`tools/build_kernel_msx.sh` + `tools/run_msx.sh`).
 
 Next:
 

--- a/tools/run_msx.sh
+++ b/tools/run_msx.sh
@@ -18,6 +18,7 @@
 #                                               emu-time seconds into build/msx/
 #                                               (throttle off, exits after last)
 #   MSX_RAM=stock tools/run_msx.sh              no 512K expansion
+#   OPENMSX="openmsx-nightly" tools/run_msx.sh  override emulator command
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -29,17 +30,18 @@ EXT=(-ext SunriseIDE_Nextor)
 [ "${MSX_RAM:-512k}" != stock ] && EXT+=(-ext ram512k)
 
 ARGS=(-machine "$MACHINE" "${EXT[@]}" -hda "$IMG")
+SCRIPT=
 
 if [ -n "${MSX_SHOTS:-}" ]; then
     mkdir -p build/msx
-    SCRIPT=$(mktemp --suffix=.tcl)
+    SCRIPT=$(mktemp -p build/msx --suffix=.tcl)
     trap 'rm -f "$SCRIPT"' EXIT
     {
         echo 'set throttle off'
         last=0
         for t in $MSX_SHOTS; do last=$t; done
         for t in $MSX_SHOTS; do
-            action="catch { screenshot $PWD/build/msx/msx-t$t.png }"
+            action="catch { screenshot -raw $PWD/build/msx/msx-t$t.png }"
             [ "$t" = "$last" ] && action="$action ; exit"
             echo "after time $t { $action }"
         done
@@ -54,10 +56,29 @@ else
     # a kernel address - the kernel grows and any hardcoded k_poll address goes
     # stale, leaving the run stuck at fast-forward (pointer leaps, saver fires in
     # seconds). ~4s of wall-clock throttle-off is well past the boot.
-    SCRIPT=$(mktemp --suffix=.tcl)
+    # mktemp under build/msx, not /tmp: the Flatpak sandbox only sees $HOME.
+    mkdir -p build/msx
+    SCRIPT=$(mktemp -p build/msx --suffix=.tcl)
     trap 'rm -f "$SCRIPT"' EXIT
     printf 'set throttle off\nafter realtime %s { set throttle on }\n' "${MSX_FF:-4}" > "$SCRIPT"
     ARGS+=(-script "$SCRIPT")
 fi
 
-exec openmsx "${ARGS[@]}"
+if [ -n "${OPENMSX:-}" ]; then
+    # shellcheck disable=SC2206
+    OPENMSX_CMD=($OPENMSX)
+elif command -v openmsx >/dev/null 2>&1; then
+    OPENMSX_CMD=(openmsx)
+elif command -v flatpak >/dev/null 2>&1 && flatpak info org.openmsx.openMSX >/dev/null 2>&1; then
+    OPENMSX_CMD=(flatpak run --command=openmsx org.openmsx.openMSX)
+else
+    echo "ERROR: openMSX not found (install openmsx or Flatpak org.openmsx.openMSX)" >&2
+    exit 1
+fi
+
+if [ -n "$SCRIPT" ]; then
+    "${OPENMSX_CMD[@]}" "${ARGS[@]}"
+    exit $?
+fi
+
+exec "${OPENMSX_CMD[@]}" "${ARGS[@]}"


### PR DESCRIPTION
Closes #292.

- README: intro/status name both platforms; Target hardware gains the MSX2 entry; a new **The MSX2 target** section documents the cross-build (-DPLATFORM_MSX / -DGB_MSX2), V9938 Screen 6, Nextor/BDOS storage, the ported app set, and the openMSX build/run workflow; roadmap done-item 12 for #287.
- tools/run_msx.sh: emulator-command detection (native openmsx -> Flatpak org.openmsx.openMSX -> error, with an OPENMSX= override), Tcl scripts written under build/msx (the Flatpak sandbox only sees $HOME), and screenshot -raw for headless captures.

Verified on this machine: fetch_msx_deps.sh deps present, tools/build_kernel_msx.sh rebuilt GBMSX.COM + QA/GBMSX.IMG from current main, and openMSX (Flatpak) boots GEOBENCH to the Screen-6 desktop (probed: PC in kernel, mode 6, palette + VRAM populated; interactive run confirmed by Salvatore).

🤖 Generated with [Claude Code](https://claude.com/claude-code)