### PR TITLE
Refresh documentation for current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ reaching the kernel through `libgb`. It's a graphical layer on top of an existin
 DOS (AMSDOS / UniDOS / MSX-DOS 2), not a replacement OS — smaller scope than
 [SymbOS](https://www.symbos.de), different goal.
 
-The desktop, file manager, Notepad, ICONED, Paint, Viewer, Clock, Telnet, Xaos,
-Settings and a set of screensavers all build from one script. The same source tree
-targets **two platforms**: the CPC (Albireo card + AMSDOS floppy) and the
-[MSX2](docs/MSX2.md) (MSX-DOS 2 / Nextor, V9938 Screen 6).
+The desktop, file manager, Notepad, ICONED, Paint, Viewer, Clock, Xaos, Settings
+and the screensavers build for both targets from the same source tree. The CPC
+distribution also ships the Telnet client and network diagnostic apps. Targets:
+the CPC (Albireo/M4 card + AMSDOS floppy) and the [MSX2](docs/MSX2.md)
+(MSX-DOS 2 / Nextor, V9938 Screen 6).
 
 ## Quick start
 
@@ -63,10 +64,11 @@ Building from source is for developers — see [docs/BUILDING.md](docs/BUILDING.
 
 ## Where it's going
 
-The core desktop, windowing, file manager, C app model and a suite of bundled apps
-all work on both platforms. Next up: a single canonical asset format shared across
-CPC and MSX, resizable Paint canvases, drawers/folders, and per-screensaver
-configuration. See the [roadmap](docs/ROADMAP.md) for the full list.
+The core desktop, windowing, file manager, C app model and most bundled apps work
+on both platforms; the network apps remain CPC-only for now. Next up: a single
+canonical asset format shared across CPC and MSX, resizable Paint canvases,
+drawers/folders, and per-screensaver configuration. See the
+[roadmap](docs/ROADMAP.md) for the full list.
 
 ## License
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -21,7 +21,8 @@ loop and calls each focused window's handlers (issue #45).
 | xaos     | `XAOS.APP`     | fractal generator, exports `.PIC` |
 | clock    | `CLOCK.APP`    | analog clock widget |
 | settings | `SETTINGS.APP` | control panel — font / icons / cursor / backdrop / wallpaper / desktop colours / screensaver, persisted to `GEOBENCH.CFG` |
-| nettest  | `NETTEST.APP`  | network diagnostic — DNS `example.com`, TCP connect, HTTP GET, and PASS/FAIL status for the active backend |
+| telnet   | `TELNET.APP`   | CPC-only Telnet/ANSI terminal using Net4CPC or M4 TCP |
+| nettest  | `NETTEST.APP`  | CPC-only network diagnostic — DNS `example.com`, TCP connect, HTTP GET, and PASS/FAIL status for the active backend |
 
 ## Screensavers (`.SAV`)
 
@@ -31,24 +32,27 @@ in `GEOBENCH.CFG`, set from **Settings → Screensaver**) after the idle timeout
 System → "Activate screensaver" runs it on demand. Each is a full-screen window
 (`WM_FS`) that animates every frame and closes on any input.
 
+The Main CPC boot floppy carries `SQUARES.SAV`; `QA/COMPANION.DSK`, the
+Albireo/M4 card distribution, and the MSX2 distribution carry all 16 savers.
+
 | Saver | Disk file | Effect |
 |-------|-----------|--------|
-| saver    | `CIRCLE.SAV`   | random circles (the first/test saver) |
+| saver    | `SQUARES.SAV`  | random squares (the default saver) |
 | deco     | `DECO.SAV`     | Art-Deco / Mondrian rectangle subdivision — ported from the SymbOS `symsav-deco` |
 | xmatrix  | `XMATRIX.SAV`  | binary "Matrix" digital rain (white → red → black glow) — ported from `symsav-xmatrix` |
 | mountain | `MOUNTAIN.SAV` | isometric 3D filled terrain + white wireframe — ported from `symsav-mountain` (writes the `#C000` screen directly) |
-| fractalic | `FRACTALI.SAV` | Sierpinski triangle + Koch snowflake (random each cycle) — ported from `symsav-fractalic`. **Albireo card only** (too big for the floppy) |
-| starfield | `STARFLD.SAV`  | 3D star-field flying toward the viewer (blue → red → white, black border) — inspired by `symsav-starfield`, fresh `#C000` impl. **Albireo card only** (the floppy pack is at its 64K ceiling) |
-| xroach   | `XROACH.SAV`   | 16×16 cockroaches scuttle on the blue field and scatter from a red rogue roach — ported from `symsav-xroach`, direct `#C000` sprite blit. **Albireo card only** |
-| pyro     | `PYRO.SAV`     | fixed-point fireworks — rockets rise and burst into shrapnel showers — ported from xscreensaver. **Albireo card only** |
-| forest   | `FOREST.SAV`   | recursive fractal trees with red blossoms — ported from xscreensaver. **Albireo card only** |
-| helix    | `HELIX.SAV`    | woven harmonograph curves (sin-table) — ported from xscreensaver. **Albireo card only** |
-| catclock | `CATCLK.SAV`   | Kit-Cat Klock — embedded body bitmap (from `assets/catclockbody.png` via `tools/png2catclock.py`) with sliding pupils + real hour/minute hands from `gb_time()`. **Albireo card only** |
-| munch    | `MUNCH.SAV`    | "munching squares" XOR moiré sweeping a power-of-two square — ported from xscreensaver. **Albireo card only** |
-| rorschach | `RORSCH.SAV`  | 4-fold-symmetric random-walk ink-blots — ported from xscreensaver. **Albireo card only** |
-| truchet  | `TRUCHET.SAV`  | random diagonal-tile maze, re-tiled every few seconds — ported from xscreensaver. **Albireo card only** |
-| ant      | `ANT.SAV`      | Langton's ant on an 80×50 grid (4-state rule, all four pens) — inspired by xscreensaver. **Albireo card only** |
-| lightning | `LIGHTN.SAV`  | midpoint-displacement forked lightning bolts that flash and re-strike — ported from xscreensaver. **Albireo card only** |
+| fractalic | `FRACTALI.SAV` | Sierpinski triangle + Koch snowflake (random each cycle) — ported from `symsav-fractalic` |
+| starfield | `STARFLD.SAV`  | 3D star-field flying toward the viewer (blue → red → white, black border) — inspired by `symsav-starfield`, fresh `#C000` impl |
+| xroach   | `XROACH.SAV`   | 16×16 cockroaches scuttle on the blue field and scatter from a red rogue roach — ported from `symsav-xroach`, direct `#C000` sprite blit |
+| pyro     | `PYRO.SAV`     | fixed-point fireworks — rockets rise and burst into shrapnel showers — ported from xscreensaver |
+| forest   | `FOREST.SAV`   | recursive fractal trees with red blossoms — ported from xscreensaver |
+| helix    | `HELIX.SAV`    | woven harmonograph curves (sin-table) — ported from xscreensaver |
+| catclock | `CATCLK.SAV`   | Kit-Cat Klock — embedded body bitmap (from `assets/catclockbody.png` via `tools/png2catclock.py`) with sliding pupils + real hour/minute hands from `gb_time()` |
+| munch    | `MUNCH.SAV`    | "munching squares" XOR moiré sweeping a power-of-two square — ported from xscreensaver |
+| rorschach | `RORSCH.SAV`  | 4-fold-symmetric random-walk ink-blots — ported from xscreensaver |
+| truchet  | `TRUCHET.SAV`  | random diagonal-tile maze, re-tiled every few seconds — ported from xscreensaver |
+| ant      | `ANT.SAV`      | Langton's ant on an 80×50 grid (4-state rule, all four pens) — inspired by xscreensaver |
+| lightning | `LIGHTN.SAV`  | midpoint-displacement forked lightning bolts that flash and re-strike — ported from xscreensaver |
 
 The Settings **Module** picker lists every `.SAV` in the system media folder for
 the selected drive, so a new screensaver appears there automatically once it is

--- a/assets/iconsets/README.md
+++ b/assets/iconsets/README.md
@@ -1,9 +1,11 @@
 # Custom icon sets
 
-Drop tracked `.IST` icon-set files here and they are **automatically copied onto
-the card** (`QA/GEOBENCH.IMG` via `stage_dist.sh`). Unlike `build/DEFAULT.IST` — a gitignored build
-artifact that `packicons.py` regenerates from `lib/icon_*.asm` on every build —
-files here are version-controlled and the build never overwrites them.
+Drop tracked `.IST` icon-set files here and they are automatically staged for the
+CPC card and MSX distributions. The CPC build copies them into `QA/CARD/GBENCH/`
+via `stage_dist.sh`; the MSX build transcodes them to Screen 6 in
+`QA/MSX/GBENCH/`. Unlike `build/DEFAULT.IST` — a gitignored build artifact that
+`packicons.py` regenerates from `lib/icon_*.asm` on every build — files here are
+version-controlled and the build never overwrites them.
 
 ## Make / edit a set
 
@@ -29,7 +31,7 @@ Select the set in the boot config `GEOBENCH.CFG` (written by `stage_dist.sh`):
 ICONS=MYSET
 ```
 
-The kernel loads `MYSET.IST` from the card at boot and falls back to
+The kernel loads `MYSET.IST` from the system folder at boot and falls back to
 `DEFAULT.IST` if it is missing.
 
 ## Changing the DEFAULT icons instead

--- a/assets/pictures/README.md
+++ b/assets/pictures/README.md
@@ -1,8 +1,9 @@
 # Pictures
 
-Drop GEOBENCH `.PIC` files here and they are **copied onto every card** (the unified
-`QA/GEOBENCH.IMG` and the loose `QA/CARD/` tree via `stage_dist.sh`) at build time —
-they show up in the Viewer.
+Drop GEOBENCH `.PIC` files here and they are staged for the card and MSX
+distributions at build time. The CPC card tree copies them into `QA/CARD/GBENCH/`
+via `stage_dist.sh`; the MSX build transcodes them to Screen 6 and places copies in
+both `QA/MSX/` and `QA/MSX/GBENCH/`. They show up in the Viewer.
 
 ## Make a .PIC from an image
 
@@ -22,8 +23,8 @@ CPC's AMSDOS/FAT expects, and the staging copies the file under its own name.
 ## Size
 
 The Viewer holds a picture up to ~10 KB of bitmap (≈ 200×200; `PENGUIN.PIC` is the
-200×200 sample) in its in-window buffer. Larger pictures load into a borrowed 16 KB
-RAM bank (#164), so on a bare 128K machine — where every app bank is already in use —
-a big image shows an empty window, while a 256K+ expansion displays it. The floppy
-image (`QA/GEOBENCH.DSK`) only carries the pictures hardcoded in
-`kernel/pack_apps.asm`; the card carries everything in this folder.
+200×200 sample) in its in-window buffer. Larger pictures load into borrowed 16 KB
+RAM bank pages, so 256K+ is the practical target for large images and multiple
+picture windows. The Main CPC boot floppy carries only its hand-packed core
+picture set; `QA/COMPANION.DSK`, the card distribution, and the MSX distribution
+carry the gallery pictures from this folder.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -19,6 +19,9 @@ into the floppy images; without it the floppy still boots via `RUN"GBKERN`:
 bash tools/build_kernel.sh
 ```
 
+The repository also has a thin top-level Makefile: `make cpc`, `make msx`,
+`make all`, and `make check` wrap the same scripts and static checks.
+
 This stages these outputs (the staged media under `QA/` are committed, so you
 can test or deploy without rebuilding first):
 
@@ -108,8 +111,9 @@ it for you) — or write the whole `QA/GBMSX.IMG` to the device. It needs **MSX-
 
 `tools/build_msx_floppy.sh` assembles a single bootable **720 KB MSX-DOS 2 floppy**
 (`QA/GBMSX.DSK`) — MSX floppies are big enough that the whole ~612 KB distro fits
-on one disk. It carries third-party MSX-DOS 2 files (`MSXDOS2.SYS`, `COMMAND2.COM`)
-so, like `QA/GBMSX.IMG`, it is a local artifact. **Status:** it boots MSX-DOS 2 and
-GEOBENCH starts, but the display currently stays blanked under a floppy DOS2 setup
-(the disk ROM holds the screen off during floppy access) — under investigation; the
-IDE/SD image (`QA/GBMSX.IMG`) is the working path for now.
+on one disk. It carries third-party MSX-DOS 2 files (`MSXDOS2.SYS`, `COMMAND2.COM`),
+so treat it as an optional generated test artifact; it may appear untracked after
+running the builder. **Status:** it boots MSX-DOS 2 and GEOBENCH starts, but the
+display currently stays blanked under a floppy DOS2 setup (the disk ROM holds the
+screen off during floppy access) — under investigation; the IDE/SD image
+(`QA/GBMSX.IMG`) is the working path for now.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,8 +70,9 @@ bash tools/build_kernel.sh
 ../1984/1984 --config=/dev/null --6128 --memory=512 --disk-a=QA/GEOBENCH.DSK --autostart=GB --screenshot-at=2200:/tmp/boot.ppm --exit-after=2200
 ```
 
-The boot splash prints the build commit below the progress bar; use that to
-cross-check media against the source tree under test.
+The boot splash prints the build commit below the progress bar only when
+`DEBUG=TRUE` is set in `GEOBENCH.CFG`; normal media show `GEOBENCH` there. Use the
+debug splash to cross-check media against the source tree under test.
 
 ### Incremental build behavior
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -66,17 +66,17 @@ backdrop, dragging icons, opening apps and menus:
 - **Screensavers** — self-contained apps shipped with a `.SAV` extension. The
   desktop's idle timer (global, so it fires over any app) launches the configured
   module after the timeout; any pointer move / click / key returns to the desktop.
-  Ships **SQUARES** (random squares), **DECO** (Art-Deco panels), **XMATRIX**
-  (binary "Matrix" rain) and **MOUNTAIN** (isometric 3D terrain) on both disks, plus
-  several **Albireo-card-only** extras: **FRACTALI** (Sierpinski + Koch), **STARFLD**
-  (3D star-field) and **XROACH** (scattering cockroaches) from the SymbOS `symsav-*`
-  set, and **MUNCH** (munching squares), **RORSCH** (symmetric ink-blots), **TRUCHET**
-  (tile maze), **ANT** (Langton's ant), **LIGHTN** (forked lightning), **PYRO**
-  (fireworks), **FOREST** (fractal trees) and **HELIX** (harmonograph) from
-  xscreensaver, plus **CATCLK** (a Kit-Cat Klock with sliding pupils + real
-  hour/minute hands). The Settings **Module** picker lists every `.SAV` in the system
-  folder (scrolling when there are more than fit), so new ones appear automatically.
-  All 16 savers are also ported to the [MSX2 target](MSX2.md).
+  The Main CPC boot floppy carries the default **SQUARES** saver; the Companion
+  floppy, the Albireo/M4 card distribution, and the MSX2 distribution carry the
+  full set: **SQUARES** (random squares), **DECO** (Art-Deco panels), **XMATRIX**
+  (binary "Matrix" rain), **MOUNTAIN** (isometric 3D terrain), **FRACTALI**
+  (Sierpinski + Koch), **STARFLD** (3D star-field), **XROACH** (scattering
+  cockroaches), **MUNCH** (munching squares), **RORSCH** (symmetric ink-blots),
+  **TRUCHET** (tile maze), **ANT** (Langton's ant), **LIGHTN** (forked lightning),
+  **PYRO** (fireworks), **FOREST** (fractal trees), **HELIX** (harmonograph), and
+  **CATCLK** (a Kit-Cat Klock with sliding pupils + real hour/minute hands). The
+  Settings **Module** picker lists every `.SAV` in the system folder (scrolling
+  when there are more than fit), so new ones appear automatically.
 - **One menu system for the whole UI (`gb_doc`)** — every app gets the **same menus**
   from one place: it registers a small "document" (its buffer + new/open/save hooks)
   and the framework supplies a standard **File** menu (New / Load / Save / Save As),

--- a/docs/KERNEL_ARCHITECTURE_REVIEW.md
+++ b/docs/KERNEL_ARCHITECTURE_REVIEW.md
@@ -2,10 +2,17 @@
 
 Date: 2026-06-28
 
+> Historical review: this file is kept as the architectural audit trail from the
+> 2026-06-28 cleanup pass. Several items called out below have since been
+> implemented or partially implemented; use `docs/ARCHITECTURE.md`,
+> `kernel/README.md`, `kernel/lowram.tsv`, and `lib/gbapp.inc` as the current
+> contracts.
+
 This review focuses on the resident kernel architecture, size pressure, and
-modularity. It is based on the current tree: `kernel/gbkern.asm`,
-`lib/gbapp.inc`, `lib/gb/gblib.s`, `lib/gb/gb.h`, the storage libraries, and the
-loadable kernel modules under `kernel/kc/` and `kernel/modules/`.
+modularity. It was based on the tree as it stood on the date above:
+`kernel/gbkern.asm`, `lib/gbapp.inc`, `lib/gb/gblib.s`, `lib/gb/gb.h`, the
+storage libraries, and the loadable kernel modules under `kernel/kc/` and
+`kernel/modules/`.
 
 ## Executive Summary
 
@@ -291,22 +298,14 @@ Recommended fix:
 This will not shrink the resident image, but it reduces accidental coupling and
 makes adding/removing modules safer.
 
-### 9. Documentation is stale in key places
+### 9. Documentation was stale in key places
 
-Examples:
-
-- `kernel/README.md` still says "Not started."
-- `lib/gbapp.inc` describes an earlier ABI and omits many live slots.
-- `kernel/kc/README.md` still refers to older sizes and a few older transfer cells.
-- `docs/ARCHITECTURE.md` is broadly useful but contains forward-looking and
-  historical sections mixed with current behavior.
-
-Recommended fix:
-
-- Update `kernel/README.md` into a concise current map.
-- Regenerate or rewrite `lib/gbapp.inc` from the live ABI.
-- Move old design records into `docs/dev/` and keep `docs/ARCHITECTURE.md` as
-  "current behavior only."
+Several examples from the original review have since been addressed: the kernel
+README now describes the active source split, `lib/gbapp.inc` lists the live ABI
+through `GB_NET`, and `tools/check_abi_table.py` validates the table. The remaining
+rule is operational rather than architectural: keep `docs/ARCHITECTURE.md` as the
+current-behavior document and keep older design records clearly marked as
+historical.
 
 ## Concrete Size-Reduction Opportunities
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,10 +8,12 @@
    select, scroll, open by type.
 4. ✅ **Banked app model + app API** — separate-binary apps over a kernel API.
 5. ✅ **Apps in C** — the whole app layer moved from assembly to C over `libgb`.
-6. ✅ **Storage write layer** — FAT16/FAT32 + Albireo read/write (save/delete/copy).
-7. ✅ **Apps** — Notepad, ICONED, Paint, Clock, Viewer, Telnet, Xaos, and a
+6. ✅ **Storage write layer** — Albireo, M4 and floppy read/write paths support
+   save/delete/copy; the archived IDE/FAT backend remains buildable for recovery.
+7. ✅ **Apps** — Notepad, ICONED, Paint, Clock, Viewer, Xaos, Diskutil, and a
    **Settings** control panel (font / icon set / cursor / drive-qualified
-   backdrop-wallpaper-saver settings + a live desktop-colours editor).
+   backdrop-wallpaper-saver settings + a live desktop-colours editor). The CPC
+   distro also ships Telnet and Nettest.
 8. ✅ **Unified menu system (`gb_doc`)** — one File / Edit / View menu framework for
    every app (New/Load/Save/Save As, a shared cross-app clipboard, **Fullscreen**, a
    navigable Open/Save dialog in a paged module); the desktop's System menu and the
@@ -23,9 +25,10 @@
 10. ✅ **M4 board SD/TCP support (#174, #259)** — a file-level backend (`GBM4.BIN`)
    ships beside `GBALB.BIN` on the shared card image. `GB.BAS` detects M4ROM
    (`KL_FIND_COMMAND` for an M4 RSX) and selects the right kernel. M4 supports
-   directory, load, save/create, and TCP through `GBNETM4.MOD`. Its storage and
+   directory, load, save/create, delete, free-space queries, and TCP through
+   `M4SAVE.MOD` / `GBNETM4.MOD`. Its storage and
    network calls preserve the active CPC video mode, so Telnet's Mode 2 fullscreen
-   terminal survives paged module loads. Delete remains pending for image-backed mode.
+   terminal survives paged module loads.
 11. ✅ **Kernel source split + build cache** — the resident kernel contracts now
    live in dedicated source files with checked ABI/low-RAM maps, and the full
    build reuses unchanged app/module outputs instead of recompiling everything.

--- a/kernel/kc/README.md
+++ b/kernel/kc/README.md
@@ -7,11 +7,11 @@ hot-path compositor. What *can* move to C is the branchy **logic**, and the
 resident region around `#8000` is tight, so that logic lives in **paged bank
 modules** the nucleus loads and calls through the trampoline — the SymbOS model.
 
-This directory holds those modules. Each is pure logic: no I/O, no firmware
-calls, no globals if avoidable. The nucleus owns memory and devices and hands
-the module pointers (or a fixed low-RAM transfer area). The modules are loaded
-into a bank page and `call`ed exactly like an app; only one is live at a time, so
-several share the same low-RAM transfer/buffer overlays.
+This directory holds the C-built modules. Most are pure policy/logic over fixed
+low-RAM transfer areas, while the network modules deliberately contain hardware or
+firmware-facing driver code that is too bulky to keep resident. The modules are
+loaded into a bank page and `call`ed exactly like an app; only one is live at a
+time, so several share the same low-RAM transfer/buffer overlays.
 
 ## Modules
 
@@ -71,10 +71,7 @@ Boot flow for the config module lives in `kernel/config_module.asm` (split out o
 
 ## Follow-ups
 
-- **DEFAULT fallback** when a configured `.FNT`/`.IST` is missing (a bad value
-  loads nothing and draws garbage). Deferred because the retry costs resident
-  bytes; it pairs with trimming the nucleus.
-- Retire `lib/config.asm` once nothing else references it (it is already
-  orphaned — `GBCFG.MOD` is the live parser).
 - Continue moving branchy policy into paged modules following this pattern, per
   `docs/KERNEL_ARCHITECTURE_REVIEW.md`.
+- Keep module transfer blocks documented in `kernel/lowram.tsv` as more services
+  move out of the resident nucleus.

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,8 +24,8 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
   (`rom/gitcommit.inc`, generated).
 - **`build_m4netmod.sh [out.RAW]`** — builds `GBNETM4.MOD`, the M4ROM TCP command
   backend for the shared `gb_net_*` API.
-- **`build_m4savemod.sh`** — builds `M4SAVE.MOD`, the M4ROM `C_OPEN`/`C_WRITE`/
-  `C_CLOSE` save backend loaded on demand by the M4 kernel.
+- **`build_m4savemod.sh`** — builds `M4SAVE.MOD`, the M4ROM save/delete/free-space
+  and chunked-read backend loaded on demand by the M4 kernel.
 - **`stage_dist.sh <out>`** — stages the shared Albireo/M4 card distribution
   (`GB.BAS`, `M4DETECT.BIN`, `GBALB.BIN`, `GBM4.BIN`, and the `GBENCH/` payload)
   into a directory.

--- a/tools/netspike/README.md
+++ b/tools/netspike/README.md
@@ -1,9 +1,10 @@
 # netspike — Net4CPC (W5100S) round-trip test harness (#238 Phase 0)
 
 A throwaway-but-kept harness that proved the GEOBENCH networking path end to end
-before building `GBNET.MOD`. It builds a tiny CPC binary against the **cpc-sdcc**
-C W5100 driver (`~/Dev/cpc-sdcc/src`: `w5100.c`/`net.c`/`netinit.c`), connects to a
-local TCP server, and prints the reply — all headless in the 1984 emulator.
+before the current `GBNET.MOD` implementation. It builds a tiny CPC binary against
+the **cpc-sdcc** C W5100 driver (`~/Dev/cpc-sdcc/src`: `w5100.c`/`net.c`/
+`netinit.c`), connects to a local TCP server, and prints the reply — all headless
+in the 1984 emulator.
 
 ## Result (proven)
 The CPC connects to `127.0.0.1:2323`, sends `hi`, and receives the server's banner
@@ -29,6 +30,6 @@ Then view `tools/netspike/spike.ppm`.
 - The server and emulator must run in the **same shell** (a backgrounded server dies
   when its launching shell exits).
 
-## Next
-Step 1 wraps this proven driver into `GBNET.MOD` (paged C module) + a `gb_net_*`
-app API. See issue #238.
+## Status
+The production path now lives in `GBNET.MOD` plus the `gb_net_*` app API. Keep this
+directory as a historical spike and as a small independent Net4CPC transport test.


### PR DESCRIPTION
## Summary
- update user-facing docs for current CPC/MSX app and screensaver packaging
- document current M4 save/delete/free-space support and DEBUG-gated splash hashes
- mark historical/spike docs clearly and remove completed TODOs

## Tests
- make check