### PR TITLE
iconedit: auto-detect cursor .SPR kind by size (no --platform needed)

### DIFF
--- a/tools/iconedit.py
+++ b/tools/iconedit.py
@@ -484,20 +484,22 @@ class IconEditor(tk.Toplevel):
                 self.icons = load_ist(path)
                 self.mode = "IST"
             elif ext == ".spr":
+                # Auto-detect the cursor kind by size (unambiguous): 66 bytes = an
+                # MSX2 V9938 hardware sprite, 256 = a CPC Mode-1 masked cursor. No
+                # --platform flag needed to open the right one.
                 data = open(path, "rb").read()
-                if PLATFORM == 'msx2':
-                    if len(data) != MSX_SPR_LEN:
-                        raise ValueError(f"{path}: expected {MSX_SPR_LEN} bytes "
-                                         f"(MSX2 sprite), got {len(data)}")
+                if len(data) == MSX_SPR_LEN:
                     grid, self.msx_hotspot = decode_msx_sprite(data)
                     self.icons = [{"w": 4, "h": 16, "grid": grid}]
                     self.mode = "MSPR"
-                else:
-                    if len(data) != 4 * PHASE:
-                        raise ValueError(f"{path}: expected {4*PHASE} bytes, got {len(data)}")
+                elif len(data) == 4 * PHASE:
                     self.icons = [{"w": CUR_W, "h": CUR_H,
                                    "grid": decode_cursor_phase0(data)}]
                     self.mode = "SPR"
+                else:
+                    raise ValueError(f"{path}: not a cursor .SPR (expected "
+                                     f"{MSX_SPR_LEN} bytes for MSX2 or {4*PHASE} "
+                                     f"for CPC, got {len(data)})")
             else:
                 raise ValueError(f"unknown extension: {ext}")
         except Exception as e:


### PR DESCRIPTION
Opening a 66-byte MSX2 .SPR without --platform msx2 fell into the CPC branch and errored (expected 256, got 66). The two formats have unambiguous sizes (66 = MSX2 hardware sprite, 256 = CPC masked cursor), so open_file now selects the codec by length and sets MSPR/SPR mode accordingly; save writes the matching format. The flag still governs the .IST pixel packing and File > New default.\n\nVerified: a 66-byte .SPR opens as the MSX pointer with no flag.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)