### PR TITLE
PCW port Phase 1: boot sector, DSK builder, CGA video spike

### DIFF
--- a/debug/1985-pcw.conf
+++ b/debug/1985-pcw.conf
@@ -1,0 +1,42 @@
+# 1985 emulator config for GEOBENCH PCW development (#331).
+# PCW 8256, 256K, CGA2 color reinterpretation (360x256, 4 colors:
+# black/cyan/magenta/white), DK'tronics AY board for the joystick
+# pointer (AY reg 14 via ports AA/A9, active-low).
+
+[machine]
+model = 8256
+memory_kb = 256
+region = pal
+turbo = false
+
+[storage]
+drive_a =
+drive_b =
+
+[display]
+scale = 2
+fullscreen = false
+fullscreen_smoothing = false
+monochrome = green
+video_mode = cga2
+
+[extensions]
+ext_second_drive        = false
+ext_sanpollo_backplane  = true
+ext_serial              = false
+ext_perryfi             = false
+ext_dktronics           = true
+input_device            = joystick
+ext_pdf_printer         = false
+
+[advanced]
+tinker = true
+status_line = true
+notifications = console
+debug = false
+debug_traces = false
+trace_io = false
+trace_fdc = false
+trace_input = false
+mouse_type = amx
+joystick_type = dksound

--- a/kernel/pcwboot.asm
+++ b/kernel/pcwboot.asm
@@ -1,0 +1,211 @@
+; -----------------------------------------------------------------------
+; pcwboot.asm - GEOBENCH boot sector for the Amstrad PCW 8256/8512 (#331)
+;
+; The PCW has no ROM: at power-on the printer-controller MCU shifts a
+; 275-byte bootstrap into low RAM, which reads track 0 / sector R=1
+; (this sector, 512 bytes) to #F000, checks that the 8-bit sum of the
+; whole sector is #FF, and jumps to #F010 - just past the 16-byte PCW
+; disc specification that starts the sector.
+;
+; This boot sector then drives the uPD765A FDC directly (polled,
+; non-DMA - there is no OS and no DMA controller) to load a raw system
+; image from the reserved tracks (T0/R2..R9, then whole tracks) and
+; jumps to it.  Loader parameters live in the spare disc-spec bytes and
+; are patched by tools/mkpcwdsk.py:
+;
+;   spec[10]    payload sector count
+;   spec[11]    load address high byte (page-aligned load)
+;   spec[12:14] entry address, little-endian
+;   spec[15]    checksum filler (sum of sector mod 256 == #FF)
+;
+; Hardware used (see docs/PCW.md):
+;   FDC  in/out port #00 = main status register, #01 = data register
+;   #F8  system control:  04 = FDC irq off (we poll)   09/0A = motor
+;                         05/06 = terminal count high/low
+;
+; Assemble: rasm kernel/pcwboot.asm   (saves build/pcwboot.bin)
+; -----------------------------------------------------------------------
+
+        org #F000
+
+; ---- 16-byte PCW disc specification (XBIOS reads [0..9]) --------------
+spec:
+        db 0                    ; [0] format: SS 180K
+        db 0                    ; [1] sided
+        db 40                   ; [2] tracks per side
+        db 9                    ; [3] sectors per track
+        db 2                    ; [4] psh (512-byte sectors)
+        db 1                    ; [5] OFF reserved tracks (patched)
+        db 3                    ; [6] BSH (1K blocks)
+        db 2                    ; [7] directory blocks
+        db #2A                  ; [8] GAP3 read/write
+        db #52                  ; [9] GAP3 format
+ld_secs: db 0                   ; [10] payload sectors      (patched)
+ld_page: db #10                 ; [11] load address hi byte (patched)
+ld_entry: dw #1000              ; [12] entry address        (patched)
+        db 0                    ; [14] spare
+        db 0                    ; [15] checksum filler      (patched)
+
+; ---- entry (#F010) -----------------------------------------------------
+entry:
+        di
+        ld sp,#F000             ; stack just below this sector
+        ld a,4
+        out (#F8),a             ; route FDC interrupt: disabled (poll)
+        ld a,9
+        out (#F8),a             ; motor on (bootstrap left it on; be sure)
+
+        ld hl,cmd_init          ; SPECIFY (non-DMA) + RECALIBRATE,
+        ld b,5                  ; streamed back-to-back (neither has a
+        call fdc_send           ; result phase)
+        call wait_seek          ; poll SENSE INTERRUPT until seek end
+
+        ld a,(ld_page)          ; running destination pointer
+        ld h,a
+        ld l,0
+        ld (dest),hl
+
+; One READ DATA command per sector (R = EOT): the FDC - real PCW CP/M
+; workloads and the 1985 model alike - delivers a single sector per
+; command in this polled non-DMA setup, so multi-sector reads are not
+; used.  Track 0 starts at R=2 (R=1 is this boot sector).
+sec_loop:
+        ld a,(ld_secs)          ; remaining sectors
+        or a
+        jr z,go
+        dec a
+        ld (ld_secs),a
+        ld a,(cur_trk)
+        ld (rd_c),a             ; command C = physical track
+        ld a,(cur_r)
+        ld (rd_r),a             ; command R = EOT = this sector
+        ld (rd_eot),a
+
+        ld hl,rd_cmd            ; READ DATA, 9 command bytes
+        ld b,9
+        call fdc_send
+        ld hl,(dest)
+        ld de,512
+        ld c,1                  ; FDC data register for INI
+rx:                             ; ---- polled non-DMA execution phase ----
+        in a,(0)                ; main status register
+        add a,a                 ; bit7 RQM -> carry
+        jr nc,rx
+        add a,a                 ; bit6 DIO
+        add a,a                 ; bit5 EXM -> carry
+        jr nc,rx_end            ; execution over early = FDC gave up
+        ini                     ; (HL) <- data reg, HL++
+        dec de
+        ld a,d
+        or e
+        jr nz,rx
+        ld a,5                  ; all bytes in: pulse terminal count so
+        out (#F8),a             ; the FDC ends the command cleanly
+        ld a,6
+        out (#F8),a
+rx_end:
+        ld (dest),hl
+        call fdc_drain          ; swallow the 7 result bytes
+
+        ld a,(cur_r)            ; advance sector; past R=9 -> next track
+        inc a
+        cp 10
+        jr c,same_trk
+        ld a,(cur_trk)
+        inc a
+        ld (cur_trk),a
+        ld (sk_trk),a
+        ld hl,cmd_seek          ; SEEK to the new track
+        ld b,3
+        call fdc_send
+        call wait_seek
+        ld a,1                  ; restart at R=1
+same_trk:
+        ld (cur_r),a
+        jr sec_loop
+
+go:
+        ld a,#0A
+        out (#F8),a             ; motor off
+        ld hl,(ld_entry)
+        jp (hl)
+
+; ---- FDC helpers -------------------------------------------------------
+
+; send B command bytes from (HL), waiting for RQM before each
+fdc_send:
+        in a,(0)
+        add a,a                 ; RQM -> carry
+        jr nc,fdc_send
+        ld a,(hl)
+        out (1),a
+        inc hl
+        djnz fdc_send
+        ret
+
+; send the single command byte in A
+fdc_send1:
+        push af
+fs1:    in a,(0)
+        add a,a
+        jr nc,fs1
+        pop af
+        out (1),a
+        ret
+
+; read one result byte -> A
+fdc_res:
+        in a,(0)
+        add a,a
+        jr nc,fdc_res
+        in a,(1)
+        ret
+
+; discard result bytes until the FDC goes idle
+fdc_drain:
+        in a,(0)
+        bit 4,a                 ; command busy?
+        ret z
+        add a,a                 ; RQM?
+        jr nc,fdc_drain
+        in a,(1)                ; result byte, discard
+        jr fdc_drain
+
+; after RECALIBRATE/SEEK: poll SENSE INTERRUPT STATUS until seek end
+wait_seek:
+        ld a,8                  ; SENSE INTERRUPT STATUS
+        call fdc_send1
+        call fdc_res            ; ST0
+        cp #80                  ; invalid = no interrupt pending yet
+        jr z,wait_seek
+        ld b,a
+        call fdc_res            ; PCN, discard
+        bit 5,b                 ; ST0 seek-end?
+        jr z,wait_seek
+        ret
+
+; ---- command templates / state ------------------------------------------
+cmd_init:
+        db #03,#0F,#FF          ; SPECIFY: timings + ND=1 (non-DMA, polled)
+        db #07,#00              ; RECALIBRATE unit 0
+cmd_seek:
+        db #0F,#00              ; SEEK unit 0
+sk_trk: db 0                    ;   new cylinder
+rd_cmd:
+        db #46                  ; READ DATA, MFM
+        db #00                  ; unit 0 head 0
+rd_c:   db 0                    ;   C = cylinder
+        db #00                  ;   H
+rd_r:   db 2                    ;   R = first sector
+        db #02                  ;   N = 512
+rd_eot: db 9                    ;   EOT = last sector
+        db #2A                  ;   GPL
+        db #FF                  ;   DTL
+
+cur_trk: db 0
+cur_r:   db 2
+dest:    dw 0
+
+boot_end:
+        assert boot_end-spec <= 512
+        save"build/pcwboot.bin",#F000,boot_end-spec

--- a/tools/mkpcwdsk.py
+++ b/tools/mkpcwdsk.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""mkpcwdsk.py - build an Amstrad PCW EXTENDED .DSK floppy image (#331).
+
+Produces the exact container the 1985 emulator (and real hardware via
+SAMdisk) expects: EXTENDED CPC DSK, 256-byte Disk-Info, per-track
+Track-Info headers with data rate 0x02 / recording mode 0x02 (CP/M+
+refuses to write without those), sectors in the PCW skew order
+{1,6,2,7,3,8,4,9,5}, filler 0xE5.
+
+Geometry:
+  cf2    3" SS DD  40 tracks x 1 side  x 9 x 512 = 180K  (boots in every PCW)
+  cf2dd  3" DS DD  80 tracks x 2 sides x 9 x 512 = 720K
+
+Boot layout (GEOBENCH.DSK): the PCW has no ROM - the printer-MCU
+bootstrap loads track 0 / sector R=1 (512 bytes) to 0xF000, requires
+the 8-bit sum of the whole sector to be 0xFF, and jumps to 0xF010
+(past the 16-byte disc spec).  --boot installs kernel/pcwboot.bin
+there; --sys writes a raw system image on the sectors after it
+(T0/R2..R9, then whole reserved tracks).  The loader parameters are
+patched into the spare disc-spec bytes the boot sector reads back:
+
+  spec[10]    payload sector count
+  spec[11]    load address high byte
+  spec[12:14] entry address (little-endian)
+  spec[15]    checksum filler so sum(sector) % 256 == 0xFF
+
+spec[5] (OFF, reserved tracks) is raised to cover the system image so
+the CP/M filesystem area never overlaps it.
+
+Usage:
+  mkpcwdsk.py OUT.dsk [--type cf2|cf2dd]
+              [--boot BOOT.BIN --sys SYS.BIN --load 0x1000 --entry 0x1000]
+  mkpcwdsk.py COMPANION.dsk            # plain formatted data disc
+"""
+
+import argparse
+import sys
+
+SKEW = [1, 6, 2, 7, 3, 8, 4, 9, 5]
+SPT = 9
+SEC_SIZE = 512
+N_CODE = 2                       # 128 << 2 = 512
+TRACK_SIZE = 256 + SPT * SEC_SIZE  # 4864
+
+
+def build_spec(is_dd, off):
+    """16-byte PCW disc specification (track 0 / sector R=1, offset 0)."""
+    return bytearray([
+        0x03 if is_dd else 0x00,   # [0] format
+        0x81 if is_dd else 0x00,   # [1] sided (bit7 = alternating flag)
+        80 if is_dd else 40,       # [2] tracks per side
+        SPT,                       # [3] sectors per track
+        N_CODE,                    # [4] psh
+        off,                       # [5] OFF reserved tracks
+        0x04 if is_dd else 0x03,   # [6] BSH
+        0x04 if is_dd else 0x02,   # [7] directory blocks
+        0x2A,                      # [8] GAP3 read/write
+        0x52,                      # [9] GAP3 format
+        0, 0, 0, 0, 0, 0,
+    ])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('out')
+    ap.add_argument('--type', choices=('cf2', 'cf2dd'), default='cf2')
+    ap.add_argument('--boot', help='512-byte-max boot sector binary (org 0xF000)')
+    ap.add_argument('--sys', help='raw system image for the reserved tracks')
+    ap.add_argument('--load', default='0x1000',
+                    help='system image load address (page-aligned, default 0x1000)')
+    ap.add_argument('--entry', default=None,
+                    help='system entry address (default = load address)')
+    args = ap.parse_args()
+
+    is_dd = args.type == 'cf2dd'
+    tracks = 80 if is_dd else 40
+    sides = 2 if is_dd else 1
+
+    load = int(args.load, 0)
+    entry = int(args.entry, 0) if args.entry else load
+    if load & 0xFF:
+        sys.exit('mkpcwdsk: --load must be page-aligned (low byte 0)')
+
+    sysimg = b''
+    if args.sys:
+        with open(args.sys, 'rb') as f:
+            sysimg = f.read()
+    sys_secs = (len(sysimg) + SEC_SIZE - 1) // SEC_SIZE
+    # Sectors available for the image: T0 has 8 (R=2..9 after the boot
+    # sector), every further reserved track has 9.
+    off = 1 if sys_secs <= 8 else 1 + (sys_secs - 8 + SPT - 1) // SPT
+    if off >= tracks - 2:
+        sys.exit('mkpcwdsk: system image too large for the disc')
+
+    spec = build_spec(is_dd, off)
+
+    boot = bytearray(SEC_SIZE)
+    boot[:] = b'\xE5' * SEC_SIZE
+    boot[0:16] = spec
+    if args.boot:
+        with open(args.boot, 'rb') as f:
+            code = f.read()
+        if len(code) > SEC_SIZE:
+            sys.exit(f'mkpcwdsk: boot sector is {len(code)} bytes (max 512)')
+        boot[:len(code)] = code
+        boot[5] = off                       # keep OFF in sync
+        boot[10] = sys_secs                 # loader params (see header)
+        boot[11] = load >> 8
+        boot[12] = entry & 0xFF
+        boot[13] = entry >> 8
+        boot[15] = 0
+        boot[15] = (0xFF - sum(boot)) & 0xFF   # MCU bootstrap checksum
+        assert sum(boot) & 0xFF == 0xFF
+    elif args.sys:
+        sys.exit('mkpcwdsk: --sys needs --boot')
+
+    # Flat logical sector map of the whole disc, then serialize with skew.
+    nsec = tracks * sides * SPT
+    secs = [b'\xE5' * SEC_SIZE] * nsec
+    secs[0] = bytes(boot)
+    for i in range(sys_secs):
+        chunk = sysimg[i * SEC_SIZE:(i + 1) * SEC_SIZE]
+        secs[1 + i] = chunk + b'\xE5' * (SEC_SIZE - len(chunk))
+
+    out = bytearray()
+    hdr = bytearray(256)
+    hdr[0:34] = b'EXTENDED CPC DSK File\r\nDisk-Info\r\n'
+    hdr[0x22:0x22 + 12] = b'mkpcwdsk    '
+    hdr[0x30] = tracks
+    hdr[0x31] = sides
+    for i in range(tracks * sides):
+        hdr[0x34 + i] = TRACK_SIZE // 256
+    out += hdr
+
+    for t in range(tracks):
+        for side in range(sides):
+            ti = bytearray(256)
+            ti[0:12] = b'Track-Info\r\n'
+            ti[0x10] = t
+            ti[0x11] = side
+            ti[0x12] = 0x02            # data rate 250 kbps
+            ti[0x13] = 0x02            # recording mode MFM
+            ti[0x14] = N_CODE
+            ti[0x15] = SPT
+            ti[0x16] = 0x4E            # GAP3
+            ti[0x17] = 0xE5            # filler
+            for i, r in enumerate(SKEW):
+                si = 0x18 + i * 8
+                ti[si + 0] = t
+                ti[si + 1] = side
+                ti[si + 2] = r
+                ti[si + 3] = N_CODE
+                ti[si + 6] = SEC_SIZE & 0xFF
+                ti[si + 7] = SEC_SIZE >> 8
+            out += ti
+            base = (t * sides + side) * SPT
+            for r in SKEW:
+                out += secs[base + r - 1]
+
+    with open(args.out, 'wb') as f:
+        f.write(out)
+    print(f'{args.out}: {args.type} {len(out)} bytes, OFF={off}, '
+          f'sys={len(sysimg)}B/{sys_secs} sectors @{load:#06x} entry {entry:#06x}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/pcwspike/build.sh
+++ b/tools/pcwspike/build.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# build.sh - assemble + run the PCW boot/video spike (#331 Phase 1).
+#
+# Boots a GEOBENCH-format disc in the 1985 emulator headless and
+# screenshots the CGA test pattern:
+#   bash tools/pcwspike/build.sh
+# Outputs: build/pcwspike.dsk, build/pcwspike.png
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+RASM="${RASM:-rasm}"
+E1985="${E1985:-$HOME/Dev/1985/1985}"
+mkdir -p build
+
+# rasm exits 0 on assembly errors - remove outputs first, assert after
+rm -f build/pcwboot.bin build/pcwspike.bin
+"$RASM" kernel/pcwboot.asm
+[ -s build/pcwboot.bin ] || { echo "ERROR: pcwboot.bin not produced" >&2; exit 1; }
+"$RASM" tools/pcwspike/spike.asm
+[ -s build/pcwspike.bin ] || { echo "ERROR: pcwspike.bin not produced" >&2; exit 1; }
+
+python3 tools/mkpcwdsk.py build/pcwspike.dsk \
+    --boot build/pcwboot.bin --sys build/pcwspike.bin --load 0x1000
+
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy "$E1985" \
+    --config debug/1985-pcw.conf \
+    --disk-a build/pcwspike.dsk \
+    --screenshot-at 250:build/pcwspike.ppm \
+    --exit-after 300
+
+python3 - <<'EOF'
+from PIL import Image
+Image.open('build/pcwspike.ppm').save('build/pcwspike.png')
+print('build/pcwspike.png written')
+EOF

--- a/tools/pcwspike/spike.asm
+++ b/tools/pcwspike/spike.asm
@@ -1,0 +1,128 @@
+; -----------------------------------------------------------------------
+; spike.asm - PCW boot + video proof-of-life payload (#331 Phase 1)
+;
+; Loaded at #1000 by kernel/pcwboot.asm from GEOBENCH.DSK's reserved
+; track sectors.  Proves the whole Phase-1 chain: custom boot sector ->
+; polled uPD765 load -> roller-RAM programming -> CGA-mode color.
+;
+; PCW video: 720x256 1bpp via "roller RAM" - a 512-byte table of one
+; 16-bit word per scanline.  Word w -> source row address
+;     A = ((w & #E000) << 1) | ((w & #1FF8) << 1) | (w & 7)
+; i.e. w = (A>>1 & #FFF8) | (A & 7), with A3 forced 0.  Within a row
+; the 90 byte-columns step by 8 (char-cell interleave), so a "cellrow"
+; of 8 scanlines is one contiguous 720-byte run: byte(xcol,y) =
+; cellrow_base + xcol*8 + (y&7).  720 = 16*45, so cellrow strides keep
+; A3=0 and the standard layout encodes cleanly.
+;
+; With the 1985 emulator's video_mode=cga2 the same bitmap is shown as
+; 2bpp / 360x256 / 4 colors: pixel i of each byte = (byte>>(6-2i))&3,
+; palette 0=black 1=cyan 2=magenta 3=white - the MSX Screen 6 packing.
+;
+; Layout (physical = CPU address, identity banking at boot):
+;   #5C00  roller table (512 bytes)
+;   #6000  framebuffer, 32 cellrows x 720 = 23040 bytes (ends #B9FF)
+;
+; Pattern: four 64-line bands of solid pens 0..3, and the two middle
+; cellrows overwritten with #1B = pens 0,1,2,3 - a 4-color ramp every
+; 4 pixels that proves per-pixel CGA packing.
+; -----------------------------------------------------------------------
+
+RTABLE  equ #5C00
+SCREEN  equ #6000
+
+        org #1000
+
+entry:
+        di
+        ld sp,#F000
+
+; ---- build the roller table: word(y) = (base>>1) | (y&7) --------------
+        ld hl,RTABLE
+        ld bc,SCREEN/2          ; BC = cellrow base >> 1
+        ld d,32                 ; 32 cellrows
+rt_cell:
+        ld e,0                  ; line within cell, 0..7
+rt_line:
+        ld a,c
+        or e                    ; low word byte = (base>>1)|line
+        ld (hl),a
+        inc hl
+        ld a,b
+        ld (hl),a
+        inc hl
+        inc e
+        ld a,e
+        cp 8
+        jr c,rt_line
+        push hl
+        ld hl,360               ; next cellrow: base += 720 -> base>>1 += 360
+        add hl,bc
+        ld b,h
+        ld c,l
+        pop hl
+        dec d
+        jr nz,rt_cell
+
+; ---- fill the framebuffer: 4 bands of solid pens ----------------------
+        ld hl,SCREEN
+        ld c,0                  ; cellrow counter
+fb_cell:
+        ld a,c
+        rrca
+        rrca
+        rrca
+        and 3                   ; band = cellrow>>3
+        push hl
+        ld hl,valtab
+        add a,l
+        ld l,a
+        jr nc,fb_nv
+        inc h
+fb_nv:  ld a,(hl)
+        pop hl
+        ld b,a                  ; B = fill byte
+        ld de,720
+fb_fill:
+        ld (hl),b
+        inc hl
+        dec de
+        ld a,d
+        or e
+        jr nz,fb_fill
+        inc c
+        ld a,c
+        cp 32
+        jr c,fb_cell
+
+; ---- middle stripe: per-pixel 4-color ramp ----------------------------
+        ld hl,SCREEN+15*720     ; cellrows 15+16 (lines 120..135)
+        ld de,1440
+mid:    ld (hl),#1B             ; pixels = pens 0,1,2,3
+        inc hl
+        dec de
+        ld a,d
+        or e
+        jr nz,mid
+
+; ---- point the hardware at it -----------------------------------------
+        ld a,#2E                ; roller base: ((1)<<14)|(#0E<<9) = #5C00
+        out (#F5),a
+        xor a
+        out (#F6),a             ; vertical scroll 0
+        ld a,#40
+        out (#F7),a             ; bit6 screen enable, bit7 normal video
+        ld a,7
+        out (#F8),a             ; display enable on
+
+hang:   jr hang
+
+; Pad the image past 11K so it spans three tracks (T0 R2-9, T1, T2) -
+; valtab then loads from the last track, proving the boot loader's
+; multi-track SEEK + read path.  Wrong/missing later sectors = black
+; or garbage bands instead of the 4-color pattern.
+        defs 11000,#E5
+
+valtab: db #00,#55,#AA,#FF      ; solid-pen fill bytes, 4px each
+
+spike_end:
+        save"build/pcwspike.bin",#1000,spike_end-entry


### PR DESCRIPTION
Part of #331 — first milestone of the Amstrad PCW 8256/8512 port (third platform target).

The PCW has no boot ROM: the printer-MCU bootstrap loads track 0 / sector 1 to `#F000`, requires the sector's 8-bit sum to be `#FF`, and jumps to `#F010`. GEOBENCH therefore boots **standalone — no CP/M shipped or required**.

- **kernel/pcwboot.asm** — custom boot sector: polled non-DMA uPD765 loader (SPECIFY ND=1; one READ DATA per sector, matching what the FDC actually delivers in this setup; SEEK + SENSE INTERRUPT across tracks). Loads a raw system image from the disc's reserved tracks and jumps to it. Loader params live in the spare disc-spec bytes.
- **tools/mkpcwdsk.py** — PCW EXTENDED .DSK writer (CF2 180K / CF2DD 720K, standard skew, data-rate/recording-mode bytes CP/M+ requires) with boot checksum fixing + reserved-track image placement.
- **tools/pcwspike/** — proof-of-life payload + headless harness (`bash tools/pcwspike/build.sh`).
- **debug/1985-pcw.conf** — 1985 emulator config: PCW 8256, `video_mode=cga2` (360×256, 4 colors — Screen-6-style packing), DK'tronics AY joystick.

Verified headless in the 1985 emulator: an 11KB image spanning 3 tracks boots and renders the CGA2 test pattern — 4 solid bands (black/cyan/magenta/white) + a per-pixel 4-color ramp — proving boot sector → checksum → multi-track FDC load → roller-RAM programming → CGA pixel packing end-to-end.

No existing CPC/MSX build files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)