### PR TITLE
docs: MSX2 build in BUILDING.md + experimental MSX boot-floppy builder

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,7 +1,11 @@
 # Building, deploying and running
 
-This covers the **Amstrad CPC** build. For the MSX2 build, see
-[The MSX2 target](MSX2.md).
+The **Amstrad CPC** build is below; the **MSX2** build is in
+[Building for MSX2](#building-for-msx2). Both share the RASM kernel + SDCC apps
+and happen inside the project distrobox (RASM, SDCC, `mtools`/`dosfstools` on
+`PATH`).
+
+## Amstrad CPC
 
 The kernel is assembled with **RASM**; the apps are compiled with **SDCC**
 (`sdcc`, `sdasz80`, `makebin` on `PATH`). In practice development happens inside
@@ -59,3 +63,53 @@ one (`rom/GEOBENCH.ROM` is the archived IDE variant) — that does two things:
   prints a `GEOBENCH <commit>` banner at cold boot (like M4 or SymbOS) before BASIC's prompt.
 
 Flash the matching ROM into a free upper-ROM slot.
+
+## Building for MSX2
+
+The same kernel and app sources cross-build for the MSX2 (`-DPLATFORM_MSX` for the
+kernel, `-DGB_MSX2` for the apps). See [The MSX2 target](MSX2.md) for the runtime
+design; this is the build.
+
+```bash
+bash tools/fetch_msx_deps.sh       # one-time: Nextor system files + NMS 8250 ROMs
+bash tools/build_kernel_msx.sh     # the whole MSX2 distribution
+tools/run_msx.sh                   # boot it in openMSX (interactive)
+MSX_SHOTS="25 40" tools/run_msx.sh # headless: screenshots into build/msx/
+```
+
+`build_kernel_msx.sh` produces:
+
+- **`QA/MSX/`** — the loose MSX distribution (committed): `GBMSX.COM`, an
+  `AUTOEXEC.BAT` that runs it, `GEOBENCH.CFG`, the `GBENCH/` system folder
+  (fonts/icons/cursor/modules/apps/savers) and the sample pictures.
+- **`QA/GBMSX.IMG`** — a bootable 32 MB **FAT16 hard-disk image** (a local
+  artifact, git-ignored like the CPC card image). `tools/build_msx_img.sh` fills
+  it from `QA/MSX` plus the Nextor system files, so Nextor's Sunrise IDE driver
+  boots it straight to the desktop.
+
+**Assets are packaged automatically.** Anything dropped into `assets/iconsets`,
+`assets/backdrops` or `assets/pictures` is transcoded from CPC Mode 1 to V9938
+Screen 6 and staged for both root (viewable) and `GBENCH/` (selectable via
+`ICONS=`/`BACKDROP=`/`WALLPAPER=`) — the tools take a `--platform msx2` flag
+(`packicons`, `png2spr`, `picconv`, `png2backdrop`, `png2cpc`) or are dedicated
+transcoders (`pic_to_msx`, `ist_to_msx`, `bdp_to_msx`). The mouse pointer is a
+V9938 hardware sprite: a hand-edited **`assets/pointer.SPR`** (edit it with
+`tools/iconedit.py --platform msx2 assets/pointer.SPR`) is preferred over
+generating it from `assets/pointer.png`.
+
+### Deploying
+
+Copy the contents of **`QA/MSX/`** onto storage your MSX-DOS 2 / Nextor setup
+mounts (an SD card, IDE disk, …) and run **`GBMSX.COM`** (the `AUTOEXEC.BAT` runs
+it for you) — or write the whole `QA/GBMSX.IMG` to the device. It needs **MSX-DOS
+2** (mapper support); a bare MSX2 with only Disk BASIC / MSX-DOS 1 won't run it.
+
+### Boot floppy (experimental)
+
+`tools/build_msx_floppy.sh` assembles a single bootable **720 KB MSX-DOS 2 floppy**
+(`QA/GBMSX.DSK`) — MSX floppies are big enough that the whole ~612 KB distro fits
+on one disk. It carries third-party MSX-DOS 2 files (`MSXDOS2.SYS`, `COMMAND2.COM`)
+so, like `QA/GBMSX.IMG`, it is a local artifact. **Status:** it boots MSX-DOS 2 and
+GEOBENCH starts, but the display currently stays blanked under a floppy DOS2 setup
+(the disk ROM holds the screen off during floppy access) — under investigation; the
+IDE/SD image (`QA/GBMSX.IMG`) is the working path for now.

--- a/tools/build_msx_floppy.sh
+++ b/tools/build_msx_floppy.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# tools/build_msx_floppy.sh - build a bootable 720KB MSX-DOS 2 floppy image for the
+# MSX2 target (#287). MSX floppies (720K) are far bigger than the CPC's (~180K), so
+# the whole GEOBENCH distro fits on ONE disk. Unlike the CPC .DSK (self-booting
+# GEOBENCH), this carries third-party MSX-DOS 2 files (MSXDOS2.SYS + COMMAND2.COM),
+# so - like QA/GBMSX.IMG - the .DSK is a LOCAL artifact (git-ignored), not committed.
+#
+# Boot chain: the disk-interface ROM runs the MSX boot sector -> loads MSXDOS.SYS
+# (= MSXDOS2.SYS) -> COMMAND2.COM -> AUTOEXEC.BAT ("GBMSX") -> the desktop. Needs an
+# MSX with MSX-DOS 2 (a DOS2 disk interface; most bare MSX2s have DOS1 - see docs).
+#
+# Usage: tools/build_msx_floppy.sh [staging-dir] [out.dsk]
+#   staging dir default: QA/MSX        (the same tree build_msx_img.sh packs)
+#   output default:      QA/GBMSX.DSK  (local artifact, git-ignored)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SRC="${1:-QA/MSX}"
+DSK="${2:-QA/GBMSX.DSK}"
+DEPS=QA/MSXDEPS
+
+for t in mkfs.fat mcopy dd; do
+    command -v "$t" >/dev/null || { echo "ERROR: missing tool '$t' (dosfstools/mtools)" >&2; exit 1; }
+done
+for f in msxboot.bin MSXDOS2.SYS COMMAND2.COM; do
+    [ -s "$DEPS/$f" ] || { echo "ERROR: $DEPS/$f missing - run tools/fetch_msx_deps.sh" >&2; exit 1; }
+done
+[ -d "$SRC" ] || { echo "ERROR: staging dir '$SRC' missing - run tools/build_kernel_msx.sh" >&2; exit 1; }
+
+rm -f "$DSK"
+# 720K (1440 x 512) FAT12, standard MSX geometry: 2 sec/cluster, 1 reserved, 2 FATs,
+# 112 root entries, 9 sec/track, 2 heads.
+mkfs.fat -F12 -S512 -s2 -R1 -f2 -r112 -h0 -n GBMSX -C "$DSK" 720 >/dev/null
+# Inject the MSX boot code (offset 0x1E..0x1FF) over mkfs's x86 stub, keeping mkfs's
+# BPB (0x00-0x1D) so it stays consistent with the filesystem the MSX boot code reads.
+dd if="$DEPS/msxboot.bin" of="$DSK" bs=1 skip=30 seek=30 count=482 conv=notrunc status=none
+
+export MTOOLS_SKIP_CHECK=1
+# The MSX-DOS 2 kernel (cartridge / disk-interface ROM) loads MSXDOS2.SYS +
+# COMMAND2.COM; also drop the DOS1 names the plain boot sector would look for, so
+# the disk boots on either a DOS2 or a DOS1 interface.
+mcopy -i "$DSK" "$DEPS/MSXDOS2.SYS" ::MSXDOS2.SYS
+mcopy -i "$DSK" "$DEPS/MSXDOS2.SYS" ::MSXDOS.SYS
+mcopy -i "$DSK" "$DEPS/COMMAND2.COM" ::COMMAND2.COM
+mcopy -i "$DSK" "$DEPS/COMMAND2.COM" ::COMMAND.COM
+# The GEOBENCH distro (GBMSX.COM + AUTOEXEC.BAT -> "GBMSX" + GBENCH/ + pictures + CFG).
+mcopy -s -i "$DSK" "$SRC"/* ::/
+
+USED=$(( $(du -sk "$SRC" | cut -f1) ))
+echo "Built $DSK (720K MSX-DOS 2 boot floppy) from $SRC  (~${USED}K of ~713K used)"


### PR DESCRIPTION
BUILDING.md gains a full Building for MSX2 section (deps, build_kernel_msx.sh, asset auto-packaging + --platform msx2 tools, assets/pointer.SPR, Nextor deploy, openMSX harness). Adds tools/build_msx_floppy.sh - a single 720K MSX-DOS 2 boot floppy. Experimental: it boots DOS2 and GEOBENCH starts, but the display is blanked under a floppy DOS2 setup (disk-ROM screen blanking) - under investigation; QA/GBMSX.IMG is the working path.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)