### PR TITLE
Refresh documentation for current project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ reaching the kernel through `libgb`. It's a graphical layer on top of an existin
 DOS (AMSDOS / UniDOS / MSX-DOS 2), not a replacement OS — smaller scope than
 [SymbOS](https://www.symbos.de), different goal.
 
+Release builds use an app-carried, RAM-resident preemptive scheduler on CPC,
+MSX2, and PCW. The desktop remains the non-preemptible owner of hardware,
+storage, modules, input, and composition; pure application computation can run
+in preemptible workers, while I/O-heavy apps advance through bounded root jobs.
+No GEOBENCH ROM is required.
+
 The desktop, file tools and graphical Shell build for all targets from the same
 source tree. CPC and PCW ship the complete network app set; Browser and Telnet
 also build for MSX2 through TCP/IP UNAPI. The streaming HTTP browser supports
@@ -74,9 +80,10 @@ hardware, or use the disk images in an emulator.
 - **Floppy** — write **`QA/CPC/Floppies/GEOBENCH.DSK`** (the main disk) and
   **`QA/CPC/Floppies/COMPANION.DSK`** (the larger apps and extra savers) to the
   working disk set. **`QA/CPC/Floppies/EXTRAS.DSK`** holds the complete picture
-  gallery, Disk Utility, and the XRoach, Cat Clock, and Helix savers. It is an extended
-  80-track data image for a Gotek/emulator or compatible drive because the gallery
-  does not fit a 180K CF2. Boot with `RUN"GB` (or `RUN"GBKERN`).
+  gallery, Disk Utility, and the XRoach, Cat Clock, Helix, Forest, and Mountain
+  savers (plus Mountain's configuration module). It is an extended 80-track
+  data image for a Gotek/emulator or compatible drive because the gallery does
+  not fit a 180K CF2. Boot with `RUN"GB` (or `RUN"GBKERN`).
 - **Live disks** — test the CPC distribution directly in the
   [js1984 web emulator](https://salvogendut.github.io/chimeric/js1984/?memory=512&diska=../media/CPC/GEOBENCH.DSK&diskb=../media/CPC/COMPANION.DSK&autorun=GB),
   with the main disk in drive A and the companion disk in drive B.
@@ -165,21 +172,28 @@ Building from source is for developers — see [docs/BUILDING.md](docs/BUILDING.
 - **[About](docs/ABOUT.md)** — what GEOBENCH is, why, how it works, design
   inspirations, target hardware, goals and non-goals, project layout.
 - **[Features](docs/FEATURES.md)** — what works today, with screenshots.
-- **[Building & running](docs/BUILDING.md)** — the CPC build, deploy targets, the
-  optional GEOBENCH ROM.
+- **[Building & running](docs/BUILDING.md)** — CPC, MSX2, and PCW builds, deploy
+  targets, and the optional GEOBENCH ROM.
 - **[The MSX2 target](docs/MSX2.md)** — selectable Screen 6/7, TCP/IP UNAPI, and
   the openMSX harness.
 - **[Portable picture format](docs/PIC_FORMAT.md)** — the byte-identical GBPC v2
   payload shared by CPC, MSX2, and PCW.
-- **[Roadmap](docs/ROADMAP.md)** — what's done and what's next.
+- **[Architecture](docs/ARCHITECTURE.md)** — current memory, execution, storage,
+  module, and media contracts.
+- **[Preemptive multitasking](docs/PREEMPTIVE_MULTITASKING.md)** — scheduler
+  boundaries, platform interrupt paths, builds, and diagnostics.
+- **[Development](docs/DEVELOPMENT.md)** — toolchain, emulators, reusable UI,
+  assets, and incremental workflows.
+- **[Roadmap](docs/ROADMAP.md)** — current priorities and longer-term work.
 
 ## Where it's going
 
-The core desktop, windowing, file manager, C app model and most bundled apps work
-across the three targets. CPC and PCW carry the full network suite; MSX2 now has
-Browser and Telnet through TCP/IP UNAPI. Next up: resizable and scrollable Paint
-canvases, drawers/folders, and configuration panels for more screensavers. See the
-[roadmap](docs/ROADMAP.md) for the full list.
+The core desktop, windowing, file manager, preemptive runtime, C app model, and
+major bundled apps work across all three targets. Current work is tracked in the
+[roadmap](docs/ROADMAP.md); the main remaining areas are deeper directory
+navigation, finishing bounded responsiveness audits for network applications,
+and target-specific ports or enhancements that can stay outside the resident
+kernel.
 
 ## License
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -6,10 +6,13 @@ to run in a 16 KB banked window (`#4000–#7FFF`), reaching the resident kernel 
 through the shared `lib/gb` API (`gb_fill`, `gb_wm_*`, the `gb_doc` document
 framework, the `gb_popup`/`gb_prompt` dialogs, and opt-in `gb_button`/`gb_field`/
 `gb_vscroll` widgets). Apps are loaded from disk on demand (GEOS-style), not
-resident; the kernel runs the cooperative window-manager loop and calls each
-focused window's handlers (issue #45).
+resident. The desktop owns the root window-manager task. Release builds install
+the app-carried preemptive scheduler, but drawing, input, storage, firmware,
+modules, and lifecycle callbacks stay on that root task. Long I/O workflows use
+bounded per-frame jobs; only explicitly registered pure-compute workers are
+preempted.
 
-## The apps (one C source each, under `apps/<name>/main.c`)
+## Applications
 
 | App | Disk file | What it is |
 |-----|-----------|------------|
@@ -18,7 +21,8 @@ focused window's handlers (issue #45).
 | viewer   | `VIEWER.APP`   | image-only `.PIC` viewer; uses banked RAM when available and demand-streams visible rows when banks are occupied |
 | notepad  | `NOTEPAD.APP`  | text editor (word-wrap, File/Edit/View, saves `.BAS` CR+LF) |
 | iconed   | `ICONED.APP`   | `.IST` icon-set / `.SPR` cursor / embedded `.APP` icon editor |
-| paint    | `PAINT.APP`    | portable GBPC v2 bitmap paint (toolchest, saves `.PIC`) |
+| paint    | `PAINT.APP`    | GBPC v2 bitmap editor from the sibling GB-PAINT repository; three-pane 20x20 area selector, magnified canvas, and toolchest |
+| basic    | `BASIC.APP` / `BASRUN.APP` | external GB-BASIC editor and GW-BASIC-flavoured runtime, with examples and a graphics overlay |
 | xaos     | `XAOS.APP`     | fractal generator, exports portable `.PIC` files |
 | mahjong  | `MAHJONG.APP`  | Kana Mahjong solitaire with selectable Katakana/Hiragana tiles, solvable Turtle deals, Undo and Hint |
 | calculator | `CALC.APP`   | fixed-point desktop calculator with basic arithmetic, percentage and square root |
@@ -33,6 +37,13 @@ focused window's handlers (issue #45).
 | brsave   | `BRSAVE.APP`   | transient Browser helper that writes captured HTML source to an `.HTM` file without displacing the Browser bank |
 | shell    | `SHELL.APP`    | fullscreen command shell with `ls`, `cd`, `pwd`, `cat`, `cp`, `rm`, `clear`, `help`, and `exit`; supports A/B/C paths and streamed arbitrary-size file copies |
 | timesync | `TIMESYNC.APP` | PCW desktop helper — reads PerryNet's firmware clock with `TIME_GET` when `TIMESYNC=true`, then applies `TIMEZONE=+/-H` |
+| diskutil | `DISKUTIL.APP` | CPC physical AMSDOS formatter and MSX2 FAT12 quick formatter; not shipped on PCW |
+
+Most sources live under `apps/<name>/`. `PAINT.APP` and `BASIC.APP` are built
+from sibling `GB-PAINT` and `GB-BASIC` checkouts and staged into the same
+distributions. GB-BASIC supplies its editor, runtime, numeric/graphics overlay,
+and examples; `.BAS` files open in `BASIC.APP`. Set `GB_PAINT_DIR` or
+`GB_BASIC_DIR` when those repositories are not adjacent to GEOBENCH.
 
 `TASKDEMO.APP` is a development-only preemption diagnostic and is not staged in
 the distributions. Its worker intentionally never yields; build it with
@@ -50,8 +61,9 @@ System → "Activate screensaver" runs it on demand. Each is a full-screen windo
 
 The Main CPC boot floppy carries `SQUARES.SAV`; the CPC floppy set carries the
 remaining savers across `COMPANION.DSK` and `EXTRAS.DSK` (`XROACH.SAV`,
-`CATCLK.SAV`, `HELIX.SAV`, and `FOREST.SAV` are on Extras to preserve Companion
-allocation blocks). The Albireo/M4 card and MSX2 distributions carry all 16
+`CATCLK.SAV`, `HELIX.SAV`, `FOREST.SAV`, and `MOUNTAIN.SAV` with its module are
+on Extras to preserve Companion allocation blocks). The Albireo/M4 card and
+MSX2 distributions carry all 16
 savers together.
 
 | Saver | Disk file | Effect |
@@ -117,8 +129,8 @@ resident kernel. Build with only the units an application uses:
 - `REPAINTTOP=1`: the `gb_repaint_top()` binding for publishing a newly opened
   opaque top window without redrawing lower layers; do not use it after a move,
   shrink, or popup that exposes parent content
-- `TASK=1 TASK_STACK_RESERVE=256`: opt a legacy window's `on_frame` callback
-  into the experimental worker scheduler and reserve its bank-top stack snapshot
+- `TASK=1 TASK_STACK_RESERVE=256`: opt a pure compute callback into the
+  release scheduler and reserve its bank-top stack snapshot
 
 For example:
 

--- a/assets/iconsets/README.md
+++ b/assets/iconsets/README.md
@@ -7,7 +7,8 @@ CPC card and MSX distributions. The CPC build copies them into
 sets (currently `REFINED.IST`) from this same canonical source. MSX and PCW let the
 kernel transcode a selected set to native display bytes when it is loaded.
 
-`build/DEFAULT.IST` is a gitignored build artifact regenerated from `lib/icon_*.asm`
+`build/DEFAULT.IST` is a gitignored build artifact regenerated from the ordered
+system/file-type `lib/icon_*.asm` sources
 each build in all desktop targets; it stays canonical (Mode-1) so it is shared by all
 platforms. Tracked sets in this folder are version-controlled and never regenerated.
 

--- a/assets/pictures/README.md
+++ b/assets/pictures/README.md
@@ -26,9 +26,12 @@ CPC's AMSDOS/FAT expects, and the staging copies the file under its own name.
 
 ## Size
 
-The Viewer holds a picture up to ~10 KB of bitmap (≈ 200×200; `PENGUIN.PIC` is the
-200×200 sample) in its in-window buffer. Larger pictures load into borrowed 16 KB
-RAM bank pages, so 256K+ is the practical target for large images and multiple
-picture windows. The Main CPC and PCW boot floppies carry only `LOGO.PIC`; the
-platform Extras disk and card/MSX `PICS/` directories carry the full gallery from
-this folder.
+Portable files and MSX Screen-7 files may be up to 64 KiB. Viewer uses borrowed
+16 KiB pages for fast redraws when available; if picture pages are exhausted it
+keeps the parsed header and reads only the visible rows in bounded chunks. This
+allows multiple large Viewer windows without the old "no free banks" failure,
+at the cost of disk-backed repaint speed. Viewer instances still consume normal
+app pages; the current desktop flow opens two picture windows and silently
+refuses a third until one closes. The Main CPC and PCW boot floppies
+carry only `LOGO.PIC`; the platform Extras disk and card/MSX `PICS/`
+directories carry the full compatible gallery from this folder.

--- a/assets/titlebars/README.md
+++ b/assets/titlebars/README.md
@@ -22,8 +22,8 @@ bucket fill, spray paint, and undo. The four arrow controls shift the active
 canvas by one pixel and clear the newly exposed edge with paper colour.
 
 All `.TBR` files in this directory are validated and staged for card and MSX
-distributions. Space-constrained CPC and PCW boot floppies carry `ORIGINAL.TBR`
-and `IMPROVED.TBR`; their `EXTRAS.DSK` carries the remaining themes. Select an
+distributions. Space-constrained CPC and PCW boot floppies carry
+`ORIGINAL.TBR`; their `EXTRAS.DSK` carries the remaining themes. Select an
 available motif live in Settings with **Title bar**, or set:
 
 ```ini

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -35,47 +35,51 @@ this project sets out to do. Instead, GEOBENCH is a much humbler thing: a
 familiar DOS underneath and adds a GEOS/Workbench-style face on top, rather than
 replacing the whole system. Smaller scope, smaller footprint, different goal.
 
-## Visual target
+## Original visual reference
 
-The long-term look we're aiming for — an Amiga Workbench-style desktop as it
-might have existed on the CPC: labelled drawer/app icons, windows with title
-bars and gadgets, a trashcan, an arrow pointer.
+The project began from this Amiga Workbench-style reference: labelled
+drawer/app icons, windows with title bars and gadgets, a trashcan, and an arrow
+pointer on an 8-bit display. The current screenshots in the top-level README
+show the implemented desktop; this image records the starting visual direction,
+not an unfinished UI specification.
 
 ![Visual target](../goal.png)
 
 > Image: a screenshot from The 8-Bit Guy's video on the **C128 "Alternate
 > Universe"** — used here purely as a visual reference for the look we're after.
 
-We're a long way from this, but it's the north star.
-
 ## How it works
 
-GEOBENCH borrows SymbOS's banked-app shape, scaled down:
+GEOBENCH borrows SymbOS's banked-app shape, scaled down and shared across three
+Z80 platforms:
 
-- **Banked memory model.** On a 128K+ machine the gate-array RAM-config port
-  pages a 16K block into the `#4000–#7FFF` window. The kernel, the stack, the
-  screen and the firmware stay in always-resident RAM; apps and the kernel's data
-  buffers (font, icons) live in bank pages and are swapped in as needed.
-- **Resident kernel (`kernel/`, Z80 asm).** Boots the machine (Mode 1, palette,
-  RAM probe, clock, top bar), owns storage + screen + input + cursor, and
+- **Banked memory model.** A target-specific mapper pages a 16K application
+  block into `#4000-#7FFF`. The kernel and fixed low-RAM contracts remain
+  mapped; applications, modules, assets, and borrowed document/picture pages
+  use the expansion-bank pool.
+- **Resident kernel (`kernel/`, Z80 asm).** Boots the target video backend,
+  probes RAM, initializes the clock/top bar, owns storage + screen + input + cursor, and
   exposes a **fixed jump-table API** at `#8000`. The kernel source has been
   split by subsystem (`boot.asm`, `assets.asm`, `modules.asm`, `app_pool.asm`,
   `input_api.asm`, `clock.asm`, `memdetect.asm`, `api_table.inc`,
   `lowram.inc`) so resident responsibilities and low-RAM contracts are easier to
   reason about without changing the generated image.
-- **Apps in C (`apps/`, SDCC).** Each app is a single `main.c` compiled to run at
-  `#4000` in a bank page. It reaches the kernel only through **`libgb`**
+- **Apps in C (`apps/`, SDCC).** Each app is compiled to run at `#4000` in a
+  bank page. It reaches the kernel only through **`libgb`**
   (`lib/gb/` — `gb.h` + asm trampolines that map the C calling convention onto the
-  jump table). The desktop launches the file manager, which opens each file in its
-  app (Notepad, ICONED, Paint, Viewer, ...); an app returns to its caller by `return`.
-- **Storage backends.** A dispatcher (`lib/fs.asm`) selects the card backend at
-  build time. The shipped card builds both the CH376 **Albireo** kernel (`GBALB`)
+  jump table). Managed windows remain co-resident and are driven by the desktop's
+  root task; I/O-heavy work is split into bounded jobs, while explicitly opted-in
+  pure computation can run in preemptible workers.
+- **Storage backends.** On CPC, a dispatcher (`lib/fs.asm`) selects the card
+  backend at build time. The shipped card builds both the CH376 **Albireo** kernel (`GBALB`)
   and the **M4 board** kernel (`GBM4`) into one shared FAT image. Both kernels also
   carry the AMSDOS-over-**floppy** fallback. The FAT16/FAT32 **IDE** backend is
   archived — source kept in-tree, not built or shipped by default (see
   [`ARCHIVED.md`](ARCHIVED.md)). The screen-independent driver path can
-  still be **offloaded to a loadable upper ROM** (`GBALB.ROM`) to free resident
-  `#8000` RAM — see [Building](BUILDING.md#optional-the-geobench-rom).
+  still be built as a legacy **loadable upper-ROM** experiment (`GBALB.ROM`) to
+  study resident `#8000` headroom, but release media use the no-ROM kernels —
+  see [Building](BUILDING.md#optional-the-geobench-rom). MSX2 uses MSX-DOS
+  2/Nextor BDOS services; PCW uses its native CF2/CF2DD floppy backend.
 
 ## Target hardware
 
@@ -100,6 +104,10 @@ GEOBENCH borrows SymbOS's banked-app shape, scaled down:
   a memory-mapper expansion (512K typical) is recommended for multiple app
   windows. Browser and Telnet use a mapped-RAM or page-3 TCP/IP UNAPI
   implementation; openMSXnet is the initial supported emulator transport.
+- **Amstrad PCW** (PCW 8256/8512 class) with banked RAM and CF2 or CF2DD
+  media. The monochrome 720x256 backend preserves the shared application and
+  asset formats; serial networking uses PerryFi/PerryNet. See
+  [The PCW target](PCW.md).
 
 ## Design inspirations
 
@@ -133,31 +141,33 @@ We deliberately cherry-pick from both ancestors rather than cloning either one.
 - A documented **application API** (the `libgb` jump table) so third parties can
   write GEOBENCH apps — in C.
 
-## Running existing AMSDOS software
+## Running existing DOS software
 
-GEOBENCH does **not** run ordinary AMSDOS `.BIN` binaries or BASIC `.BAS`
-programs. Those expect to own the whole machine under BASIC/AMSDOS, so the
-desktop does not attempt to launch or contain them: double-clicking a `.BIN` or
-`.BAS` in the File Manager shows an info note telling you to run it from BASIC
-instead (`RUN"PROG"`). GEOBENCH only runs its own apps — the C `.APP` programs and
-`.SAV` screensavers — which cooperate with the kernel window manager.
+GEOBENCH does **not** run ordinary machine-code `.BIN` programs inside a
+managed window. Those programs expect to own the machine under BASIC or DOS,
+so the File Manager reports that they must be run after leaving GEOBENCH.
+
+`.BAS` files are different: when the separately maintained **GB-BASIC** package
+is installed, double-clicking a `.BAS` file opens it in `BASIC.APP`. GEOBENCH's
+native executable formats remain `.APP` applications and `.SAV` screensavers.
 
 This was an early aspiration ("layer on top of DOS, launch the existing
 catalogue"), but coaxing software that assumes total machine ownership into a
-cooperative desktop proved out of scope, so it is a non-goal rather than a
+managed desktop proved out of scope, so it is a non-goal rather than a
 roadmap item.
 
-## Non-goals (for now)
+## Non-goals
 
-- Multitasking / preemptive scheduling (cooperative, single-app-at-a-time is the
-  realistic start on a Z80).
+- Preempting the resident kernel, firmware, paged modules, storage drivers, or
+  drawing operations. Release builds preempt explicitly opted-in pure app
+  workers; shared machine services stay atomic under the desktop root task.
 - Hard compatibility with actual GEOS or Workbench binaries. GEOBENCH is
   *inspired by* them, not a binary-compatible reimplementation.
 - 100% feature parity with either ancestor.
 
 ## Tech notes
 
-- **CPU:** Zilog Z80 (~4 MHz), banked 128K+ memory map.
+- **CPU:** Zilog Z80 (~3.5-4 MHz), banked 128K+ memory map.
 - **Kernel:** Z80 assembly, assembled with **RASM**.
 - **Apps:** **C**, compiled with **SDCC**, linked against the shared `libgb`
   (`lib/gb/`) and a small crt0 to run as a banked binary at `#4000`.
@@ -176,19 +186,21 @@ geobench/
 │                      #     gb_doc menu/document framework (gbdoc.c), window
 │                      #     drag/resize (gbwin.c) + dialog stubs (the dialog renderer
 │                      #     is a paged kernel module, kernel/kc/gbui_mod.c)
-├── apps/              # the C apps (each a single main.c)
+├── apps/              # native C apps and screensavers
 │   ├── desktop/       #   the boot shell: backdrop, icons, drag, launch, System menu
 │   ├── filemgr/       #   scrolling file manager (multi-drive, drag-and-drop, Trash)
 │   ├── notepad/       #   text editor (File/Edit/View menus, copy/paste, .BAS CR+LF)
 │   ├── iconed/        #   icon/cursor editor for .IST sets and .SPR cursors
-│   ├── paint/         #   Mode-1 paint app (toolchest, palette, .PIC files)
 │   ├── xaos/          #   fixed-point Mandelbrot generator (.PIC export)
 │   ├── viewer/        #   banked/demand-streamed .PIC image viewer
 │   ├── clock/         #   analog clock window
 │   └── settings/      #   control panel: config/media picker + desktop colours
-├── rom/               # per-backend upper ROMs (GBALB.ROM shipped; IDE ROM archived)
-│                      #   for driver offload + the boot banner
-├── assets/            # icon/cursor/paint source PNGs + sample files (WELCOME.TXT)
+├── rom/               # optional CPC ROM/offload sources
+├── assets/            # icon/cursor/picture sources + sample files (WELCOME.TXT)
 ├── docs/              # architecture, development, archive notes, review docs
 └── tools/            # host-side build/asset tooling (build_kernel.sh, build_rom.sh, ...)
 ```
+
+`PAINT.APP` and `BASIC.APP` are owned by the sibling `GB-PAINT` and `GB-BASIC`
+repositories and staged by the distribution build. Normal and preemptive
+release media do not require a GEOBENCH ROM.

--- a/docs/APP_ICON_FORMAT.md
+++ b/docs/APP_ICON_FORMAT.md
@@ -99,12 +99,13 @@ bytes, so native variants remain optional per application.
 
 Issue #430 moved Notepad, Icon Editor, Paint, Browser, Viewer, Telnet, Mahjong,
 and Shell into app-owned headers; BASIC.APP followed from its external
-repository. The resident desktop set fell from 25 to 16 slots (`6,324` to
-`3,984` bytes), recovering 2,340 bytes of kernel data-page headroom. At the
-format level, before the additional code-size reductions used by tight
-applications, the two shipped icon sets and nine v1 headers make the raw
-distribution payload 2,232 bytes smaller. Clock, Desktop, File Manager, and
-shared file-type/device icons remain resident.
+repository. Removing those nine application slots recovered 2,340 bytes from
+the boot-loaded set. Additional system/file-type slots were added later, so the
+current `DEFAULT.IST` and `REFINED.IST` each contain **21 slots** and occupy
+**5,284 bytes**. Clock, Desktop, File Manager, and shared file-type/device icons
+remain resident. At the format level, before application-specific code-size
+reductions, moving the nine v1 icons still reduces the combined raw distribution
+payload by 2,232 bytes.
 
 `tools/iconedit.py` opens either ASM source and both resources inside a v2 APP.
 Use Previous/Next to switch variants. `ICONED.APP` edits both variants on MSX

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,7 +12,7 @@ GEOBENCH is organised as layers, lowest (closest to hardware) at the bottom:
 ```
 ┌─────────────────────────────────────────────┐
 │  apps/  desktop·filemgr·notepad·iconed·       │  ← banked binaries, run on demand
-│         paint·viewer·clock (C)                │
+│         viewer·clock·network tools (C)        │
 ├─────────────────────────────────────────────┤
 │  libgb  C bindings -> the kernel jump table,  │  ← lib/gb/ (gb.h + trampolines,
 │         window + dialog helpers               │     gbwin.c, gbdlg.c/gbprompt.c)
@@ -20,7 +20,7 @@ GEOBENCH is organised as layers, lowest (closest to hardware) at the bottom:
 │  kernel/   boot · API table · banking · fs ·  │  ← resident; Z80 asm
 │            assets · modules · input · WM       │
 ├─────────────────────────────────────────────┤
-│  Amstrad CPC hardware  (Z80, CRTC, gate array, AMSDOS)│
+│  CPC / MSX2 / PCW hardware and DOS/firmware services │
 └─────────────────────────────────────────────┘
 ```
 
@@ -31,11 +31,11 @@ the first one booted and the one other apps return to.
 
 ## Memory model
 
-128K+ only (the banked app model needs the expansion banks). The gate-array
-RAM-config port pages a 16K block into the `#4000–#7FFF` window:
+128K+ only (the banked app model needs expansion banks). A target-specific
+memory mapper pages a 16K block into the `#4000-#7FFF` window:
 
 - The **kernel is resident** in always-mapped RAM at `#8000+`. So are the stack,
-  the screen, fixed low-RAM contracts, and the firmware.
+  fixed low-RAM contracts, and the target's screen/firmware interface.
 - The kernel's **data buffers** (font, icon set, directory scratch) live in a
   bank page (`PAGE_DATA`); a service swaps that page in, touches the buffer, and
   restores the caller's page.
@@ -57,7 +57,8 @@ subsystem so responsibilities are explicit:
 - `kernel/api_table.inc` — the fixed kernel jump table.
 - `kernel/lowram.inc` / `kernel/lowram.tsv` — absolute low-RAM ownership and the
   checked manifest used by `tools/check_lowram_map.py`.
-- `kernel/boot.asm` — boot path, desktop launch, return-to-BASIC path.
+- `kernel/boot.asm` plus `boot_msx.asm` / `boot_pcw.asm` — target boot, desktop
+  launch, and exit/warm-boot paths.
 - `kernel/assets.asm` — font/icon/cursor/backdrop/wallpaper reload helpers.
 - `kernel/config_module.asm` — `GBCFG.MOD` boot-time parse/load path.
 - `kernel/modules.asm` — shared paged-module runners (`GBUI`, `GBWEB`, `GBIMG`, `GBNET`, config).
@@ -70,20 +71,22 @@ size work safer.
 
 ## Execution model
 
-GEOBENCH is currently cooperative and callback-driven:
+GEOBENCH uses a hybrid preemptive runtime:
 
 - The resident window manager owns the master event loop and keeps several
   banked app windows resident at once.
-- Each app registers frame, draw, and event callbacks; the manager currently
-  invokes the focused app's frame callback and composites repaint callbacks in
-  z-order.
+- Each app registers frame, draw, and event callbacks. The root task invokes
+  bounded app jobs and composites repaint callbacks in z-order.
 - One window owns input focus. Kernel services, paged modules, storage, and
   painting execute atomically.
+- Apps may explicitly register a pure compute worker. Timer preemption rotates
+  those workers without allowing them to call kernel, UI, firmware, storage, or
+  module services.
 
-The build-gated preemptive conversion keeps kernel work atomic while allowing
-application tasks to be time-sliced. Its scheduler is carried by
-`DESKTOP.APP`, installed in fixed RAM, and explicitly does not use the optional
-GEOBENCH/M4 ROM paths; see
+The scheduler is the release default on CPC, MSX2, and PCW. It is carried by
+`DESKTOP.APP`, installed in fixed RAM, and does not use the optional
+GEOBENCH/M4 ROM paths. Explicit cooperative builds remain available for
+regression testing; see
 [PREEMPTIVE_MULTITASKING.md](PREEMPTIVE_MULTITASKING.md).
 
 ## The system API
@@ -115,7 +118,7 @@ without linking against private kernel internals.
 
 ## Storage and distribution shape
 
-The shipped runtime targets are:
+The shipped CPC runtime targets are:
 
 - **Albireo / CH376 card** as the primary read/write storage path.
 - **M4 board** as a shared-image card path (`GBM4.BIN` on the same FAT image as
@@ -124,16 +127,24 @@ The shipped runtime targets are:
   such as Telnet are not forced back to Mode 1 while modules are loaded.
 - **AMSDOS floppy** as the fallback path and as the bootable disk-pair format.
 
+MSX2 uses MSX-DOS 2 / Nextor BDOS calls for mapper-aware drive access. PCW uses
+its native uPD765 CF2/CF2DD backend and boots without CP/M. These target
+backends expose the same app-visible file API.
+
 The **IDE** backend still exists in source but is not built by the default workflow.
 See [`ARCHIVED.md`](ARCHIVED.md) for the exact support boundary.
 
-The default media layout is intentionally simple:
+The CPC media layout is intentionally simple:
 
 - card: `QA/CPC/CARD/` with `GB.BAS`, `M4DETECT.BIN`, `GBALB.BIN`, `GBM4.BIN`,
   `GEOBENCH.CFG`, `GBENCH/`, root-level `PICS/`, and root-level `DIAG/`
 - floppy: `QA/CPC/Floppies/GEOBENCH.DSK` (Main),
   `QA/CPC/Floppies/COMPANION.DSK` (drive-B apps), and
   `QA/CPC/Floppies/EXTRAS.DSK` (the complete gallery)
+
+MSX2 stages loose files under `QA/MSX/` and two FAT12 floppies under
+`QA/MSX/Floppies/`; its generated `QA/GBMSX.IMG` is local and ignored. PCW
+ships `QA/PCW/GEOBENCH.DSK`, `COMPANION.DSK`, and a 720K `EXTRAS.DSK`.
 
 Pictures, icon sets, and backdrops use portable payloads. CPC, MSX2, and PCW all
 store canonical Mode-1 GBPC v2 picture bytes; the MSX2 and PCW screen backends
@@ -149,6 +160,8 @@ payload with sixteen colours.
 rules are:
 
 - on MSX2, `MSXMODE=6|7` selects the mode-specific kernel at the next boot;
+- on MSX2, `MSXMOUSE=TRUE|FALSE` selects mouse or joystick interpretation for
+  the joystick port;
 - backdrop, wallpaper, and saver names may be **drive-qualified** (`A:NAME`,
   `B:NAME`, `C:NAME`) so the Settings app can point at either floppy or Albireo
   content explicitly;
@@ -177,9 +190,9 @@ the level of asset reload, storage, and window-manager primitives.
 
 ## Hardware notes
 
-- **Video:** Mode 1 (320×200, 4 colours) is the planned default desktop surface
-  — a compromise between resolution and the ~16K framebuffer cost. The graphics
-  library isolates the Mode 1 byte/pixel layout so other modes remain possible.
+- **Video:** CPC uses Mode 1 (320x200, 4 colours); MSX2 uses V9938 Screen 6 or
+  Screen 7 at 512x212; PCW uses a monochrome 720x256 surface. Platform drawing
+  backends translate canonical portable assets at the display boundary.
 - **CPC vs CPC+:** addressed behind named constants; the plus's extra features
   (hardware sprites, palette) are a possible enhancement, not a dependency.
 - **AMSDOS:** file I/O goes through firmware vectors. Note that USB/FAT-drive
@@ -188,16 +201,16 @@ the level of asset reload, storage, and window-manager primitives.
 ## Known architectural limits
 
 - **128K+ only.** The app model depends on banked memory.
-- **Cooperative execution in release builds.** The build-gated preemptive task
-  conversion is tracked in [PREEMPTIVE_MULTITASKING.md](PREEMPTIVE_MULTITASKING.md).
+- **Shared services are atomic.** Preemption is restricted to opted-in pure app
+  workers; UI callbacks, storage, modules, firmware, and kernel work remain on
+  the root task.
 - **Flat-ish content layout.** Nested subdirectories deeper than one level are
   not a supported storage workflow today; see [`File_Manager_Issue.md`](File_Manager_Issue.md).
-- **Legacy AMSDOS software is not run.** GEOBENCH does not launch ordinary
-  `.BIN`/`.BAS` programs (they assume total machine ownership); the File Manager
-  shows an info note pointing the user to BASIC. This is a non-goal, not a
-  pending feature.
+- **Legacy machine-code software is not contained.** Ordinary `.BIN` programs
+  still require leaving GEOBENCH. `.BAS` files open in the external GB-BASIC
+  application when that package is staged.
 
-## Booting and distribution
+## CPC booting and distribution
 
 `bash tools/build_kernel.sh` stages (and ships under `QA/`):
 
@@ -247,10 +260,11 @@ The loader is **BASIC, not machine code**, on purpose: under UniDOS (CP/M-based)
 and the DOS's RSXs/BIOS are unreachable from a loaded binary — whereas a BASIC program
 runs with the DOS fully active, so its `RUN"GBALB` or `RUN"GBKERN` simply works.
 
-### The GEOBENCH ROM (driver offload + boot banner)
+### Optional legacy GEOBENCH ROM (driver offload + boot banner)
 
-The screen-independent low-level drivers — the FAT read/write core, the AMSDOS floppy
-reader, the IDE backend and the CH376/Albireo backend — can run from a **16K loadable
+For recovery and size experiments, the screen-independent low-level drivers —
+the FAT read/write core, the AMSDOS floppy reader, the IDE backend and the
+CH376/Albireo backend — can run from a **16K loadable
 upper ROM** instead of the resident kernel, freeing `#8000` RAM (the headroom that
 unblocks window-chrome work like #156). `tools/build_rom.sh` builds one per card:
 `rom/GEOBENCH.ROM` (IDE) and `rom/GBALB.ROM` (Albireo).
@@ -262,7 +276,7 @@ The ROM is read-only, so each backend's writable state is relocated to fixed low
 both the resident stubs and the ROM agree on (the FAT core at `#1C00`, the CH376 path at
 `#1293`, a transfer area at `#1270`). The resident kernel is built with `-DGB_ROM_REQ=1`
 to use the stubs; without the ROM the plain kernel runs every driver resident, so the ROM
-is optional.
+is optional and is not part of the normal release configuration.
 
 The same image is a standard CPC **background ROM** (type-1 header at `#C000`):
 the firmware initialises it at cold boot and it prints a `GEOBENCH <commit>`

--- a/docs/ARCHIVED.md
+++ b/docs/ARCHIVED.md
@@ -17,15 +17,12 @@ is the only storage backend still archived: its source stays in the tree, but
 
 ## M4 support boundary
 
-The M4 backend is active again for boot, directory listing, load, save/create, and
-TCP networking. The same `QA/CPC/GEOBENCH.IMG` can be used by Albireo and by 1984's
-M4 image mode. The active M4 storage and TCP paths preserve the caller's video
-mode while paging M4ROM, including Telnet's Mode 2 fullscreen terminal.
-
-One M4 caveat remains:
-
-- the historical real-hardware report of blank >8 KB pictures needs to be
-  revalidated on current M4ROM and current GEOBENCH.
+The M4 backend is active again for boot, directory listing, load, save/create,
+and TCP networking. The same `QA/CPC/GEOBENCH.IMG` can be used by Albireo and by
+1984's M4 image mode. The active M4 storage and TCP paths preserve the caller's
+video mode while paging M4ROM, including Telnet's Mode 2 fullscreen terminal.
+Chunked file copy and large-picture reads have been validated on current M4
+hardware; the old 8 KiB transfer ceiling no longer applies.
 
 ## What's frozen (still in-tree, unbuilt)
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -1,9 +1,12 @@
 # Building, deploying and running
 
 The **Amstrad CPC** build is below; the **MSX2** build is in
-[Building for MSX2](#building-for-msx2). Both share the RASM kernel + SDCC apps
-and happen inside the project distrobox (RASM, SDCC, `mtools`/`dosfstools` on
-`PATH`).
+[Building for MSX2](#building-for-msx2), and PCW-specific media details are in
+[The PCW target](PCW.md#what-ships-where). All three share the RASM kernel +
+SDCC apps and are normally built inside the project distrobox (RASM, SDCC,
+`mtools`/`dosfstools` on `PATH`). Full distribution builds also require sibling
+`GB-PAINT` and `GB-BASIC` checkouts; override their locations with
+`GB_PAINT_DIR=` and `GB_BASIC_DIR=`.
 
 ## Amstrad CPC
 
@@ -47,8 +50,9 @@ themes. Available assets appear in Settings > Title bar and Settings > Gadgets.
 Legacy 106-byte combined `.TBR` files remain loadable.
 
 The About dialog reads the release version from the root `VERSION` file and bakes
-that value plus the current 12-character Git commit into `GBUI.MOD`. Override
-either value for a packaged build with `VERSION=...` or `GIT_COMMIT=...`.
+that value plus the current 12-character Git commit into `GBUI.MOD`; installed
+RAM is read at runtime. Override either build value for a packaged build with
+`VERSION=...` or `GIT_COMMIT=...`.
 
 This stages these outputs (the staged media under `QA/` are committed, so you
 can test or deploy without rebuilding first):
@@ -93,10 +97,25 @@ card backend or falls back to the AMSDOS floppy path. On a floppy you can also
 `tools/build_capp.sh <app_dir> <out.RAW>` builds a single C app against `libgb`
 if you just want to iterate on one.
 
+## Building for PCW
+
+```bash
+bash tools/build_kernel_pcw.sh
+# or: make pcw
+```
+
+This rebuilds `QA/PCW/GEOBENCH.DSK`, `COMPANION.DSK`, and the 720K
+`EXTRAS.DSK`. The build imports Paint and BASIC from their sibling repositories.
+Use `../1985/1985` with the current 1985 configuration for emulator testing;
+see [PCW.md](PCW.md) for boot, disk geometry, serial networking, and deployment
+details.
+
 ## Optional: the GEOBENCH ROM
 
-`tools/build_rom.sh` builds a 16K upper ROM — `rom/GBALB.ROM` (Albireo) is the shipped
-one (`rom/GEOBENCH.ROM` is the archived IDE variant) — that does two things:
+`tools/build_rom.sh` builds an optional legacy 16K upper ROM:
+`rom/GBALB.ROM` for Albireo or the archived IDE
+`rom/GEOBENCH.ROM`. Neither is required or included in normal release media.
+The proof-of-concept does two things:
 
 - **Offloads the low-level drivers.** The screen-independent storage drivers (FAT
   read/write, the AMSDOS floppy reader, the IDE backend and the CH376/Albireo backend) run

--- a/docs/CONTIKI_NG_REVIEW.md
+++ b/docs/CONTIKI_NG_REVIEW.md
@@ -5,6 +5,11 @@ Reviewed 2026-07-10 against Contiki-NG `develop` commit
 The focus is networking and a possible small web browser for 8-bit targets.
 Implementation is tracked by [issue #367](https://github.com/salvogendut/geobench/issues/367).
 
+> Historical research note. The bounded network result states, shared streaming
+> HTTP parser, WGET, and text-first Browser proposed here have since been
+> implemented. Use [Features](FEATURES.md) and the current `gb_net_*` sources for
+> the shipped behavior; the remainder of this document records the design input.
+
 ## Short conclusion
 
 Do not port the complete Contiki-NG network stack. GEOBENCH already uses hardware

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,7 +1,7 @@
 # Development
 
-How GEOBENCH is built and run during development. None of this runs on the CPC;
-it's the host-side workflow.
+How GEOBENCH is built and run during development. This is the host-side workflow
+for the CPC, MSX2, and PCW targets.
 
 ## Toolchain
 
@@ -27,12 +27,15 @@ dependencies are expected to exist.
 
 ## Emulators
 
-We develop against two emulators with distinct roles:
+We develop against target-specific emulators with distinct roles:
 
 | Emulator | Role | Why |
 |----------|------|-----|
 | **1984** (`../1984`) | **Primary dev target** | The user's own cycle-stepped CPC emulator. Standard firmware/AMSDOS software runs well — which is all GEOBENCH is. `--screenshot-at=N:PATH` dumps a `.ppm` and exits, giving clean headless visual verification, and `--autostart=NAME` autoruns a file after boot. Dogfooding it exercises the emulator too. |
 | **cap32** (`../caprice32`) | **Cross-check oracle** | Mature, widely-validated [Caprice32](https://github.com/ColinPitrat/caprice32). When a behaviour is ambiguous, run the same artifact on cap32: if the two disagree, the bug is localised. |
+| **1983** (`../1983`) | **MSX2 integration target** | Uses the current local machine configuration for disk/card, mapper, mouse/joystick, and UNAPI checks. `tools/run_msx.sh` remains the normal openMSX launcher. |
+| **openMSX** | **MSX2 reference/network target** | The NMS 8250 setup and openMSXnet extension validate Screen 6/7, DOS2/Nextor, and TCP/IP UNAPI behavior. |
+| **1985** (`../1985`) | **PCW integration target** | Boots the committed PCW media and exercises CF2/CF2DD geometry, pointer fallback, serial/PerryNet, and monochrome rendering. |
 
 ### Why 1984 is primary, not cap32
 
@@ -73,6 +76,10 @@ bash tools/build_kernel.sh
 The boot splash prints the build commit below the progress bar only when
 `DEBUG=TRUE` is set in `GEOBENCH.CFG`; normal media show `GEOBENCH` there. Use the
 debug splash to cross-check media against the source tree under test.
+
+For MSX2 and PCW, use `make msx` / `tools/run_msx.sh` and `make pcw`
+respectively. The complete commands and media layouts are documented in
+[BUILDING.md](BUILDING.md), [MSX2.md](MSX2.md), and [PCW.md](PCW.md).
 
 ### Incremental build behavior
 
@@ -350,9 +357,10 @@ picker. `.APP` entries without a valid preamble remain hidden on all targets.
   Mode-1 payload is byte-identical on CPC, MSX2, and PCW; target kernels translate
   it while drawing. For an MSX Screen 7 image, choose 16 colours in the GUI or
   pass `--colors 16`; leave either size field blank to preserve aspect
-  ratio, or set both to fit the Screen 7 limit of 512x255. This mode-7 extension is not editable in Paint and
-  is not displayed by CPC, PCW, or the Screen 6 backend. `.PIC` opens in Viewer
-  and portable mode-1 files edit in PAINT. See
+  ratio, or set both to fit the Screen 7 limit of 512x255. This mode-7 extension
+  is editable only by MSX Paint while GEOBENCH is running Screen 7; it is not
+  displayed by CPC, PCW, or the Screen 6 backend. `.PIC` opens in Viewer and
+  portable mode-1 files edit in Paint on every target. See
   [PIC_FORMAT.md](PIC_FORMAT.md).
 
 ## File line endings

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -41,6 +41,10 @@ backdrop, dragging icons, opening apps and menus:
 - **Notepad** — a text editor: type/edit, word-wrap, click or cursor keys to place
   the caret, **File / Edit / View** menus (New/Load/Save/Save As, copy/paste,
   Fullscreen). Saves `.BAS` with CR+LF so CPC BASIC can load them.
+- **GB-BASIC** — a separately maintained GW-BASIC-flavoured editor/runtime.
+  Double-clicking a `.BAS` file opens it in `BASIC.APP`; Run launches the
+  co-resident console and its bounded numeric/graphics overlay. Programs and
+  examples are staged from the sibling GB-BASIC repository.
 - **ICONED** — an icon/cursor editor for `.IST` sets, `.SPR` cursors, and optional
   icons embedded in `GBAP` `.APP` files (magnified canvas, pen palette, Prev/Next,
   undo, New/Load/Save/Save As, View > Fullscreen). Its Load dialog hides legacy
@@ -49,16 +53,22 @@ backdrop, dragging icons, opening apps and menus:
   Screen 7. Saving the configured active `.IST` reloads it immediately and
   repaints the desktop; inactive sets take effect when selected in Settings.
   The Python editor also edits the canonical ASM sources directly.
-- **Paint** — a Mode-1 paint app: a canvas + toolchest (pencil, square, circle,
-  flood fill, undo), a 4-ink palette and pencil width, New/Load/Save to the `.PIC`
-  format (a versioned bitmap with its own size + palette), View > Fullscreen. Tool
-  icons are a normal `.IST` set, editable in ICONED.
+- **Paint** — the separately maintained GB-PAINT application uses an Area
+  Selector, a magnified 20x20 work canvas, and a floating toolchest. It supports
+  pencil and shape tools, fill, spray, line, selection/clipboard operations and
+  undo; edits are reflected in the selected picture area. New chooses explicit
+  dimensions, while Load/Save use bounded GBPC v2 `.PIC` files. MSX Paint
+  requires 16-color mode and is the only build that opens native 16-color
+  pictures. Tool icons live in `PAINT.IST`.
 - **Viewer** — open `.PIC` images in a window sized to the picture. File > Load
   selects another picture and View > Fullscreen maximises it; windows remain
   draggable and resizeable, with horizontal and vertical scrolling. Viewer uses
   borrowed RAM banks for fast redraws. If other windows or pictures occupy the
   remaining banks, it reads the visible rows from disk in bounded chunks instead
-  of refusing a second large image. Text editing belongs to Notepad.
+  of failing solely because a picture cache page is unavailable. Concurrent
+  Viewer windows are still bounded by the shared app-page pool; the current
+  desktop flow supports two open pictures and silently refuses a third. Text
+  editing belongs to Notepad.
 - **Clock** — an analog clock window (Dallas RTC, else software); View > Fullscreen
   rescales the face to the whole screen, an Options menu sets the time / toggles seconds.
 - **Settings** — a control panel for `GEOBENCH.CFG`: pick the **font** (`.FNT`),
@@ -76,6 +86,9 @@ backdrop, dragging icons, opening apps and menus:
   choices are labelled
   **4 colors** and **16 colors** (Screen 6 and Screen 7).
   **Return to Defaults** restores the complete target-specific configuration.
+  MSX2 also exposes **Input device** (`Mouse` or `Joystick`), persisted as
+  `MSXMOUSE=TRUE|FALSE`; the setting must match the device connected to the
+  selected joystick port.
   Media settings are stored as
   **drive-qualified names** such as `A:DARKER` or `C:XMATRIX`, so Settings can
   browse either floppy or Albireo content without ambiguity. Invalid media
@@ -136,6 +149,9 @@ backdrop, dragging icons, opening apps and menus:
 - **Calculator** — a compact windowed fixed-point calculator with keyboard and
   pointer input, basic arithmetic, percentage, square root, sign and clear
   operations, and a black display with red digits.
+- **Disk Utility** — formats CPC AMSDOS data/system media (including supported
+  80-track geometry) or performs an MSX2 FAT12 quick format. It is deliberately
+  app-linked and modal because formatting is destructive; PCW does not ship it.
 - **Kana Mahjong** — a fullscreen 144-tile Mahjong solitaire game using an
   original C engine and selectable 42-face Katakana or 36-face Hiragana tile
   sets. New deals are assigned along a known legal Turtle-layout removal order,
@@ -176,4 +192,8 @@ backdrop, dragging icons, opening apps and menus:
 - **Banked app model** — the desktop and every app are separate binaries, paged
   into expansion-bank slots and run co-resident with the kernel; shared window
   chrome (drag/resize) lives in `libgb`.
+- **Preemptive release runtime** — CPC, MSX2, and PCW release images carry the
+  scheduler in `DESKTOP.APP`. Pure compute workers may be time-sliced; UI,
+  storage, modules, firmware and drawing remain root-owned and atomic. Explicit
+  cooperative builds remain available for regression testing.
 - **Hybrid implementation** — the kernel is Z80 assembly; **every app is C**.

--- a/docs/File_Manager_Issue.md
+++ b/docs/File_Manager_Issue.md
@@ -1,5 +1,10 @@
 # Nested subdirectories (depth ≥ 2) don't navigate on this platform
 
+> Historical investigation retained as the evidence for the current one-level
+> content-layout limit. The IDE-specific reproduction below is not a description
+> of the shipped backend; see [ARCHIVED.md](ARCHIVED.md) for current storage
+> support and [ARCHITECTURE.md](ARCHITECTURE.md) for the active limit.
+
 **Status:** won't-fix — a **kernel FAT-core / storage re-mount limitation**, below the File
 Manager. Reproduced **deterministically in the 1984 emulator on the IDE backend** (which the
 emulator runs faithfully), and on Albireo/CH376. **Resolution: ship content flat in

--- a/docs/MSX2.md
+++ b/docs/MSX2.md
@@ -1,7 +1,7 @@
 # The MSX2 target
 
-The same OS, cross-built for the MSX2 (issue #287). It is **one source tree, two
-platforms**: the resident kernel assembles from the same `kernel/` sources under
+The same OS, cross-built for the MSX2 (issue #287). It is **one source tree,
+three platforms**: the resident kernel assembles from the same `kernel/` sources under
 `-DPLATFORM_MSX`, and the apps compile from the same `main.c` files under
 `-DGB_MSX2` — the platform differences live in the kernel's video/input/storage
 back-ends, not in the apps.
@@ -31,7 +31,7 @@ Clock — all co-resident under the kernel window manager on a V9938.
 - **Assets:** icon sets and backdrop tiles stay in canonical Mode-1 bytes and are
   decoded by either MSX video backend. Portable four-colour pictures use the same
   [GBPC v2 format](PIC_FORMAT.md) on every platform. Screen 7 additionally accepts
-  mode-7 sixteen-colour `.PIC` files in Viewer and as wallpaper. MSX pictures live
+  mode-7 sixteen-colour `.PIC` files in Viewer, Paint, and as wallpaper. MSX pictures live
   under root-level `PICS/`; low-level diagnostics such as `GBSPIKE.COM` are
   under `DIAG/`, while app diagnostics such as `SNDTEST.APP` live in `GBENCH/`.
 

--- a/docs/PCW.md
+++ b/docs/PCW.md
@@ -132,9 +132,10 @@ directory layout. `k_drive_poll` uses a single-sector probe for media presence.
 - **EXTRAS.DSK** (720K CF2DD data): every portable picture from
   `assets/pictures`, stored byte-for-byte in canonical GBPC v2 format, plus
   GB-PAINT (`PAINT.APP` and `PAINT.IST`), GB-BASIC (`BASIC.APP`, its runtime and
-  engine), the BASIC examples, and the other verified portable PCW savers
-  (`ANT`, `DECO`, and `XMATRIX`). Use it in drive B to browse pictures, run the
-  applications and savers, and save edited pictures or programs.
+  engine), the BASIC examples, and the other verified portable PCW savers:
+  `ANT`, `DECO`, `XMATRIX` with `XMATRIX.MOD`, and `MOUNTAIN` with
+  `MOUNTAIN.MOD`. Use it in drive B to browse pictures, run the applications and
+  savers, and save edited pictures or programs.
 
 ## PCW Time Sync With PerryFi / PerryNet
 

--- a/docs/PIC_FORMAT.md
+++ b/docs/PIC_FORMAT.md
@@ -2,7 +2,7 @@
 
 GBPC v2 keeps the original four-colour format portable across CPC, MSX2, and
 PCW. It also defines an optional sixteen-colour Screen 7 payload for the MSX2
-Viewer.
+Viewer, wallpaper loader, and Paint.
 
 ## GBPC v2 layout
 

--- a/docs/PREEMPTIVE_APP_AUDIT.md
+++ b/docs/PREEMPTIVE_APP_AUDIT.md
@@ -3,9 +3,9 @@
 Date: 2026-08-26
 Issue: [#477](https://github.com/salvogendut/geobench/issues/477)
 
-This audit determines what each GEOBENCH application needs before the optional
-preemptive build can be considered broadly application-compatible. It does not
-assume that every application should become a scheduled worker.
+This audit records how each GEOBENCH application fits the default preemptive
+runtime. It does not assume that every application should become a scheduled
+worker; most UI and I/O code remains a bounded root job.
 
 ## Responsiveness contract
 
@@ -39,13 +39,13 @@ kernel work into a worker would make the system unsafe rather than preemptible.
 
 | Priority | Area | Result |
 |---|---|---|
-| P0 | File Manager | Copy, directory preparation, and APP-icon probing are bounded root jobs. |
-| P0 | Settings | Asset enumeration and icon-set validation are bounded root jobs; modal/I/O lifecycle needs cross-target validation. |
-| P0 | Screensavers | All shipped savers now use fixed or incremental frame budgets; lifecycle validation remains. |
-| P1 | BASIC, Paint, and Notepad | BASIC graphics/scans and Paint/Notepad document I/O are bounded. |
-| P1 | Browser, WGET, Telnet, Shell | Shell storage commands are bounded; the network applications remain to audit. |
-| P1 | Viewer, Notepad, Icon Editor, Mahjong | Viewer, Notepad, and Icon Editor use bounded root jobs; Mahjong still needs deal/shuffle measurement. |
-| P2 | Clock and small utilities | Clock is already bounded; remaining utilities need lifecycle smoke tests. |
+| P0 | File Manager | Copy, directory preparation, and APP-icon probing are bounded root jobs and have cross-target smoke coverage. |
+| P0 | Settings | Asset enumeration and icon-set validation are bounded root jobs; initial CPC/MSX2/PCW validation is complete. |
+| P0 | Screensavers | All shipped savers use fixed or incremental frame budgets and have initial cross-target smoke coverage. |
+| P1 | BASIC, Paint, Notepad, Icon Editor, Shell | Long graphics, document, and storage operations are bounded and have target smoke coverage. |
+| P1 | Browser, WGET, Telnet | Network receive/parser and cancellation paths remain the main conversion work. |
+| P1 | Viewer and Mahjong | Viewer is a bounded root renderer; Mahjong is event-driven. Resource/error feedback and worst-case measurement remain. |
+| P2 | Clock and small utilities | Clock is bounded and smoke-tested; destructive and diagnostic utilities still need lifecycle edge tests. |
 
 ## P0: File Manager
 
@@ -259,7 +259,6 @@ floppy/card storage, MSX DOS drives, and PCW floppies.
 | Browser | Bounded root network/parser job | Bound each receive, parse, image, redirect, and cache step; cancellation must close the channel. |
 | WGET | Bounded root network/storage job | Verify one receive/write unit per frame and safe partial-file cleanup/resume. |
 | Telnet | Bounded root network/serial job | Cap receive and ANSI parsing per frame; disconnect must cancel every transport state. |
-| Shell | Bounded root command jobs | Preemptive `ls`, `cat`, and `cp` are metered per frame, serialize storage, and clean partial copies on cancellation or close. |
 | Viewer | Root-owned image renderer | Image-only; retains native banked rendering and falls back to bounded visible-row reads when picture banks are exhausted. |
 | Notepad | Bounded root document job | Preemptive builds load/save 512 bytes per frame, serialize storage, clean partial saves, and cap input shifts to two characters per frame. Validate maximum files and deferred save actions. |
 | Icon Editor | Bounded root document job | Loads and saves 512 bytes per frame while preserving borrowed-bank, preview, and active-icon-set reload state. |
@@ -284,18 +283,18 @@ floppy/card storage, MSX DOS drives, and PCW floppies.
   fixed-point Mandelbrot computation and publishes complete rows; root code owns
   all drawing and lifecycle.
 
-## Implementation order
+## Remaining order
 
-1. Validate the implemented File Manager copy, progressive directory scan, and
-   queued APP-icon probing across all storage backends.
-2. Validate Settings progressive picker enumeration and finish its modal cleanup audit.
-3. Validate every incremental and fixed-budget screensaver, including dense and
-   maximum-setting cases.
-4. Complete the screensaver timing and lifecycle matrix across CPC, MSX2, and PCW.
-5. Validate GB-BASIC's bounded graphics and scan lifecycle across all targets.
-6. Validate GB-PAINT and Notepad bounded document jobs, cancellation, and exact-size files.
-7. Browser/WGET/Telnet/Shell and the remaining P1 application checks.
-8. Complete cross-target smoke matrix before issue #477 is proposed for merge.
+1. Audit Browser, WGET, and Telnet receive/parser loops, transport cancellation,
+   timeout, and partial-file behavior.
+2. Finish Browser Save's chunked write path and the remaining Nettest, Time Sync,
+   and Disk Utility lifecycle checks.
+3. Exercise exact-boundary, cancellation, slow-media, and contention cases for
+   the already bounded File Manager, Settings, BASIC, Paint, Notepad, Icon
+   Editor, Shell, and screensaver paths.
+4. Add explicit Viewer feedback/resource handling when the app-page pool cannot
+   open a third picture window.
+5. Maintain the CPC/MSX2/PCW smoke matrix as these follow-ups land.
 
 All changes should remain app-linked or app-local. This audit identifies no
 reason to add more resident kernel code before the application passes are

--- a/docs/PREEMPTIVE_MULTITASKING.md
+++ b/docs/PREEMPTIVE_MULTITASKING.md
@@ -250,6 +250,8 @@ resident-kernel bytes.
   desktop. A manual System > Exit smoke test also completed the expected PCW
   warm reboot after restoring the interrupt bootstrap.
 
-The scheduler path and the XAOS compute-worker integration now build on all
-three targets. Preemption remains a development option while production apps
-are converted individually; normal distributions are still cooperative.
+The scheduler path and the XAOS compute-worker integration build on all three
+targets. Preemption is the release default; applications are converted
+individually where a pure worker or bounded root job improves responsiveness.
+The cooperative targets remain regression profiles, not the normal
+distribution.

--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -23,9 +23,9 @@ reference resources — not dependencies, and not vendored into this repo.
   original ROM image for verification.
   **Why it matters:** GEOBENCH calls the firmware for screen, keyboard, and disk.
   This is the authoritative reference for the **TXT/GRA VDU vectors** and the
-  CAS/AMSDOS file paths the kernel uses. (Note: GEOBENCH does **not** launch
-  legacy `.BIN`/`.BAS` software — that is a non-goal; see `ARCHITECTURE.md` →
-  "Known architectural limits.")
+  CAS/AMSDOS file paths the kernel uses. (Note: GEOBENCH does **not** contain
+  legacy machine-code `.BIN` software; `.BAS` files may be opened by the
+  separately maintained GB-BASIC application.)
 
 ## Locomotive BASIC
 
@@ -34,5 +34,5 @@ reference resources — not dependencies, and not vendored into this repo.
   documented, modular Z80 assembly, with the original ROM image for verification.
   **Why it matters:** GEOBENCH boots from a `RUN"GB` BASIC loader and shares the
   machine with the BASIC ROM, so this documents how BASIC enters/exits and manages
-  its workspace — and what state the desktop must preserve. (GEOBENCH does not
-  launch `.BAS` programs itself; running them is a non-goal.)
+  its workspace — and what state the desktop must preserve. GB-BASIC provides
+  the managed editor/runtime used when a staged `.BAS` file is opened.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,68 +1,34 @@
-# Roadmap (rough)
+# Roadmap
 
-## Done
+GEOBENCH has working CPC, MSX2, and PCW distributions. Completed platform and
+format milestones belong in [Features](FEATURES.md) and the Git history rather
+than in a growing checklist here.
 
-1. ✅ **Boot + desktop** — Mode 1 backdrop, top bar, software pointer.
-2. ✅ **Windowing + icons** — windows with title bars/gadgets, draggable icons.
-3. ✅ **File manager** — browse a drive (list/icon views, sorted by type + name),
-   select, scroll, open by type.
-4. ✅ **Banked app model + app API** — separate-binary apps over a kernel API.
-5. ✅ **Apps in C** — the whole app layer moved from assembly to C over `libgb`.
-6. ✅ **Storage write layer** — Albireo, M4 and floppy read/write paths support
-   save/delete/copy; the archived IDE/FAT backend remains buildable for recovery.
-7. ✅ **Apps** — Notepad, ICONED, Paint, Clock, Viewer, Xaos, Diskutil, and a
-   **Settings** control panel (font / icon set / cursor / drive-qualified
-   backdrop-wallpaper-saver settings + a live desktop-colours editor). CPC and
-   PCW ship the complete network app set; MSX2 currently ships Browser and
-   Telnet through TCP/IP UNAPI.
-8. ✅ **Unified menu system (`gb_doc`)** — one File / Edit / View menu framework for
-   every app (New/Load/Save/Save As, a shared cross-app clipboard, **Fullscreen**, a
-   navigable Open/Save dialog in a paged module); the desktop's System menu and the
-   clock's Options menu render through it too.
-9. ✅ **Driver offload to ROM (#152)** — the screen-independent low-level drivers (FAT
-   read/write, AMSDOS floppy, IDE, CH376/Albireo) run from a 16K upper ROM
-   (`GEOBENCH.ROM`/`GBALB.ROM`), freeing resident RAM; the ROM is also a CPC background ROM
-   that boots a `GEOBENCH <commit>` banner.
-10. ✅ **M4 board SD/TCP support (#174, #259)** — a file-level backend (`GBM4.BIN`)
-   ships beside `GBALB.BIN` on the shared card image. `GB.BAS` detects M4ROM
-   (`KL_FIND_COMMAND` for an M4 RSX) and selects the right kernel. M4 supports
-   directory, load, save/create, delete, free-space queries, and TCP through
-   `M4SAVE.MOD` / `GBNETM4.MOD`. Its storage and
-   network calls preserve the active CPC video mode, so Telnet's Mode 2 fullscreen
-   terminal survives paged module loads.
-11. ✅ **Kernel source split + build cache** — the resident kernel contracts now
-   live in dedicated source files with checked ABI/low-RAM maps, and the full
-   build reuses unchanged app/module outputs instead of recompiling everything.
-12. ✅ **MSX2 port (#287)** — the kernel and app set cross-build to a second
-   platform under MSX-DOS 2 / Nextor, with selectable V9938 Screen 6/7
-   backends, a hardware sprite pointer, MSX mouse, all 16 screensavers, and an
-   openMSX test harness (`tools/build_kernel_msx.sh` + `tools/run_msx.sh`).
-13. ✅ **Portable picture payloads (#381)** — CPC, MSX2, and PCW distributions
-   carry the same canonical GBPC v2 Mode-1 `.PIC` bytes. MSX2 and PCW translate
-   pixels at the display boundary; Paint and XAOS also save the portable format.
-14. ✅ **Portable icon-set payloads** — CPC, MSX2, and PCW distributions carry
-   canonical Mode-1 `.IST` bytes. Non-CPC kernels transcode the selected set when
-   loading it, and ICONED preserves the portable format on every target.
-15. ✅ **Portable backdrop payloads (#388)** — all targets carry the same 64-byte
-   canonical Mode-1 `.BDP` tiles. MSX2 and PCW convert the selected tile at load
-   time while CPC draws the already-native bytes from its desktop app, preserving
-   the resident kernel's stack guard.
-16. ✅ **Per-screensaver configuration (#390)** — Settings has a generic
-   same-stem `.MOD` launcher instead of embedded saver dialogs. STARFLD's module
-   persists speed and star count; XMATRIX's module adds binary/Kana glyphs,
-   speed, and a CPC/MSX Screen 7 color choice with palette restoration on exit.
-   MOUNTAIN's module adds speed, peak-count, and hold-time controls; its MSX
-   Screen 7 renderer uses an eight-band elevation palette.
-17. ✅ **MSX2 TCP/IP UNAPI networking (#397)** — Browser and Telnet use the shared
-   `gb_net_*` API through a discovered mapped-RAM or page-3 UNAPI implementation.
-   The initial emulator target is openMSXnet; no network code is added to the
-   resident kernel.
+## Current priorities
 
-## Next
+1. **Finish runtime hardening.** Continue converting user-visible long-running
+   work to bounded root jobs or safe pure workers, and reduce unnecessary full
+   desktop repaints. See [Preemptive multitasking](PREEMPTIVE_MULTITASKING.md)
+   and the [application audit](PREEMPTIVE_APP_AUDIT.md).
+2. **Application robustness.** Improve error reporting and resource lifecycle
+   in Viewer, Browser, Paint, BASIC, and network applications. Viewer currently
+   supports two simultaneous picture windows in the normal desktop flow; a
+   third launch needs explicit resource handling and feedback.
+3. **Desktop organization.** Add richer drawer/folder behavior and persistent
+   spatial arrangement without enlarging the resident kernel unnecessarily.
+4. **Modular configuration.** Add same-stem configuration modules only where a
+   screensaver or application has useful options; keep Settings and the kernel
+   independent of feature-specific controls.
+5. **Platform validation.** Keep emulator tests paired with real-hardware checks
+   for CPC storage/network boards, MSX mouse/joystick and UNAPI transports, and
+   PCW floppy/serial hardware.
 
-- **Paint** follow-ups — resizable canvas and scrolling for pictures bigger than the
-  screen (Fullscreen already centers the canvas + tools).
-- **Drawers/folders** and richer desktop arrangement.
-- **More screensaver controls** — add same-stem configuration companions as
-  individual savers gain useful parameters; Settings needs no corresponding
-  source or resident-kernel change.
+## Longer-term investigations
+
+- A constrained MSX1 port, documented separately in [MSX1_port.md](MSX1_port.md).
+- More app-carried 16-color icons and MSX Screen-7-aware application artwork.
+- Additional external applications that use the reusable UI and document
+  helpers without adding resident bytes.
+
+This list is intentionally short. GitHub issues are the authority for scoped
+implementation work and its acceptance criteria.

--- a/docs/dev/ROM_OFFLOAD_POC.md
+++ b/docs/dev/ROM_OFFLOAD_POC.md
@@ -1,5 +1,11 @@
 # GEOBENCH.ROM offload — PoC design & findings (#152)
 
+> Historical proof-of-concept record. Normal CPC distributions now use the
+> no-ROM Albireo/M4 kernels, and the default preemptive runtime is deliberately
+> ROM-independent. The optional sources remain for recovery and size research;
+> use [BUILDING.md](../BUILDING.md) and [ARCHIVED.md](../ARCHIVED.md) for current
+> support boundaries.
+
 > **Status: SHIPPED.** The PoC below grew into the full feature on branch
 > `152-rom-offload`. The IDE *and* Albireo backends now run from the ROM (FAT
 > read/write, AMSDOS floppy read, IDE read, the CH376 backend), the kernel keeps thin

--- a/kernel/README.md
+++ b/kernel/README.md
@@ -14,16 +14,19 @@ desktop and banked apps are running.
 - **System services / API dispatch** — the call gate applications use to reach
   kernel routines for graphics, windowing, input, files, modules, clipboard,
   drive state, and networking.
-- **Window manager** — own the cooperative master loop, focus/z-order, managed
-  chrome, damage repaint, drag/drop, and top-bar dispatch.
+- **Window manager** — own the root event/compositor loop, focus/z-order,
+  managed chrome, damage repaint, drag/drop, and top-bar dispatch.
 - **Timing / input** — frame pacing, keyboard, pointer, and RTC readout.
 
 ## Design constraints
 
 - Keep it **small**. Every byte resident is a byte applications can't use.
-- Cooperative window/app model. There is no preemptive scheduler.
-- All hardware addresses and firmware vectors live behind named constants so the
-  CPC-vs-CPC+ and 64K-vs-128K differences stay contained.
+- Keep kernel, firmware, storage, modules, and drawing atomic. The release
+  scheduler is carried by `DESKTOP.APP` and preempts only opted-in pure app
+  workers; it adds no resident kernel feature code.
+- Hardware addresses and firmware vectors live behind named constants and
+  target backends so CPC/CPC+, MSX2, PCW, and memory-size differences stay
+  contained.
 - Absolute low-RAM ownership is explicit in `lowram.tsv`; validate it with
   `python3 tools/check_lowram_map.py`. The assembly equates live in `lowram.inc`.
 - The app ABI is the fixed jump table at `GB_KERNEL` (`#8000`) in
@@ -31,8 +34,9 @@ desktop and banked apps are running.
 
 ## Status
 
-Active. The shipped default target is the no-ROM Albireo kernel, with optional
-ROM/offload and recovery storage profiles still present in source. Source-level
+Active on CPC, MSX2, and PCW. CPC ships no-ROM Albireo and M4 kernels, with
+optional ROM/offload and recovery storage profiles still present in source.
+Source-level
 contracts and boot/assets/module boundaries now live in `api_table.inc`,
 `lowram.inc`, `boot.asm`, `assets.asm`, `config_module.asm`, `modules.asm`, and
 `app_pool.asm`; input polling lives in `input_api.asm`; clock/RTC and RAM probing
@@ -43,5 +47,7 @@ Current documentation anchors:
 
 - `../lib/gbapp.inc` — app-visible ABI contract.
 - `lowram.tsv` — fixed low-RAM ownership map.
-- `../docs/KERNEL_ARCHITECTURE_REVIEW.md` — architecture review and further
-  resident-size recommendations.
+- `../docs/PREEMPTIVE_MULTITASKING.md` — current scheduler/root ownership
+  contract.
+- `../docs/KERNEL_ARCHITECTURE_REVIEW.md` — dated architecture review retained
+  as audit history.

--- a/kernel/kc/README.md
+++ b/kernel/kc/README.md
@@ -29,6 +29,11 @@ The `.c`/`.h` pairs `net`, `udp`, `dns`, `w5100` (plus `netinit.h`) are the
 Net4CPC stack compiled into `GBNET.MOD`; `gbnet_m4_mod.c` is intentionally
 separate so M4 does not carry W5100 register code.
 
+`GBTITLE.MOD` follows the same paged-module architecture but is assembled from
+`kernel/modules/gbtitle.asm` and `gbtitle_install.asm`, so it is not part of this
+C-module table. `tools/build_titlebarmod.sh` builds its CPC/MSX2/PCW variants
+and validates/stages the `.TBR` and `.GDT` assets.
+
 ## Why C costs more here
 
 A C routine compiled with SDCC is roughly **4–5×** the size of the hand-written

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,8 +1,9 @@
 # lib/
 
-System libraries shared by the kernel (and, via `gb/`, the C apps). The `.asm`
-files are assembled into the kernel; they abstract the CPC's hardware so higher
-layers never poke video, storage or input registers directly.
+System libraries shared by the kernel and, via `gb/`, the C apps. Common `.asm`
+files are assembled into the target kernel; the root implementations serve CPC
+and shared code, while `msx/` and `pcw/` keep their video, banking, storage, and
+input details out of higher layers.
 
 ## Kernel libraries (Z80 asm)
 
@@ -10,11 +11,11 @@ layers never poke video, storage or input registers directly.
 |------|------|
 | `gbapp.inc` | The **app ABI**: jump-table addresses, the banked memory model, app load address. Included by the kernel and mirrored by `libgb`. |
 | `firmware.inc` | AMSDOS/firmware vector equates used by the kernel. |
-| `screen.asm` | Mode 1 drawing: address math, filled rectangles, blits, save/restore. Hides the 320×200 pixel/byte layout. |
+| `screen.asm` and target screen backends | Drawing, address math, fills, blits, save/restore, and portable-asset translation for CPC Mode 1, MSX Screen 6/7, and PCW monochrome video. |
 | `text.asm` | The 6×8 (sub-byte) proportional text renderer. |
 | `font.asm` | Loads a `.FNT` font set into the data bank. |
-| `input.asm` | Keyboard/joystick polling -> pointer direction + fire/quit. |
-| `cursor.asm` | Software pointer sprite: draw, erase, move with save-under. |
+| `input.asm` and target input backends | Keyboard, joystick, mouse, and pointer-button polling. |
+| `cursor.asm` and target cursor backends | Software or V9938 hardware pointer handling. |
 | `cursor_arrow.asm`, `cursor_hand.asm` | Pointer bitmaps. |
 | `fs.asm` | Storage dispatcher — picks a backend at boot. |
 | `fs_amsdos.asm` | AMSDOS directory + file load over the floppy. |
@@ -46,5 +47,5 @@ The shared **C bindings** every GEOBENCH app links against:
 - **Speed first.** These run on a ~4 MHz Z80; inner loops are hand-tuned asm.
 - **One way in.** Each library exposes clear entry points; the kernel and apps
   call the same code rather than duplicating it.
-- Mode 1 (320×200, 4 colours) is the assumed surface; pixel-layout assumptions
-  stay isolated in `screen.asm`.
+- Pixel-layout assumptions stay inside the target screen backend. Portable
+  `.PIC`, `.IST`, and `.BDP` payloads are translated at the display boundary.

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,8 +24,9 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
   Nextor `QA/GBMSX.IMG`, plus the two 720K images under `QA/MSX/Floppies/`.
   The dependency fetcher supplies a local openMSXnet
   `UNAPINET.COM`, which is staged before `GBMSX.COM`; `MSX_UNAPI_TSR` overrides
-  it, and an explicitly empty value omits it. Loose staging remains untracked;
-  the released system floppy embeds the MIT-licensed TSR and notice.
+  it, and an explicitly empty value omits it. The standalone staged TSR and
+  dependency bundle remain untracked; the released system floppy embeds the
+  MIT-licensed TSR and notice, while the rest of `QA/MSX/` is committed.
 - **`build_msx_floppy.sh`** — builds `GEOBENCH.DSK` with the full system and
   `EXTRAS.DSK` with the picture gallery. The disks use standard 720K FAT12
   geometry and, as shipped with `NEXTOR.SYS`, require a Nextor kernel ROM
@@ -42,9 +43,10 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
 - **`m4detect.asm`** — a tiny BASIC-callable detector that asks the firmware
   (`KL_FIND_COMMAND`) whether an M4 ROM RSX is installed. The staged `GB.BAS` loads
   it as `M4DETECT.BIN` and uses its result to pick `GBM4` vs `GBALB`.
-- **`build_rom.sh`** — builds the 16K upper ROMs that offload the low-level drivers
-  and carry the cold-boot banner: `rom/GBALB.ROM` (Albireo, shipped) and `rom/GEOBENCH.ROM`
-  (the archived IDE backend). Bakes the git commit into the banner
+- **`build_rom.sh`** — builds optional legacy 16K upper-ROM experiments that
+  offload low-level drivers and carry the cold-boot banner:
+  `rom/GBALB.ROM` (Albireo) and `rom/GEOBENCH.ROM` (the archived IDE backend).
+  Neither is staged in normal release media. The script bakes the git commit into the banner
   (`rom/gitcommit.inc`, generated).
 - **`build_m4netmod.sh [out.RAW]`** — builds `GBNETM4.MOD`, the M4ROM TCP command
   backend for the shared `gb_net_*` API.
@@ -106,11 +108,12 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
   match the exported `lib/gbapp.inc` slot addresses through `kernel/api_table.inc`.
 - **`check_lowram_map.py`** — validates the fixed low-RAM ownership map in
   `kernel/lowram.tsv` for accidental range overlaps.
-- **`build_scheduler.sh {cpc|msx|pcw}`** — assembles the optional, app-carried
+- **`build_scheduler.sh {cpc|msx|pcw}`** — assembles the release, app-carried
   preemptive scheduler into a bounded 512-byte raw payload. `build_capp.sh`
   embeds it in the root desktop when `TASK_ROOT=1`; the resulting runtime is
   installed in fixed RAM and requires no GEOBENCH or M4 ROM. See
-  `docs/PREEMPTIVE_MULTITASKING.md`.
+  `docs/PREEMPTIVE_MULTITASKING.md`. Explicit `*-cooperative` Make targets omit
+  it for regression testing.
 - **`check_app_layout.py` / `test_app_layout.py`** — enforce the normal app
   image limits and the `#7F00-#7FFF` task stack-snapshot reserve.
 - **`deploy_ide.sh`** — *(archived)* copy the staged distribution onto a real/emulated IDE


### PR DESCRIPTION
## Summary
- align user and maintainer documentation with the default preemptive runtime
- update current app, platform, media, icon, build, and external-project details
- replace the completed-milestone roadmap and mark historical audits/PoCs clearly
- document the current two-Viewer-window resource limit for follow-up

## Validation
- make check
- all tracked Markdown local links resolve
- git diff --check