### PR TITLE
Make the MSX image network-ready with UNAPINET

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ __pycache__/
 # QA/CPC/CARD/ and QA/CPC/Floppies/), so re-include it despite the binary ignores above.
 # Regenerate with `bash tools/build_kernel.sh`.
 !QA/**
-# Optional third-party TCP/IP UNAPI TSR, staged only for local MSX network tests.
+# Fetched third-party TCP/IP UNAPI TSR, staged only in local MSX builds.
 QA/MSX/UNAPINET.COM
 # ...except the 32MB card image: it is rebuilt (and byte-churns) on every build, so it
 # is a local build artifact, not committed. Build it with tools/build_card_img.sh.

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -94,33 +94,34 @@ kernel, `-DGB_MSX2` for the apps). See [The MSX2 target](MSX2.md) for the runtim
 design; this is the build.
 
 ```bash
-bash tools/fetch_msx_deps.sh       # one-time: Nextor system files + NMS 8250 ROMs
+bash tools/fetch_msx_deps.sh       # one-time: Nextor, UNAPINET + NMS 8250 ROMs
 bash tools/build_kernel_msx.sh     # the whole MSX2 distribution
 tools/run_msx.sh                   # boot it in openMSX (interactive)
 MSX_SHOTS="25 40" tools/run_msx.sh # headless: screenshots into build/msx/
 ```
 
 Browser and Telnet are included in the MSX distribution and use TCP/IP UNAPI.
-For an openMSXnet test image, pass its required TSR while building and enable
-the matching emulator extension while running:
+The dependency fetcher places openMSXnet v0.9.7's guest TSR in ignored
+`QA/MSXDEPS/`; the standard MSX build stages it automatically. Enable the
+matching emulator extension while running:
 
 ```bash
-MSX_UNAPI_TSR=/path/to/UNAPINET.COM make msx
+make msx
 OPENMSX=/path/to/openmsxnet/openmsx \
 OPENMSX_SYSTEM_DATA=/path/to/openmsxnet/share \
 tools/run_msx.sh
 ```
 
-`MSX_UNAPI_TSR` is optional for a normal build, but openMSXnet networking does
-not work without both that TSR and the emulator extension. `run_msx.sh` enables
-the `unapinet` extension by default. It also automatically uses an openMSXnet
-bundle installed at `QA/MSXDEPS/openmsxnet/`; use `OPENMSXNET_HOME` for another
-bundle location, or the explicit `OPENMSX` variables shown above. If the bundle
-needs libraries absent from the host (notably Tcl 8.6 on current Fedora), the
-launcher automatically uses `my-distrobox`; `MSX_DISTROBOX` overrides its name.
-Set `MSX_UNAPI=0` only for a non-networked run. The third-party TSR is never
-committed. Run `make msx` again without `MSX_UNAPI_TSR` to restore the standard
-staged `AUTOEXEC.BAT`; see
+`MSX_UNAPI_TSR=/path/to/UNAPINET.COM` overrides the fetched driver, while an
+explicitly empty `MSX_UNAPI_TSR=` builds a network-free image. openMSXnet does
+not work without both the guest TSR and emulator extension. `run_msx.sh` enables
+the `unapinet` extension by default and automatically uses a bundle installed at
+`QA/MSXDEPS/openmsxnet/`; use `OPENMSXNET_HOME` for another location, or the
+explicit `OPENMSX` variables shown above. If the bundle needs libraries absent
+from the host (notably Tcl 8.6 on current Fedora), the launcher automatically
+uses `my-distrobox`; `MSX_DISTROBOX` overrides its name. Set `MSX_UNAPI=0` for a
+non-networked run. The third-party TSR and generated image are never committed;
+see
 [The MSX2 target](MSX2.md#browser-and-telnet-networking) for current UNAPI
 implementation coverage.
 

--- a/docs/MSX2.md
+++ b/docs/MSX2.md
@@ -99,12 +99,17 @@ recommended setup when networking and several windows are used together.
 
 [openMSXnet](https://github.com/antxiko/openMSXnet) is the initial emulator
 target. It needs both its custom openMSX build with the `unapinet` extension and
-its `UNAPINET.COM` TSR. To produce a local image that installs the TSR before
-GEOBENCH:
+its `UNAPINET.COM` TSR. `tools/fetch_msx_deps.sh` downloads the official v0.9.7
+guest driver into the ignored `QA/MSXDEPS/` directory, and the normal MSX build
+stages and runs it before GEOBENCH:
 
 ```bash
-MSX_UNAPI_TSR=/path/to/UNAPINET.COM bash tools/build_kernel_msx.sh
+bash tools/fetch_msx_deps.sh
+bash tools/build_kernel_msx.sh
 ```
+
+`MSX_UNAPI_TSR=/path/to/UNAPINET.COM` selects another local driver binary;
+`MSX_UNAPI_TSR=` explicitly builds an image without the TSR.
 
 Then run that image with the openMSXnet executable and data directory:
 
@@ -121,9 +126,9 @@ host-side sockets. `run_msx.sh` enables that extension by default; use
 `QA/MSXDEPS/openmsxnet/` is selected automatically; `OPENMSXNET_HOME` selects a
 different location. When its libraries are not available on the host, the
 launcher runs it through `my-distrobox` (override with `MSX_DISTROBOX`). The
-normal committed distribution bundles neither third-party component. On an
-existing Nextor installation, copy `UNAPINET.COM` to the boot drive and run it
-before `GBMSX.COM`; another compatible mapped-RAM or page-3 TCP/IP UNAPI
-implementation may be used instead. Browser and Telnet report a
-network-initialisation error when discovery fails. Browser currently supports
-plain HTTP only.
+third-party executable and generated image remain untracked; a source checkout
+without fetched dependencies still contains neither component. On an existing
+Nextor installation, copy `UNAPINET.COM` to the boot drive and run it before
+`GBMSX.COM`; another compatible mapped-RAM or page-3 TCP/IP UNAPI implementation
+may be used instead. Browser and Telnet report a network-initialisation error
+when discovery fails. Browser currently supports plain HTTP only.

--- a/tools/README.md
+++ b/tools/README.md
@@ -21,8 +21,9 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
   sibling GB-PAINT and GB-BASIC checkouts.
 - **`build_kernel_msx.sh`** — builds the `GBMSX.COM` video-mode selector,
   `GBMSX6.COM`, `GBMSX7.COM`, the MSX2 app/module payload, and the bootable
-  Nextor `QA/GBMSX.IMG`. Set `MSX_UNAPI_TSR` to stage a local
-  openMSXnet `UNAPINET.COM` before `GBMSX.COM`; the TSR remains untracked.
+  Nextor `QA/GBMSX.IMG`. The dependency fetcher supplies a local openMSXnet
+  `UNAPINET.COM`, which is staged before `GBMSX.COM`; `MSX_UNAPI_TSR` overrides
+  it, and an explicitly empty value omits it. The TSR remains untracked.
 - **`run_msx.sh`** — launches the MSX2 image in native or Flatpak openMSX.
   It adds openMSXnet's `unapinet` extension by default when using its custom
   emulator build and automatically selects a bundle in

--- a/tools/build_kernel_msx.sh
+++ b/tools/build_kernel_msx.sh
@@ -9,8 +9,9 @@
 # v2 pictures, icon sets, and backdrop tiles remain canonical and are translated
 # to native bytes by the kernel at display/load time.
 #
-#   bash tools/build_kernel_msx.sh
+#   bash tools/build_kernel_msx.sh       # uses QA/MSXDEPS/UNAPINET.COM
 #   MSX_UNAPI_TSR=/path/to/UNAPINET.COM bash tools/build_kernel_msx.sh
+#   MSX_UNAPI_TSR= bash tools/build_kernel_msx.sh  # explicitly omit the TSR
 #   MSX_SHOTS="20 30 45" tools/run_msx.sh      # then verify in openMSX
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -18,6 +19,17 @@ cd "$(dirname "$0")/.."
 RASM="${RASM:-rasm}"
 command -v "$RASM" >/dev/null || { echo "ERROR: rasm not on PATH" >&2; exit 1; }
 command -v sdcc >/dev/null || { echo "ERROR: sdcc not on PATH" >&2; exit 1; }
+
+# fetch_msx_deps.sh supplies the standard local guest driver. An explicitly
+# set MSX_UNAPI_TSR overrides it; setting the variable to empty deliberately
+# produces a network-free image. The binary stays in ignored paths.
+if [ "${MSX_UNAPI_TSR+x}" = x ]; then
+    UNAPI_TSR="$MSX_UNAPI_TSR"
+elif [ -s QA/MSXDEPS/UNAPINET.COM ]; then
+    UNAPI_TSR=QA/MSXDEPS/UNAPINET.COM
+else
+    UNAPI_TSR=
+fi
 
 mkdir -p build/msx
 
@@ -172,9 +184,9 @@ rm -f QA/MSX/GBSPIKE.COM                 # pre-DIAG staging location (#379)
 cp build/msx/GBMSX.COM build/msx/GBMSX6.COM build/msx/GBMSX7.COM QA/MSX/
 rm -f QA/MSX/DIAG/FORMREF.APP             # MSX app loading resolves through /GBENCH
 rm -f QA/MSX/UNAPINET.COM
-if [ -n "${MSX_UNAPI_TSR:-}" ]; then
-    [ -s "$MSX_UNAPI_TSR" ] || { echo "ERROR: MSX_UNAPI_TSR not found: $MSX_UNAPI_TSR" >&2; exit 1; }
-    cp "$MSX_UNAPI_TSR" QA/MSX/UNAPINET.COM
+if [ -n "$UNAPI_TSR" ]; then
+    [ -s "$UNAPI_TSR" ] || { echo "ERROR: MSX_UNAPI_TSR not found: $UNAPI_TSR" >&2; exit 1; }
+    cp "$UNAPI_TSR" QA/MSX/UNAPINET.COM
     printf 'UNAPINET\r\nGBMSX\r\n' > QA/MSX/AUTOEXEC.BAT
 else
     printf 'GBMSX\r\n' > QA/MSX/AUTOEXEC.BAT

--- a/tools/fetch_msx_deps.sh
+++ b/tools/fetch_msx_deps.sh
@@ -3,7 +3,7 @@
 # emulator testing (issue #287). Everything lands outside the git tree:
 #
 #   QA/MSXDEPS/            (git-ignored)  Nextor system files for image staging:
-#     NEXTOR.SYS COMMAND2.COM
+#     NEXTOR.SYS COMMAND2.COM UNAPINET.COM
 #   ~/.openMSX/share/systemroms/          ROMs openMSX identifies by sha1:
 #     Nextor-2.1.1.SunriseIDE.ROM         (matches the bundled SunriseIDE_Nextor
 #                                          extension's expected sha1)
@@ -23,6 +23,8 @@ ROMS="$HOME/.openMSX/share/systemroms"
 NEXTOR_ROM_VER=v2.1.1        # must match the sha1 in openMSX's SunriseIDE_Nextor.xml
 NEXTOR_SYS_VER=v2.1.3        # newest release that ships NEXTOR.SYS
 NEXTOR_TOOLS_VER=v2.1.0      # newest release that ships tools.zip (COMMAND2.COM)
+OPENMSXNET_VER=v0.9.7
+UNAPINET_SHA256=86e7bb27d1f020e235929a6806f5f2dc8188c458119041c4017afd93a3c13227
 
 mkdir -p "$DEPS" "$ROMS"
 
@@ -30,6 +32,22 @@ fetch() { # url dest
     [ -s "$2" ] && { echo "have  $2"; return; }
     echo "fetch $2"
     curl -sfL -o "$2" "$1"
+}
+
+verify_sha256() { # path expected
+    local actual
+    actual="$(python3 - "$1" <<'PY'
+import hashlib, sys
+with open(sys.argv[1], "rb") as source:
+    print(hashlib.sha256(source.read()).hexdigest())
+PY
+)"
+    [ "$actual" = "$2" ] || {
+        echo "ERROR: SHA-256 mismatch for $1" >&2
+        echo "expected $2" >&2
+        echo "actual   $actual" >&2
+        exit 1
+    }
 }
 
 # --- Nextor kernel ROM + system files ---------------------------------------
@@ -44,6 +62,13 @@ if [ ! -s "$DEPS/COMMAND2.COM" ]; then
     rm -f "$DEPS/tools.zip"
     echo "have  $DEPS/COMMAND2.COM"
 fi
+
+# --- openMSXnet TCP/IP UNAPI guest driver ----------------------------------
+# This is the guest half of the port-mapped host bridge. It remains in the
+# ignored dependency/staging directories and is never committed to GeoBench.
+fetch "https://github.com/antxiko/openMSXnet/releases/download/$OPENMSXNET_VER/UNAPINET.COM" \
+      "$DEPS/UNAPINET.COM"
+verify_sha256 "$DEPS/UNAPINET.COM" "$UNAPINET_SHA256"
 
 # --- Philips NMS 8250 system ROMs (sha1-carved from the MiSter BIOS pack) ----
 need_roms=0
@@ -86,4 +111,4 @@ if missing:
 EOF
 fi
 
-echo "MSX deps ready: $DEPS + $ROMS"
+echo "MSX deps ready: $DEPS (including UNAPINET.COM) + $ROMS"


### PR DESCRIPTION
Closes #454.

The standard MSX dependency fetch now downloads and verifies the official openMSXnet v0.9.7 `UNAPINET.COM`. The MSX image build discovers it automatically and generates a boot sequence that runs `UNAPINET` before `GBMSX`; an explicit empty `MSX_UNAPI_TSR=` remains available for network-free images.

The third-party executable and generated image remain ignored and are not committed.

Verified with:
- `bash -n tools/fetch_msx_deps.sh tools/build_kernel_msx.sh`
- clean dependency fetch and pinned SHA-256 verification
- full `tools/build_kernel_msx.sh` build
- image inspection: `UNAPINET.COM` is 2046 bytes and `AUTOEXEC.BAT` contains `UNAPINET`, then `GBMSX`
- headless boot of the rebuilt image to the GeoBench desktop in 1983 with the TCP/IP UNAPI bridge enabled