### PR TITLE
tools: --platform msx2 for iconedit / png2backdrop / png2cpc #287

### DIFF
--- a/tools/iconedit.py
+++ b/tools/iconedit.py
@@ -15,7 +15,11 @@ Multiple sets can be open at once, each in its own window (File > Open in New
 Window), so you can Copy/Paste Icon between two sets side by side.
 
 Run:
-    python3 tools/iconedit.py [file.IST | file.SPR]
+    python3 tools/iconedit.py [--platform msx2] [file.IST | file.SPR]
+
+--platform msx2 edits V9938 Screen-6 icon sets (round-trips byte-for-byte with
+packicons.py --platform msx2). Cursors (.SPR) are CPC-only here - MSX cursors are
+hardware sprites; build them with png2spr.py --platform msx2.
 """
 import json
 import os
@@ -25,12 +29,21 @@ import tempfile
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
-# --- Mode 1 pixel packing (matches png2spr / png2cpc) -----------------------
+# --- pixel packing: CPC Mode 1 (default) or MSX2 Screen 6 (--platform msx2) --
+# Both pack 4 pixels per byte; only the bit layout differs. PLATFORM is set by
+# main() and switches the .IST codec so the editor round-trips MSX icon sets
+# byte-for-byte with `packicons.py --platform msx2`. (Cursors stay CPC-only -
+# MSX cursors are V9938 hardware sprites, a different format; use png2spr.)
+PLATFORM = 'cpc'
 
 def decode_pixel(b, i):
+    if PLATFORM == 'msx2':
+        return (b >> (6 - 2 * i)) & 3          # Screen 6: pen in bits 7-2i, 6-2i
     return ((b >> (7 - i)) & 1) | (((b >> (3 - i)) & 1) << 1)
 
 def set_pixel(b, i, pen):
+    if PLATFORM == 'msx2':
+        return (b & ~(3 << (6 - 2 * i))) | ((pen & 3) << (6 - 2 * i))
     if pen & 1:
         b |= 1 << (7 - i)
     if pen & 2:
@@ -417,6 +430,10 @@ class IconEditor(tk.Toplevel):
                 self.icons = load_ist(path)
                 self.mode = "IST"
             elif ext == ".spr":
+                if PLATFORM == 'msx2':
+                    raise ValueError("MSX2 cursors are V9938 hardware sprites, not "
+                                     ".SPR bitmaps - build them with png2spr.py "
+                                     "--platform msx2 from a PNG.")
                 data = open(path, "rb").read()
                 if len(data) != 4 * PHASE:
                     raise ValueError(f"{path}: expected {4*PHASE} bytes, got {len(data)}")
@@ -857,7 +874,11 @@ class IconEditor(tk.Toplevel):
 
 
 def main():
-    path = sys.argv[1] if len(sys.argv) > 1 else None
+    global PLATFORM
+    argv = sys.argv[1:]
+    if len(argv) >= 2 and argv[0] == '--platform':
+        PLATFORM, argv = argv[1], argv[2:]
+    path = argv[0] if argv else None
     root = tk.Tk()
     root.withdraw()                      # the real root stays hidden; editors are Toplevels
     IconEditor(root, path)               # the first window (File > Open in New Window adds more)

--- a/tools/png2backdrop.py
+++ b/tools/png2backdrop.py
@@ -6,13 +6,27 @@ and windows (the GEOS/Workbench dither look). Each pixel is quantised to one of
 the 4 desktop pens (blue paper / white / black / red) and packed Mode-1 (4 px per
 byte). Output is a raw 64-byte file: 16 rows x 4 bytes, no header.
 
-    tools/png2backdrop.py <in.png> <out.BDP>
+    tools/png2backdrop.py [--platform msx2] <in.png> <out.BDP>
 
 The kernel loads the .BDP into a low-RAM tile buffer at boot (BACKDROP=<name>) and
 fill_pattern repeats it, phased off absolute screen x,y so adjacent fills line up.
+--platform msx2 emits V9938 Screen-6 packing instead of CPC Mode 1 (same 4px/byte
+geometry, so the 64-byte tile is unchanged in size).
 """
 import sys
 from PIL import Image
+
+
+def mode1_to_screen6(data):
+    """CPC Mode-1 bytes -> V9938 Screen-6 bytes (pixel i's pen in bits 7-2i,6-2i)."""
+    out = bytearray()
+    for byte in data:
+        s6 = 0
+        for i in range(4):
+            pen = ((byte >> (7 - i)) & 1) | (((byte >> (3 - i)) & 1) << 1)
+            s6 |= pen << (6 - 2 * i)
+        out.append(s6)
+    return bytes(out)
 
 # The desktop pens, by their default ink colour. A pixel maps to the nearest one.
 PENS = [((0, 0, 170), 0),        # pen 0: blue (paper / backdrop)
@@ -45,10 +59,14 @@ def mode1_byte(pens4):
 
 
 def main():
-    if len(sys.argv) != 3:
+    argv = sys.argv[1:]
+    platform = 'cpc'
+    if len(argv) >= 2 and argv[0] == '--platform':
+        platform, argv = argv[1], argv[2:]
+    if len(argv) != 2:
         print(__doc__)
         sys.exit(2)
-    in_png, out_bdp = sys.argv[1], sys.argv[2]
+    in_png, out_bdp = argv
     img = Image.open(in_png).convert("RGB")
     if img.size != (TILE, TILE):
         img = img.resize((TILE, TILE), Image.NEAREST)   # tolerate other sizes
@@ -59,9 +77,11 @@ def main():
         for bx in range(0, TILE, 4):                    # 4 px -> 1 Mode-1 byte
             pens4 = [nearest_pen(px[bx + i, y]) for i in range(4)]
             blob.append(mode1_byte(pens4))
+    if platform == 'msx2':
+        blob = bytearray(mode1_to_screen6(blob))
     with open(out_bdp, "wb") as f:
         f.write(blob)
-    print(f"{in_png}: backdrop .BDP {TILE}x{TILE} -> {len(blob)} bytes ({out_bdp})")
+    print(f"{in_png}: backdrop .BDP {TILE}x{TILE} ({platform}) -> {len(blob)} bytes ({out_bdp})")
 
 
 if __name__ == "__main__":

--- a/tools/png2cpc.py
+++ b/tools/png2cpc.py
@@ -21,7 +21,10 @@ Output is a RASM-includable .asm file: a label, <label>_w (width in BYTES),
 <label>_h (height in rows), and the row-major encoded bytes.
 
 Usage:
-    tools/png2cpc.py <in.png> <out.asm> <label> [WxH]
+    tools/png2cpc.py [--platform msx2] <in.png> <out.asm> <label> [WxH]
+
+--platform msx2 emits V9938 Screen-6 packing instead of CPC Mode 1 (same 4px/byte
+geometry).
 
 If WxH is given the image is resized (Lanczos) to that size first, so a large
 source art file can be reduced to icon size in one step. Width must end up a
@@ -63,15 +66,28 @@ def encode_byte(pens4):
     return byte
 
 
+def mode1_to_screen6(byte):
+    """CPC Mode-1 byte -> V9938 Screen-6 byte (pixel i's pen in bits 7-2i,6-2i)."""
+    s6 = 0
+    for i in range(4):
+        pen = ((byte >> (7 - i)) & 1) | (((byte >> (3 - i)) & 1) << 1)
+        s6 |= pen << (6 - 2 * i)
+    return s6
+
+
 def main():
-    if len(sys.argv) not in (4, 5):
+    argv = sys.argv[1:]
+    platform = 'cpc'
+    if len(argv) >= 2 and argv[0] == '--platform':
+        platform, argv = argv[1], argv[2:]
+    if len(argv) not in (3, 4):
         print(__doc__)
         sys.exit(2)
-    in_png, out_asm, label = sys.argv[1], sys.argv[2], sys.argv[3]
+    in_png, out_asm, label = argv[0], argv[1], argv[2]
 
     img = Image.open(in_png).convert("RGB")
-    if len(sys.argv) == 5:
-        tw, th = (int(v) for v in sys.argv[4].lower().split("x"))
+    if len(argv) == 4:
+        tw, th = (int(v) for v in argv[3].lower().split("x"))
         img = img.resize((tw, th), Image.LANCZOS)
     w, h = img.size
     if w % 4 != 0:
@@ -92,6 +108,9 @@ def main():
                 used[pen] = used.get(pen, 0) + 1
             row.append(encode_byte(pens))
         rows.append(row)
+
+    if platform == 'msx2':
+        rows = [[mode1_to_screen6(b) for b in row] for row in rows]
 
     if out_asm.lower().endswith(".bin"):
         # Raw row-major Mode-1 bytes (no header) - what restore_block blits directly.


### PR DESCRIPTION
Extends --platform msx2 (already on packicons/png2spr/picconv/pic_to_msx) to the remaining Mode-1-only asset tools, so the whole suite can create MSX2 Screen-6 assets:

- **iconedit.py** (Tk icon editor) - loads/saves Screen-6 .IST, byte-for-byte compatible with packicons --platform msx2. Cursors stay CPC-only (MSX cursors are hardware sprites -> png2spr).
- **png2backdrop.py / png2cpc.py** - emit Screen-6 packing.

All reuse the standard mode1_to_screen6 map. Verified: converter MSX output == transcode(CPC); iconedit round-trips a packicons --platform msx2 set. png2catclock left CPC-only (catclock runtime-transcodes catimg on MSX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)