### PR TITLE
Support configurable FAT16 image sizes

### DIFF
--- a/browser-work.md
+++ b/browser-work.md
@@ -1,0 +1,259 @@
+# Browser Work Log
+
+This document records the paused Browser/DOX experiment as of 2026-08-27.
+The work is preserved on feature branches and in Git stashes; neither feature
+branch has been merged into the default branch.
+
+## Repository State At Pause
+
+### GEOBENCH
+
+- Default branch: `main`
+- `main` commit at pause: `6309ff3dc1414449b0234bcf7dc8a532975ade5c`
+- Feature issue: [#487](https://github.com/salvogendut/geobench/issues/487)
+- Feature branch: `issue-487-browser-enhancements`
+- Pushed feature commit: `aa88e69d5f73f8606b0511083abeec073ad0e888`
+  (`Enhance Browser with bounded DOX rendering`)
+- Unfinished stash commit: `39a6c6398f567364ddae4912ce46b08e4b66b705`
+- Stash description: `WIP browser cache experiment after aa88e69`
+
+### GB-proxy
+
+GB-proxy uses `master`, not `main`, as its default branch.
+
+- Default branch: `master`
+- `master` commit at pause: `9ae3d12bf65ad8bfc50dd4db4d2bd78001bb23e8`
+- Feature issue: `#20`
+- Feature branch: `issue-20-geobench-dox-profile`
+- Pushed feature commit: `71d206bbbe1fb4722ff7067c9f176fbc3f52f783`
+  (`Add bounded GEOBENCH DOX profile`)
+- Local-files stash commit: `465c9a6df7a60fb1a22305c5a2b00d39766a27d6`
+- Stash description: `WIP local files after 71d206b`
+
+The branch commits are also present on `origin`. The stash hashes are recorded
+because `stash@{N}` numbers change whenever another stash is created or
+removed.
+
+## Goal And Design History
+
+The experiment started from the rendering model in `symapp-symzilla`. The aim
+was to let GB-proxy perform expensive HTML processing on a modern host and send
+GEOBENCH a deterministic, bounded DOX document rather than arbitrary HTML.
+
+The selected architecture was:
+
+1. Keep direct, streamed HTML for plain HTTP sites when no proxy is configured.
+2. Negotiate a strict `geobench-1` DOX profile when GB-proxy is configured.
+3. Decode DOX incrementally in the app-loaded `GBDOX.MOD`, with no resident
+   kernel growth.
+4. Preserve text, links, GET forms, tables, and image references in bounded
+   Browser records.
+5. Keep images in the existing GBPC/PIC format instead of adding SGX support.
+6. Fetch proxy-converted images separately and retain decoded pictures in a
+   bounded current-page bank cache.
+7. Keep Browser work as bounded root-owned state-machine steps. Network,
+   firmware, module, and drawing calls are not safe worker-task operations, so
+   Browser is responsive/preemptible between those steps rather than being a
+   pure preemptive worker.
+
+The detailed feasibility analysis is on the feature branch in
+`docs/BROWSER_DOX_FEASIBILITY.md`.
+
+## Pushed GEOBENCH Baseline
+
+Commit `aa88e69` contains the coherent implementation baseline:
+
+- Adds app-loaded `GBDOX.MOD` and the Browser module-call glue.
+- Adds strict incremental DOX validation and rendering.
+- Retains the existing direct streamed-HTML path.
+- Adds proxy negotiation with `X-GB-DOX: geobench-1` and GBPC mode selection.
+- Supports compact paragraphs, links, GET search controls, table grids, and
+  lazy external image references.
+- Adds a bounded current-page image cache with a 32-entry directory and up to
+  two borrowed 16 KiB image banks.
+- Supports portable four-colour GBPC images and MSX Screen 7 sixteen-colour
+  GBPC images.
+- Reduces redraw scope for URL editing, caret updates, scrolling, and image
+  completion.
+- Accepts proxy values such as `192.168.68.202:5001`; the user does not need to
+  type the `http://` prefix.
+- Adds Browser-specific build, staging, documentation, icon, module, and QA
+  artifact changes for CPC, MSX, and PCW.
+
+GB-proxy commit `71d206b` is the matching server implementation:
+
+- Adds the strict bounded `geobench-1` profile.
+- Generates validated DOX documents from HTML.
+- Emits compact lazy image references and converts requested resources to
+  bounded GBPC pictures.
+- Preserves bounded table layouts and GET form metadata.
+- Adds GEOBENCH capability negotiation, response variation, resource-registry
+  handling, documentation, and host-side tests.
+- Keeps SymZilla negotiation independent, so SymZilla continues to receive its
+  canonical DOX/SGX profile.
+
+The two pushed commits must be tested together. Using only one side gives a
+protocol mismatch or falls back to behavior that does not represent the
+experiment.
+
+## Tests And Observed Behavior
+
+The main acceptance page was:
+
+- `http://retrocheats.neocities.org`
+
+It exercises a table containing six images. During development it progressed
+from displaying only one image to displaying the table and all images, but
+each image was still fetched separately and loading remained slow.
+
+`http://frogfind.au` was used to test:
+
+- inline image conversion;
+- a one-line GET search field;
+- the Search button and generated query URL;
+- ordinary text and links.
+
+The pushed baseline restored the FrogFind form and reduced several large
+repaints. The last user-visible issues were:
+
+- the search field text was clipped at the bottom;
+- image-heavy pages still caused too many proxy requests;
+- scrolling could fetch an image again after its cache bytes had been evicted;
+- the fixed two-bank image cache was too small for some complete pages;
+- loading all images serially made first-page completion slow;
+- cache behavior had not yet been validated across low-memory and high-memory
+  CPC, MSX, and PCW configurations.
+
+The QA images for all three targets were rebuilt during the experiment, and
+`make check` passed after the final stashed source changes. That does not count
+as functional acceptance of the stashed cache design.
+
+## Unfinished GEOBENCH Stash
+
+Stash commit `39a6c6398f567364ddae4912ce46b08e4b66b705` is based on `aa88e69`.
+Its source changes are:
+
+- `kernel/kc/gbimg_mod.c`
+  - moves full-height form text from `y + 4` to `y + 2` to address bottom
+    clipping;
+  - scans from the first page record through all `BUI_HIST_COUNT` records
+    instead of stopping at the visible viewport;
+  - extends image offsets and capacity across an optional third 16 KiB bank.
+- `apps/browser/main.c`
+  - resets the image scan position to record zero after HTML or DOX parsing
+    completes, triggering whole-page image discovery.
+- `kernel/kc/gbweb_mod.c`
+  - counts free app pages;
+  - allocates a third image bank only when more than two pages remain free;
+  - releases the third bank during Browser cleanup.
+- `lib/gb/gbbrowser.h`
+  - adds `BUI_IMAGE_PAGE3` at low-RAM address `0x3BC2`.
+- `kernel/lowram.tsv`
+  - extends documented Browser shared state through `0x3BC2`.
+
+In effect, this changes the policy from visible-only lazy loading to scanning
+and prefetching every image referenced by the current page, with a maximum
+image cache of 48 KiB when enough banks are free.
+
+This was intentionally stashed rather than committed. It is a useful probe,
+but it is not a satisfactory final design:
+
+- it hard-codes one extra bank instead of scaling to available memory;
+- it can delay first-page usability while all images are fetched serially;
+- it still evicts and refetches when total decoded image data exceeds 48 KiB;
+- it does not define a clear reserve for other applications, Viewer windows,
+  source capture, or Save helpers;
+- eager prefetch spends network time on images the user may never view;
+- the complete CPC/MSX/PCW behavior was not accepted after this change.
+
+The same stash also contains regenerated CPC/MSX/PCW binaries and disk images,
+plus these untracked local test captures:
+
+- `1983-20260826-155330.gif`
+- `1983-20260826-171406.gif`
+- `1983-20260826-175508.gif`
+- `1983-20260827-001352.gif`
+- `1983-20260827-003833.gif`
+
+These generated files are not needed to recover the source experiment.
+
+## GB-proxy Stash
+
+GB-proxy stash commit `465c9a6df7a60fb1a22305c5a2b00d39766a27d6`
+contains no source changes. It preserves only untracked local files:
+
+- `1983-10102.ppm`
+- `1983-11050.ppm`
+- `MEMORY.md`
+
+The matching proxy source is already fully represented by pushed commit
+`71d206b`.
+
+## Recommended Restart
+
+Start from the pushed feature commits without applying the experimental cache
+stash:
+
+```shell
+cd /var/home/salvogendut/Dev/geobench
+git switch issue-487-browser-enhancements
+
+cd /var/home/salvogendut/Dev/GB-proxy
+git switch issue-20-geobench-dox-profile
+```
+
+Then proceed in small, independently testable steps:
+
+1. Apply only the two-pixel form baseline adjustment and verify FrogFind on all
+   three platforms.
+2. Instrument or otherwise verify image-cache hits, misses, evictions, and
+   network fetch count before changing allocation policy.
+3. Replace the fixed two/three-bank fields with a bounded variable bank list.
+   Retain current-page images while memory is available, but reserve enough
+   pages for Browser source handling and other applications.
+4. Keep visible images demand-loaded. Optional background prefetch should run
+   only after the visible viewport is complete and should stop immediately on
+   input, navigation, low memory, or another app launch.
+5. Define eviction explicitly, preferably least-recently-used or
+   viewport-distance based, and never refetch an image that is still present.
+6. Test both four-colour and MSX sixteen-colour images because the latter use
+   roughly twice the cache space.
+7. Test low-memory fallback as well as 512 KiB/1 MiB systems before rebuilding
+   committed QA artifacts.
+8. Update `docs/BROWSER_DOX_FEASIBILITY.md`; parts of its phased status and form
+   notes became stale as the prototype grew.
+
+The desired policy is therefore **lazy loading with adaptive retention**, not
+unconditional whole-page prefetch and not a fixed number of image banks.
+
+## Recovering The Stashed Experiment
+
+To restore the complete GEOBENCH stash, including generated artifacts and GIFs:
+
+```shell
+cd /var/home/salvogendut/Dev/geobench
+git switch issue-487-browser-enhancements
+git stash apply 39a6c6398f567364ddae4912ce46b08e4b66b705
+```
+
+Prefer applying rather than popping until the recovered tree has been checked.
+To restore only the tracked source experiment:
+
+```shell
+git restore --source=39a6c6398f567364ddae4912ce46b08e4b66b705 -- \
+  apps/browser/main.c \
+  kernel/kc/gbimg_mod.c \
+  kernel/kc/gbweb_mod.c \
+  kernel/lowram.tsv \
+  lib/gb/gbbrowser.h
+```
+
+The GB-proxy stash is optional because it has no source changes. To recover its
+local files:
+
+```shell
+cd /var/home/salvogendut/Dev/GB-proxy
+git switch issue-20-geobench-dox-profile
+git stash apply 465c9a6df7a60fb1a22305c5a2b00d39766a27d6
+```
+

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -66,8 +66,9 @@ can test or deploy without rebuilding first):
   root-level `DIAG/`.
 - **`QA/CPC/GEOBENCH.IMG`** — a ready-to-flash shared **Albireo/M4 card image**: a
   partitioned FAT16 disk the CH376 auto-detects and 1984's M4 image mode can mount.
-  Built by `tools/build_card_img.sh`; a 32 MB local artifact, rebuilt every build
-  and not committed.
+  Built by `tools/build_card_img.sh`; a 32 MB local artifact by default,
+  rebuilt every build and not committed. Pass a size in megabytes as the third
+  argument to build a different 4-2048 MB image.
 - **`QA/CPC/Floppies/GEOBENCH.DSK`** — the bootable **Main** floppy image.
 - **`QA/CPC/Floppies/COMPANION.DSK`** — the **Companion** floppy with the larger apps
   (including Telnet, WGET, Browser, Shell, Mahjong and Calculator) and extra savers for drive B.
@@ -174,10 +175,12 @@ for current UNAPI implementation coverage.
   selector, `GEOBENCH.CFG`, the `GBENCH/` system folder
   (fonts/icons/cursor/modules/apps/savers), the complete gallery in `PICS/`, and
   development diagnostics in `DIAG/`.
-- **`QA/MSX/GBMSX.IMG`** — a bootable 32 MB **FAT16 hard-disk image** (a local
-  artifact, git-ignored like the CPC card image). `tools/build_msx_img.sh` fills
-  it from `QA/MSX/CARD` plus the Nextor system files, so Nextor's Sunrise IDE driver
-  boots it straight to the desktop.
+- **`QA/MSX/GBMSX.IMG`** — a bootable, 32 MB by default **FAT16 hard-disk
+  image** (a local artifact, git-ignored like the CPC card image).
+  `tools/build_msx_img.sh` fills it from `QA/MSX/CARD` plus the Nextor system
+  files, so Nextor's Sunrise IDE driver boots it straight to the desktop. Pass
+  a size in megabytes as the third argument to build a different 4-2048 MB
+  image.
 - **`QA/MSX/Floppies/GEOBENCH.DSK`** — the bootable 720K FAT12 system floppy,
   with the selectors, complete `GBENCH/` and `DIAG/` trees, `NEXTOR.SYS`,
   `COMMAND2.COM`, `UNAPINET.COM`, both third-party distribution notices, and

--- a/tools/README.md
+++ b/tools/README.md
@@ -121,9 +121,15 @@ project's distrobox (which carries `rasm`, `sdcc`, `mtools`, `dosfstools`, ...).
 
 ## Card / disk images
 
-- **`build_card_img.sh [CARD] [IMG]`** — builds a partitioned **FAT16 card image**
+- **`build_card_img.sh [CARD] [IMG] [SIZE_MB]`** — builds a partitioned **FAT16 card image**
   (`QA/CPC/GEOBENCH.IMG` by default) from the staged `QA/CPC/CARD/` for Albireo and M4
-  image mode. Called by `build_kernel.sh`.
+  image mode. The size defaults to 32 MB and may be set from 4 through 2048 MB;
+  `CARD_IMG_MB` remains available as an environment-variable override. Called
+  by `build_kernel.sh`.
+- **`build_msx_img.sh [CARD] [IMG] [SIZE_MB]`** — builds the corresponding
+  partitioned FAT16/MBR Nextor image from `QA/MSX/CARD/`. The size defaults to
+  32 MB and may be set from 4 through 2048 MB; `MSX_IMG_MB` remains available
+  as an environment-variable override.
 - **`mkcpcmedia.py OUT.dsk --add FILE ...`** — builds the extended 80-track,
   single-sided AMSDOS DATA image used for the CPC picture gallery.
 - **`mkpcwdsk.py`** — builds bootable or data PCW CF2/CF2DD images, including

--- a/tools/build_card_img.sh
+++ b/tools/build_card_img.sh
@@ -4,16 +4,23 @@
 # partition table) and the Albireo CH376 (which auto-detects the FAT partition). The IDE
 # kernel and UniDOS/FATFS both read FAT16, so one image serves the boot AND the runtime.
 #
-# Output: QA/CPC/GEOBENCH.IMG (a 32 MB FAT16 partition at sector 32 / byte 16384 - the same
+# Output: QA/CPC/GEOBENCH.IMG (a FAT16 partition at sector 32 / byte 16384 - the same
 # layout as a real CPC CF/SD card). Rebuilt by tools/build_kernel.sh after the card is staged.
+#
+# Usage: tools/build_card_img.sh [staging-dir] [out.img] [size-MB]
+#   size defaults to CARD_IMG_MB, or 32 MB when the variable is unset.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 CARD="${1:-QA/CPC/CARD}"
 IMG="${2:-QA/CPC/GEOBENCH.IMG}"
-SIZE_MB="${CARD_IMG_MB:-32}"
+SIZE_MB="${3:-${CARD_IMG_MB:-32}}"
 POFF=32                       # partition start, in 512-byte sectors (byte 16384)
 
 [ -d "$CARD" ] || { echo "ERROR: $CARD not found - run tools/build_kernel.sh first" >&2; exit 1; }
+[[ "$SIZE_MB" =~ ^[0-9]+$ ]] && (( SIZE_MB >= 4 && SIZE_MB <= 2048 )) || {
+    echo "ERROR: size-MB must be an integer from 4 through 2048" >&2
+    exit 1
+}
 for t in sfdisk mkfs.fat mcopy; do
     command -v "$t" >/dev/null || { echo "ERROR: missing tool '$t' (dosfstools/mtools/util-linux)" >&2; exit 1; }
 done
@@ -23,7 +30,11 @@ dd if=/dev/zero of="$IMG" bs=1M count="$SIZE_MB" status=none
 # MBR with one FAT16 partition (type 0x06) from sector POFF to the end of the image.
 printf 'label: dos\nstart=%s, type=06\n' "$POFF" | sfdisk -q "$IMG" >/dev/null
 # Format that partition as FAT16 (offset is in sectors).
-mkfs.fat -F16 --offset "$POFF" -n GEOBENCH "$IMG" >/dev/null
+MKFS_ARGS=(-F16 --offset "$POFF" -n GEOBENCH)
+# dosfstools otherwise chooses too many sectors per cluster for small FAT16
+# volumes and rejects them. One-sector clusters support the 4-15 MB range.
+(( SIZE_MB < 16 )) && MKFS_ARGS+=(-s 1)
+mkfs.fat "${MKFS_ARGS[@]}" "$IMG" >/dev/null
 # Copy the whole staged card into the partition root (-s = recurse into GEOBENCH/).
 export MTOOLS_SKIP_CHECK=1
 mcopy -s -i "$IMG@@$((POFF * 512))" "$CARD"/* ::/

--- a/tools/build_msx_img.sh
+++ b/tools/build_msx_img.sh
@@ -1,21 +1,26 @@
 #!/usr/bin/env bash
 # tools/build_msx_img.sh - build a bootable Nextor FAT16 hard-disk image for the
 # MSX2 target (issue #287). Mirrors tools/build_card_img.sh (the CPC card): a
-# 32 MB image, MBR partition (type 0x06) at sector 32, FAT16, filled from a
+# configurable-size image, MBR partition (type 0x06) at sector 32, FAT16, filled from a
 # staging directory. Nextor's Sunrise IDE driver boots NEXTOR.SYS/COMMAND2.COM
 # from the partition root, so the same image is both boot and payload media.
 #
-# Usage: tools/build_msx_img.sh [staging-dir] [out.img]
+# Usage: tools/build_msx_img.sh [staging-dir] [out.img] [size-MB]
 #   staging dir default: QA/MSX/CARD (falls back to a minimal QA/MSXDEPS boot set)
 #   output default:      QA/MSX/GBMSX.IMG (local artifact, git-ignored like GEOBENCH.IMG)
+#   size default:         MSX_IMG_MB, or 32 MB when the variable is unset
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 SRC="${1:-QA/MSX/CARD}"
 IMG="${2:-QA/MSX/GBMSX.IMG}"
-SIZE_MB="${MSX_IMG_MB:-32}"
+SIZE_MB="${3:-${MSX_IMG_MB:-32}}"
 POFF=32                       # partition start, in 512-byte sectors
 
+[[ "$SIZE_MB" =~ ^[0-9]+$ ]] && (( SIZE_MB >= 4 && SIZE_MB <= 2048 )) || {
+    echo "ERROR: size-MB must be an integer from 4 through 2048" >&2
+    exit 1
+}
 for t in sfdisk mkfs.fat mcopy; do
     command -v "$t" >/dev/null || { echo "ERROR: missing tool '$t' (dosfstools/mtools/util-linux)" >&2; exit 1; }
 done
@@ -25,7 +30,9 @@ done
 rm -f "$IMG"
 dd if=/dev/zero of="$IMG" bs=1M count="$SIZE_MB" status=none
 printf 'label: dos\nstart=%s, type=06\n' "$POFF" | sfdisk -q "$IMG" >/dev/null
-mkfs.fat -F16 --offset "$POFF" -n GBMSX "$IMG" >/dev/null
+MKFS_ARGS=(-F16 --offset "$POFF" -n GBMSX)
+(( SIZE_MB < 16 )) && MKFS_ARGS+=(-s 1)
+mkfs.fat "${MKFS_ARGS[@]}" "$IMG" >/dev/null
 
 export MTOOLS_SKIP_CHECK=1
 mcopy -i "$IMG@@$((POFF * 512))" QA/MSXDEPS/NEXTOR.SYS QA/MSXDEPS/COMMAND2.COM ::/


### PR DESCRIPTION
## Summary
- allow CPC and MSX FAT16/MBR image builders to accept a 4-2048 MB size argument
- retain existing environment-variable overrides and support small-volume cluster geometry
- document the paused Browser/DOX work and stable stash recovery details

## Verification
- built and inspected populated 8 MB CPC and MSX images
- verified DOS MBR, type 0x06 partition at sector 32, and readable FAT16 roots
- make check